### PR TITLE
NO-JIRA - Fixed __repr__(self) function of Node class in client.py to…

### DIFF
--- a/python/qpid_dispatch/management/client.py
+++ b/python/qpid_dispatch/management/client.py
@@ -119,7 +119,7 @@ class Node(object):
             self.client = None
 
     def __repr__(self):
-        return "%s(%s)"%(self.__class__.__name__, self.address)
+        return "%s(%s)"%(self.__class__.__name__, self.url)
 
     @staticmethod
     def check_response(response, expect=OK):


### PR DESCRIPTION
… use url instead of address. There is no address attribute in the Node class