### PR TITLE
NO-JIRA - Preserve newlines in .config file

### DIFF
--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -59,7 +59,7 @@ class Config(object):
             line = re.sub(attr, r'"\1": "\2",', line)
             return line
 
-        js_text = "[%s]"%("".join([sub(l) for l in lines]))
+        js_text = "[%s]"%("\n".join([sub(l) for l in lines]))
         spare_comma = re.compile(r',\s*([]}])') # Strip spare commas
         js_text = re.sub(spare_comma, r'\1', js_text)
         # Convert dictionary keys to camelCase


### PR DESCRIPTION
Concatenating causes awful error messages for syntactic errors in
config. Error is always being reported on line 1. Substitutions do
not add or remove lines, therefore with this patch, reported error
will be meaningful.