### PR TITLE
DISPATCH-401 - Made qdstat and qdmanage verify peer name by default. …

### DIFF
--- a/tests/system_tests_qdmanage.py
+++ b/tests/system_tests_qdmanage.py
@@ -328,7 +328,8 @@ class QdmanageTestSsl(QdmanageTest):
                                              '--ssl-certificate=' + self.ssl_file('client-certificate.pem'),
                                              '--ssl-key=' + self.ssl_file('client-private-key.pem'),
                                              '--ssl-password=client-password',
-                                             '--timeout', str(TIMEOUT)],
+                                             '--timeout', str(TIMEOUT),
+                                             '--ssl-disable-peer-name-verify'],
             stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=expect)
         out = p.communicate(input)[0]
         try:

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -39,6 +39,7 @@ class QdstatTest(system_test.TestCase):
         p = self.popen(
             ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
             name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+
         out = p.communicate()[0]
         assert p.returncode == 0, \
             "qdstat exit status %s, output:\n%s" % (p.returncode, out)
@@ -114,8 +115,10 @@ try:
 
         def run_qdstat(self, args, regexp=None, address=None):
             p = self.popen(
-                ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
+                ['qdstat', '--bus', str(address or self.router.addresses[0]), '--ssl-disable-peer-name-verify',
+                 '--timeout', str(system_test.TIMEOUT) ] + args,
                 name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+
             out = p.communicate()[0]
             assert p.returncode == 0, \
                 "qdstat exit status %s, output:\n%s" % (p.returncode, out)

--- a/tests/system_tests_sasl_plain.py
+++ b/tests/system_tests_sasl_plain.py
@@ -258,6 +258,7 @@ class RouterTestPlainSaslOverSsl(RouterTestPlainSaslCommon):
              '--sasl-username=test@domain.com',
              '--sasl-password=password',
              # The following are SSL args
+             '--ssl-disable-peer-name-verify',
              '--ssl-trustfile=' + self.ssl_file('ca-certificate.pem'),
              '--ssl-certificate=' + self.ssl_file('client-certificate.pem'),
              '--ssl-key=' + self.ssl_file('client-private-key.pem'),


### PR DESCRIPTION
…Added new option --ssl-disable-peer-name-verify to disable peer name verification