### PR TITLE
DISPATCH-401 - Made qdstat and qdmanage verify peer name by default. …

### DIFF
--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -96,6 +96,9 @@ def connection_options(options, title="Connection Options"):
     # Use the --sasl-password-file option to avoid having the --sasl-password in history or scripts.
     group.add_option("--sasl-password-file", action="store", type="string", metavar="SASL-PASSWORD-FILE",
                      help="Password for SASL plain authentication")
+    group.add_option("--ssl-disable-peer-name-verify", action="store_true", default=False,
+                     help="Disables SSL host name verification. WARNING - This option is insecure and must not be used "
+                          "in production environments")
 
     return group
 
@@ -139,8 +142,13 @@ def opts_ssl_domain(opts, mode=SSLDomain.MODE_CLIENT):
     """Return proton.SSLDomain from command line options or None if no SSL options specified.
     @param opts: Parsed optoins including connection_options()
     """
-    certificate, key, trustfile, password, password_file = opts.ssl_certificate, opts.ssl_key, opts.ssl_trustfile, \
-                                                           opts.ssl_password, opts.ssl_password_file
+
+    certificate, key, trustfile, password, password_file, ssl_disable_peer_name_verify = opts.ssl_certificate,\
+                                                                                         opts.ssl_key,\
+                                                                                         opts.ssl_trustfile,\
+                                                                                         opts.ssl_password,\
+                                                                                         opts.ssl_password_file, \
+                                                                                         opts.ssl_disable_peer_name_verify
 
     if not (certificate or trustfile):
         return None
@@ -149,9 +157,14 @@ def opts_ssl_domain(opts, mode=SSLDomain.MODE_CLIENT):
         password = get_password(password_file)
 
     domain = SSLDomain(mode)
+
     if trustfile:
         domain.set_trusted_ca_db(str(trustfile))
-        domain.set_peer_authentication(SSLDomain.VERIFY_PEER, str(trustfile))
+        if ssl_disable_peer_name_verify:
+            domain.set_peer_authentication(SSLDomain.VERIFY_PEER, str(trustfile))
+        else:
+            domain.set_peer_authentication(SSLDomain.VERIFY_PEER_NAME, str(trustfile))
+
     if certificate:
         domain.set_credentials(str(certificate), str(key), str(password))
     return domain

--- a/tests/system_tests_qdmanage.py
+++ b/tests/system_tests_qdmanage.py
@@ -328,7 +328,8 @@ class QdmanageTestSsl(QdmanageTest):
                                              '--ssl-certificate=' + self.ssl_file('client-certificate.pem'),
                                              '--ssl-key=' + self.ssl_file('client-private-key.pem'),
                                              '--ssl-password=client-password',
-                                             '--timeout', str(TIMEOUT)],
+                                             '--timeout', str(TIMEOUT),
+                                             '--ssl-disable-peer-name-verify'],
             stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=expect)
         out = p.communicate(input)[0]
         try:

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -39,6 +39,7 @@ class QdstatTest(system_test.TestCase):
         p = self.popen(
             ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
             name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+
         out = p.communicate()[0]
         assert p.returncode == 0, \
             "qdstat exit status %s, output:\n%s" % (p.returncode, out)
@@ -114,8 +115,10 @@ try:
 
         def run_qdstat(self, args, regexp=None, address=None):
             p = self.popen(
-                ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
+                ['qdstat', '--bus', str(address or self.router.addresses[0]), '--ssl-disable-peer-name-verify',
+                 '--timeout', str(system_test.TIMEOUT) ] + args,
                 name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+
             out = p.communicate()[0]
             assert p.returncode == 0, \
                 "qdstat exit status %s, output:\n%s" % (p.returncode, out)

--- a/tests/system_tests_sasl_plain.py
+++ b/tests/system_tests_sasl_plain.py
@@ -258,6 +258,7 @@ class RouterTestPlainSaslOverSsl(RouterTestPlainSaslCommon):
              '--sasl-username=test@domain.com',
              '--sasl-password=password',
              # The following are SSL args
+             '--ssl-disable-peer-name-verify',
              '--ssl-trustfile=' + self.ssl_file('ca-certificate.pem'),
              '--ssl-certificate=' + self.ssl_file('client-certificate.pem'),
              '--ssl-key=' + self.ssl_file('client-private-key.pem'),


### PR DESCRIPTION
…Added new option --ssl-disable-peer-name-verify to disable peer name verification