### PR TITLE
DISPATCH-207 - Allow empty message bodies. This will prevent dispatch…

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -318,8 +318,12 @@ static int qd_check_and_advance(qd_buffer_t         **buffer,
     int pre_consume = 1;  // Count the already extracted tag
     int consume     = 0;
     unsigned char tag = next_octet(&test_cursor, &test_buffer);
-    if (!test_cursor) return 0;
-    switch (tag & 0xF0) {
+
+    unsigned char tag_subcat = tag & 0xF0;
+    if (!test_cursor && tag_subcat != 0x40)
+        return 0;
+
+    switch (tag_subcat) {
     case 0x40:               break;
     case 0x50: consume = 1;  break;
     case 0x60: consume = 2;  break;


### PR DESCRIPTION
… router from displaying the 'Invalid body value' error