### PR TITLE
DISPATCH-182 - Enable all logging options in proton by default. This …

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -295,11 +295,11 @@ static void thread_process_listeners_LH(qd_server_t *qd_server)
 
         //
         // Proton pushes out its trace to qd_transport_tracer() which in turn writes a trace message to the qdrouter log
-        // If trace level logging is enabled on the router set PN_TRACE_FRM on the proton transport
+        // If trace level logging is enabled on the router set PN_TRACE_RAW | PN_TRACE_FRM | PN_TRACE_DRV on the proton transport
         //
         pn_transport_set_context(tport, ctx);
         if (qd_log_enabled(qd_server->log_source, QD_LOG_TRACE)) {
-            pn_transport_trace(tport, PN_TRACE_FRM);
+            pn_transport_trace(tport, PN_TRACE_RAW | PN_TRACE_FRM | PN_TRACE_DRV);
             pn_transport_set_tracer(tport, qd_transport_tracer);
         }
 
@@ -861,10 +861,10 @@ static void cxtr_try_open(void *context)
     //
     // Proton pushes out its trace to qd_transport_tracer() which in turn writes a trace message to the qdrouter log
     //
-    // If trace level logging is enabled on the router set PN_TRACE_FRM on the proton transport
+    // If trace level logging is enabled on the router set PN_TRACE_RAW | PN_TRACE_FRM | PN_TRACE_DRV on the proton transport
     pn_transport_set_context(tport, ctx);
     if (qd_log_enabled(ct->server->log_source, QD_LOG_TRACE)) {
-        pn_transport_trace(tport, PN_TRACE_FRM);
+        pn_transport_trace(tport, PN_TRACE_RAW | PN_TRACE_FRM | PN_TRACE_DRV);
         pn_transport_set_tracer(tport, qd_transport_tracer);
     }
 


### PR DESCRIPTION
…is because proton cannot tell us what logging option the message belongs to