### PR TITLE
DISPATCH-236: Allow the valgrind tool and suppression file to be cust…

### DIFF
--- a/README
+++ b/README
@@ -69,3 +69,8 @@ If valgrind is installed it will be used by default when running the tests.
 Set the cmake option 'USE_VALGRIND' to 'ON' or 'OFF' to enable/disable valgrind.
 You can also set the environment variable 'USE_VALGRIND' to 'ON or 'OFF'.
 If set the environment variable takes precendence over the cmake option.
+
+By default valgrind uses the memcheck tool to find memory-related issues.  The
+tool used can be overrided using the 'VALGRIND_TOOL' environment variable.  The
+location of the valgrind suppression file can be overrided by setting the
+'VALGRIND_SUPPRESSIONS' environment variable to an alternate suppression file.

--- a/run.py.in
+++ b/run.py.in
@@ -36,7 +36,10 @@ run.py --sh                                # Print a shell script to set the run
 
 Valgrind can be enabled or disabled by the cmake 'USE_VALGRIND' option and the
 environment variable 'USE_VALGRIND' (set to 'ON' or 'OFF'). The environment
-variable takes precendence if set.
+variable takes precendence if set.  By default valgrind runs the 'memcheck'
+tool. The valgrind tool and supression file can be overridden by setting the
+'VALGRIND_TOOL' and 'VALGRIND_SUPPRESSIONS' environment variables,
+respectively.
 """
 
 import os, sys, runpy
@@ -114,10 +117,13 @@ def with_valgrind(args, outfile=None):
         opts = ['--trace-children=yes',
                 #  '--leak-check=full',  way too noisy due to Python leaks
                 '--demangle=yes',
-                '--suppressions=${CMAKE_SOURCE_DIR}/tests/valgrind.supp',
                 '--num-callers=12',
                 '--error-exitcode=%d' % VALGRIND_ERROR,
                 '--quiet']
+        opts.append('--tool=%s' % os.environ.get('VALGRIND_TOOL', 'memcheck'))
+        supp = os.environ.get('VALGRIND_SUPPRESSIONS',
+                              '${CMAKE_SOURCE_DIR}/tests/valgrind.supp')
+        opts.append('--suppressions=%s' % supp)
         if outfile: opts.append('--log-file=%s' % outfile)
         return ([valgrind_exe]+opts+args, VALGRIND_ERROR)
     return (args, 0)


### PR DESCRIPTION
…omized.

This is an alternative/complement to the compile-time thread sanitizer.   This change allows us to customize the valgrind tool and suppression file used by the unit tests.  We could enable thread sanitizing simply by:

$ VALGRIND_TOOL=helgrind VALGRIND_SUPPRESSIONS=path/to/helgrind.supp  ctest

