### PR TITLE
Ensure that only 1 signal handler runs at a time

### DIFF
--- a/src/server_private.h
+++ b/src/server_private.h
@@ -174,6 +174,7 @@ struct qd_server_t {
     int                       pause_next_sequence;
     int                       pause_now_serving;
     qd_signal_handler_cb_t    signal_handler;
+    bool                      signal_handler_running;
     void                     *signal_context;
     int                       pending_signal;
     qd_connection_list_t      connections;


### PR DESCRIPTION
When I ran qdrouterd with perf and pressed Ctrl+C, perf would send SIGTERM as well as SIGINT right after each other to the router.

Scenario: 

Tthe first thread would pick up and handle the first signal in handle_signals_LH(). However, within the function, it unlocks the qd_server->lock before calling the registered handler. 

When it unlocks this lock, some other thread will pick up the second signal and jump into the qd_server_pause() code, where it will wait indefinitely for threads to pause (I saw this in GDB, where 1 thread was 'missing', and all others marked as canceled). The original handler will have canceled the thread trying to pause all others, but it is not able to jump out.

This patch ensures that only 1 signal handler can run at a time, which fixes the issue for me. Maybe another approach involving a signal handler lock would be better, but this signal_handler_running variable is protected by the qd_server->lock lock.