### PR TITLE
DISPATCH-401 - Made qdstat and qdmanage verify host name by default. …

### DIFF
--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -113,9 +113,15 @@ try:
             cls.router = cls.tester.qdrouterd('test-router', config)
 
         def run_qdstat(self, args, regexp=None, address=None):
-            p = self.popen(
-                ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
-                name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+            if address.startswith("amqps"):
+                p = self.popen(
+                    ['qdstat', '--bus', str(address or self.router.addresses[0]), '--ssl-allow-peer-name-mismatch',
+                     '--timeout', str(system_test.TIMEOUT) ] + args,
+                    name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+            else:
+                p = self.popen(
+                    ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
+                    name='qdstat-'+self.id(), stdout=PIPE, expect=None)
             out = p.communicate()[0]
             assert p.returncode == 0, \
                 "qdstat exit status %s, output:\n%s" % (p.returncode, out)


### PR DESCRIPTION
…Added --ssl-allow-peer-name-mismatch to allow peer name mismatch