### PR TITLE
DISPATCH-451: Configurable settings for session capacity and max sessions

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -30,6 +30,13 @@
 
 
 /**
+ * AMQP Constants
+ */
+typedef enum {
+    QD_AMQP_MIN_MAX_FRAME_SIZE = 512
+} qd_amqp_constants_t;
+
+/**
  * AMQP Performative Tags
  */
 typedef enum {

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -418,6 +418,22 @@ typedef struct qd_server_config_t {
     uint32_t max_frame_size;
 
     /**
+     * The max_sessions value is the number of sessions allowed on the Connection. 
+     * This value minus one is the Open performative channel-max setting.
+     */
+    uint32_t max_sessions;
+
+    /**
+     * The max_session_window value is the maximum number of outstanding octets that are
+     * allowed to be in flight on a session. This value is used to calculate the number of
+     * outstanding transfers that are allowed by the formula:
+     *   incoming_window = max_session_window / max_frame_size
+     * If max_session_window=1000000 and max_frame_size=32768 then 30 transfers may
+     * be outstanding before session flow control begins.
+     */
+    uint32_t max_session_window;
+
+    /**
      * The idle timeout, in seconds.  If the peer sends no data frames in this many seconds, the
      * connection will be automatically closed.
      */

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -419,19 +419,16 @@ typedef struct qd_server_config_t {
 
     /**
      * The max_sessions value is the number of sessions allowed on the Connection. 
-     * This value minus one is the Open performative channel-max setting.
      */
     uint32_t max_sessions;
 
     /**
-     * The max_session_window value is the maximum number of outstanding octets that are
-     * allowed to be in flight on a session. This value is used to calculate the number of
-     * outstanding transfers that are allowed by the formula:
-     *   incoming_window = max_session_window / max_frame_size
-     * If max_session_window=1000000 and max_frame_size=32768 then 30 transfers may
-     * be outstanding before session flow control begins.
+     * The incoming capacity value is calculated to be (sessionMaxFrames * maxFrameSize).
+     * In a round about way the calculation forces the AMQP Begin/incoming-capacity value
+     * to equal the specified sessionMaxFrames value measured in units of transfer frames.
+     * This calculation is done to satisfy proton pn_session_set_incoming_capacity().
      */
-    uint32_t max_session_window;
+    uint32_t incoming_capacity;
 
     /**
      * The idle timeout, in seconds.  If the peer sends no data frames in this many seconds, the

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -620,7 +620,7 @@
                 },
                 "maxSessionFrames": {
                     "type": "integer",
-                    "description": "Session incoming window measured in transfer frames for sessions created on this connection. This is the number of transfer frames that may simultaneously be in flight for all links in the session. Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value. Defaults to 100.",
+                    "description": "Session incoming window measured in transfer frames for sessions created on this connection. This is the number of transfer frames that may simultaneously be in flight for all links in the session. Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value. The numerical product of maxFrameSize and maxSessionFrames may not exceed 2^31-1. If (maxFrameSize x maxSessionFrames) exceeds 2^31-1 then maxSessionFrames is reduced to (2^31-1 / maxFrameSize). maxSessionFrames has a minimum value of 1. Defaults to 100.",
                     "default": 100,
                     "required": false,
                     "create": true
@@ -746,7 +746,7 @@
                 },
                 "maxSessionFrames": {
                     "type": "integer",
-                    "description": "Session incoming window measured in transfer frames for sessions created on this connection. This is the number of transfer frames that may simultaneously be in flight for all links in the session. Setting this value to zero selects the default session window size. Policy settings will not overwrite this value. Defaults to 100.",
+                    "description": "Session incoming window measured in transfer frames for sessions created on this connection. This is the number of transfer frames that may simultaneously be in flight for all links in the session. Setting this value to zero selects the default session window size. Policy settings will not overwrite this value. The numerical product of maxFrameSize and maxSessionFrames may not exceed 2^31-1. If (maxFrameSize x maxSessionFrames) exceeds 2^31-1 then maxSessionFrames is reduced to (2^31-1 / maxFrameSize). maxSessionFrames has a minimum value of 1. Defaults to 100.",
                     "default": 100,
                     "required": false,
                     "create": true

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -609,18 +609,18 @@
                 "maxFrameSize": {
                     "type": "integer",
                     "default": 16384,
-                    "description": "Defaults to 16384.  If specified, it is the maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity.",
+                    "description": "Defaults to 16384.  If specified, it is the maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity. Policy settings, if specified, will overwrite this value.",
                     "create": true
                 },
                 "maxSessions": {
                     "type": "integer",
                     "default": 32768,
-                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions.",
+                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions. Policy settings, if specified, will overwrite this value.",
                     "create": true
                 },
                 "maxSessionWindow": {
                     "type": "integer",
-                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size.",
+                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value.",
                     "default": 1000000,
                     "required": false,
                     "create": true
@@ -713,14 +713,13 @@
                     "required": false,
                     "create": true,
                     "description": "For the 'inter-router' role only.  This value assigns a cost metric to the inter-router connection.  The default (and minimum) value is one.  Higher values represent higher costs.  The cost is used to influence the routing algorithm as it attempts to use the path with the lowest total cost from ingress to egress."
-                },                
-                            
+                },
                 "sslProfile": {
                     "type": "string",
                     "required": false,
                     "description": "Name of the sslProfile.",
                     "create": true
-                },            
+                },
                 "saslMechanisms": {
                     "type": "string",
                     "required": false,
@@ -736,18 +735,18 @@
                 "maxFrameSize": {
                     "type": "integer",
                     "default": 65536,
-                    "description": "Maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity.",
+                    "description": "Maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity. Policy settings, if specified, will overwrite this value.",
                     "create": true
                 },
                 "maxSessions": {
                     "type": "integer",
                     "default": 32768,
-                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions.",
+                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions. Policy settings, if specified, will overwrite this value.",
                     "create": true
                 },
                 "maxSessionWindow": {
                     "type": "integer",
-                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size.",
+                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value.",
                     "default": 1000000,
                     "required": false,
                     "create": true

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -612,6 +612,19 @@
                     "description": "Defaults to 16384.  If specified, it is the maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity.",
                     "create": true
                 },
+                "maxSessions": {
+                    "type": "integer",
+                    "default": 32768,
+                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions.",
+                    "create": true
+                },
+                "maxSessionWindow": {
+                    "type": "integer",
+                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size.",
+                    "default": 1000000,
+                    "required": false,
+                    "create": true
+                },
                 "idleTimeoutSeconds": {
                     "type": "integer",
                     "default": 16,
@@ -724,6 +737,19 @@
                     "type": "integer",
                     "default": 65536,
                     "description": "Maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity.",
+                    "create": true
+                },
+                "maxSessions": {
+                    "type": "integer",
+                    "default": 32768,
+                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions.",
+                    "create": true
+                },
+                "maxSessionWindow": {
+                    "type": "integer",
+                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size.",
+                    "default": 1000000,
+                    "required": false,
                     "create": true
                 },
                 "idleTimeoutSeconds": {

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -609,19 +609,19 @@
                 "maxFrameSize": {
                     "type": "integer",
                     "default": 16384,
-                    "description": "Defaults to 16384.  If specified, it is the maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity. Policy settings, if specified, will overwrite this value.",
+                    "description": "The maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity. Policy settings, if specified, will overwrite this value. Defaults to 16384.",
                     "create": true
                 },
                 "maxSessions": {
                     "type": "integer",
                     "default": 32768,
-                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions. Policy settings, if specified, will overwrite this value.",
+                    "description": "The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions. Policy settings, if specified, will overwrite this value. Defaults to 32768.",
                     "create": true
                 },
-                "maxSessionWindow": {
+                "maxSessionFrames": {
                     "type": "integer",
-                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value.",
-                    "default": 1000000,
+                    "description": "Session incoming window measured in transfer frames for sessions created on this connection. This is the number of transfer frames that may simultaneously be in flight for all links in the session. Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value. Defaults to 100.",
+                    "default": 100,
                     "required": false,
                     "create": true
                 },
@@ -734,20 +734,20 @@
                 },
                 "maxFrameSize": {
                     "type": "integer",
-                    "default": 65536,
-                    "description": "Maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity. Policy settings, if specified, will overwrite this value.",
+                    "default": 16384,
+                    "description": "The maximum frame size in octets that will be used in the connection-open negotiation with a connected peer.  The frame size is the largest contiguous set of uninterrupted data that can be sent for a message delivery over the connection. Interleaving of messages on different links is done at frame granularity. Policy settings will not overwrite this value. Defaults to 16384.",
                     "create": true
                 },
                 "maxSessions": {
                     "type": "integer",
                     "default": 32768,
-                    "description": "Defaults to 32768.  The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions. Policy settings, if specified, will overwrite this value.",
+                    "description": "The maximum number of sessions that can be simultaneously active on the connection. Setting this value to zero selects the default number of sessions. Policy settings will not overwrite this value. Defaults to 32768.",
                     "create": true
                 },
-                "maxSessionWindow": {
+                "maxSessionFrames": {
                     "type": "integer",
-                    "description": "Incoming window measured in octets for sessions created on this connection. The AMQP negotiated session incoming window, measured in transfers, is calculated to be (maxSessionWindow / maxFrameSize). Setting this value to zero selects the default session window size. Policy settings, if specified, will overwrite this value.",
-                    "default": 1000000,
+                    "description": "Session incoming window measured in transfer frames for sessions created on this connection. This is the number of transfer frames that may simultaneously be in flight for all links in the session. Setting this value to zero selects the default session window size. Policy settings will not overwrite this value. Defaults to 100.",
+                    "default": 100,
                     "required": false,
                     "create": true
                 },

--- a/python/qpid_dispatch/management/qdrouter.policyRuleset.settings.txt
+++ b/python/qpid_dispatch/management/qdrouter.policyRuleset.settings.txt
@@ -42,7 +42,7 @@ Until the schema is extended specify embedded maps this document describes the v
           "maxFrameSize": {
               "type": "integer",
               "description": "Largest frame that may be sent on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Open, max-frame-size)",
-              "default": 65536,
+              "default": 16384,
               "required": false,
               "create": true
           },
@@ -56,7 +56,7 @@ Until the schema is extended specify embedded maps this document describes the v
           "maxSessionWindow": {
               "type": "integer",
               "description": "Largest incoming window in octets for sessions created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Begin, incoming-window)",
-              "default": 1000000,
+              "default": 1638400,
               "required": false,
               "create": true
           },

--- a/python/qpid_dispatch/management/qdrouter.policyRuleset.settings.txt
+++ b/python/qpid_dispatch/management/qdrouter.policyRuleset.settings.txt
@@ -41,42 +41,42 @@ Until the schema is extended specify embedded maps this document describes the v
           },
           "maxFrameSize": {
               "type": "integer",
-              "description": "Largest frame that may be sent on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Open, max-frame-size)",
+              "description": "Largest frame that may be sent on this connection. Non-zero policy values overwrite values specified for a listener object. (AMQP Open, max-frame-size)",
               "default": 16384,
               "required": false,
               "create": true
           },
           "maxMessageSize": {
               "type": "integer",
-              "description": "Largest message size supported by links created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Attach, max-message-size)",
+              "description": "[NOT IMPLEMENTED] Largest message size supported by links created on this connection. Non-zero policy values overwrite values specified for a listener object. (AMQP Attach, max-message-size)",
               "default": 0,
               "required": false,
               "create": true
           },
           "maxSessionWindow": {
               "type": "integer",
-              "description": "Largest incoming window in octets for sessions created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Begin, incoming-window)",
+              "description": "Largest incoming window in octets for sessions created on this connection. Non-zero policy values overwrite values specified for a listener object. (AMQP Begin, incoming-window)",
               "default": 1638400,
               "required": false,
               "create": true
           },
           "maxSessions": {
               "type": "integer",
-              "description": "Maximum number of sessions that may be created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Open, channel-max)",
+              "description": "Maximum number of sessions that may be created on this connection. Non-zero policy values overwrite values specified for a listener object. (AMQP Open, channel-max)",
               "default": 32768,
               "required": false,
               "create": true
           },
           "maxSenders": {
               "type": "integer",
-              "description": "Maximum number of sending links that may be created on this connection. Zero implies system default.",
+              "description": "Maximum number of sending links that may be created on this connection. Zero disables all sender links.",
               "default": 2147483647,
               "required": false,
               "create": true
           },
           "maxReceivers": {
               "type": "integer",
-              "description": "Maximum number of receiving links that may be created on this connection. Zero implies system default.",
+              "description": "Maximum number of receiving links that may be created on this connection. Zero disables all receiver links.",
               "default": 2147483647,
               "required": false,
               "create": true

--- a/python/qpid_dispatch/management/qdrouter.policyRuleset.settings.txt
+++ b/python/qpid_dispatch/management/qdrouter.policyRuleset.settings.txt
@@ -41,29 +41,29 @@ Until the schema is extended specify embedded maps this document describes the v
           },
           "maxFrameSize": {
               "type": "integer",
-              "description": "Largest frame that may be sent on this connection. Zero implies system default. (AMQP Open, max-frame-size)",
+              "description": "Largest frame that may be sent on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Open, max-frame-size)",
               "default": 65536,
               "required": false,
               "create": true
           },
           "maxMessageSize": {
               "type": "integer",
-              "description": "Largest message size supported by links created on this connection. Zero implies system default. (AMQP Attach, max-message-size)",
+              "description": "Largest message size supported by links created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Attach, max-message-size)",
               "default": 0,
               "required": false,
               "create": true
           },
           "maxSessionWindow": {
               "type": "integer",
-              "description": "Largest incoming and outgoing window for sessions created on this connection. Zero implies system default. (AMQP Begin, incoming-window, outgoing-window)",
-              "default": 2147483647,
+              "description": "Largest incoming window in octets for sessions created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Begin, incoming-window)",
+              "default": 1000000,
               "required": false,
               "create": true
           },
           "maxSessions": {
               "type": "integer",
-              "description": "Maximum number of sessions that may be created on this connection. Zero implies system default. (AMQP Open, channel-max)",
-              "default": 2147483647,
+              "description": "Maximum number of sessions that may be created on this connection. Zero implies system default. Policy setting overwrites values specified for a listener or connector. (AMQP Open, channel-max)",
+              "default": 32768,
               "required": false,
               "create": true
           },

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -183,6 +183,8 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
     config->inter_router_cost    = qd_entity_opt_long(entity, "cost", 1);             CHECK();
     config->protocol_family      = qd_entity_opt_string(entity, "protocolFamily", 0); CHECK();
     config->max_frame_size       = qd_entity_get_long(entity, "maxFrameSize");        CHECK();
+    config->max_sessions         = qd_entity_get_long(entity, "maxSessions");         CHECK();
+    config->max_session_window   = qd_entity_get_long(entity, "maxSessionWindow");    CHECK();
     config->idle_timeout_seconds = qd_entity_get_long(entity, "idleTimeoutSeconds");  CHECK();
     config->sasl_username        = qd_entity_opt_string(entity, "saslUsername", 0);   CHECK();
     config->sasl_password        = qd_entity_opt_string(entity, "saslPassword", 0);   CHECK();
@@ -192,10 +194,16 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
     set_config_host(config, entity);
 
     //
-    // Handle the defaults for link capacity.
+    // Handle the defaults for various settings
     //
     if (config->link_capacity == 0)
         config->link_capacity = 250;
+
+    if (config->max_sessions == 0)
+        config->max_sessions = 32768;
+
+    if (config->max_session_window == 0)
+        config->max_session_window = 1000000;
 
     //
     // For now we are hardwiring this attribute to true.  If there's an outcry from the

--- a/src/container.c
+++ b/src/container.c
@@ -764,10 +764,9 @@ qd_link_t *qd_link(qd_node_t *node, qd_connection_t *conn, qd_direction_t dir, c
 {
     qd_link_t *link = new_qd_link_t();
     const qd_server_config_t * cf = qd_connection_config(conn);
-    assert(cf);
 
     link->pn_sess = pn_session(qd_connection_pn(conn));
-    pn_session_set_incoming_capacity(link->pn_sess, cf->max_session_window);
+    pn_session_set_incoming_capacity(link->pn_sess, cf->incoming_capacity);
 
     if (dir == QD_OUTGOING)
         link->pn_link = pn_sender(link->pn_sess, name);

--- a/src/container.c
+++ b/src/container.c
@@ -763,9 +763,11 @@ qd_lifetime_policy_t qd_container_node_get_life_policy(const qd_node_t *node)
 qd_link_t *qd_link(qd_node_t *node, qd_connection_t *conn, qd_direction_t dir, const char* name)
 {
     qd_link_t *link = new_qd_link_t();
+    const qd_server_config_t * cf = qd_connection_config(conn);
+    assert(cf);
 
     link->pn_sess = pn_session(qd_connection_pn(conn));
-    pn_session_set_incoming_capacity(link->pn_sess, 1000000);
+    pn_session_set_incoming_capacity(link->pn_sess, cf->max_session_window);
 
     if (dir == QD_OUTGOING)
         link->pn_link = pn_sender(link->pn_sess, name);

--- a/src/policy.c
+++ b/src/policy.c
@@ -438,8 +438,7 @@ void qd_policy_apply_session_settings(pn_session_t *ssn, qd_connection_t *qd_con
         capacity = qd_conn->policy_settings->maxSessionWindow;
     } else {
         const qd_server_config_t * cf = qd_connection_config(qd_conn);
-        assert(cf);
-        capacity = cf->max_session_window;
+        capacity = cf->incoming_capacity;
     }
     pn_session_set_incoming_capacity(ssn, capacity);
 }

--- a/src/policy.c
+++ b/src/policy.c
@@ -433,11 +433,15 @@ bool qd_policy_approve_amqp_session(pn_session_t *ssn, qd_connection_t *qd_conn)
 //
 void qd_policy_apply_session_settings(pn_session_t *ssn, qd_connection_t *qd_conn)
 {
+    size_t capacity;
     if (qd_conn->policy_settings && qd_conn->policy_settings->maxSessionWindow) {
-        pn_session_set_incoming_capacity(ssn, qd_conn->policy_settings->maxSessionWindow);
+        capacity = qd_conn->policy_settings->maxSessionWindow;
     } else {
-        pn_session_set_incoming_capacity(ssn, 1000000);
+        const qd_server_config_t * cf = qd_connection_config(qd_conn);
+        assert(cf);
+        capacity = cf->max_session_window;
     }
+    pn_session_set_incoming_capacity(ssn, capacity);
 }
 
 //

--- a/src/server.c
+++ b/src/server.c
@@ -680,6 +680,7 @@ static void thread_process_listeners_LH(qd_server_t *qd_server)
         //
         pn_transport_set_server(tport);
         pn_transport_set_max_frame(tport, config->max_frame_size);
+        pn_transport_set_channel_max(tport, config->max_sessions - 1);
         pn_transport_set_idle_timeout(tport, config->idle_timeout_seconds * 1000);
 
         //
@@ -1247,6 +1248,7 @@ static void cxtr_try_open(void *context)
     // Configure the transport
     //
     pn_transport_set_max_frame(tport, config->max_frame_size);
+    pn_transport_set_channel_max(tport, config->max_sessions - 1);
     pn_transport_set_idle_timeout(tport, config->idle_timeout_seconds * 1000);
 
     //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ foreach(py_test_module
     system_tests_one_router
     system_tests_policy
     system_tests_protocol_family
+    system_tests_protocol_settings
     system_tests_qdmanage
     system_tests_qdstat
     system_tests_sasl_plain

--- a/tests/system_tests_protocol_settings.py
+++ b/tests/system_tests_protocol_settings.py
@@ -1,0 +1,316 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+from proton import Message, Delivery, PENDING, ACCEPTED, REJECTED
+from system_test import TestCase, Qdrouterd, main_module
+from proton.handlers import MessagingHandler
+from proton.reactor import Container, AtMostOnce, AtLeastOnce
+from proton.utils import BlockingConnection, SyncRequestResponse
+from qpid_dispatch.management.client import Node
+from proton import ConnectionException
+
+class MaxFrameMaxSessionFramesTest(TestCase):
+    """System tests setting proton negotiated size max-frame-size and incoming-window"""
+    @classmethod
+    def setUpClass(cls):
+        '''Start a router'''
+        super(MaxFrameMaxSessionFramesTest, cls).setUpClass()
+        name = "MaxFrameMaxSessionFrames"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxFrameSize': '2048', 'maxSessionFrames': '10'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_frame_max_session_frames__max_sessions_default(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxFrameMaxSessionFrames.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # max-frame is from the config
+            self.assertTrue(' max-frame-size=2048,' in open_lines[0])
+            # channel-max is default
+            self.assertTrue(" channel-max=32767" in open_lines[0])
+            begin_lines = [s for s in log_lines if "-> @begin" in s]
+            # incoming-window is from the config
+            self.assertTrue(" incoming-window=10," in begin_lines[0] )
+
+
+class MaxSessionsTest(TestCase):
+    """System tests setting proton channel-max"""
+    @classmethod
+    def setUpClass(cls):
+        """Start a router and a messenger"""
+        super(MaxSessionsTest, cls).setUpClass()
+        name = "MaxSessions"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxSessions': '10'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_sessions(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxSessions.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # channel-max is 10
+            self.assertTrue(" channel-max=9" in open_lines[0])
+
+
+class MaxSessionsZeroTest(TestCase):
+    """System tests setting proton channel-max"""
+    @classmethod
+    def setUpClass(cls):
+        """Start a router and a messenger"""
+        super(MaxSessionsZeroTest, cls).setUpClass()
+        name = "MaxSessionsZero"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxSessions': '0'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_sessions_zero(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxSessionsZero.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # channel-max is 0. Should get proton default 32767
+            self.assertTrue(" channel-max=32767" in open_lines[0])
+
+
+class MaxSessionsLargeTest(TestCase):
+    """System tests setting proton channel-max"""
+    @classmethod
+    def setUpClass(cls):
+        """Start a router and a messenger"""
+        super(MaxSessionsLargeTest, cls).setUpClass()
+        name = "MaxSessionsLarge"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxSessions': '500000'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_sessions_large(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxSessionsLarge.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # channel-max is 0. Should get proton default 32767
+            self.assertTrue(" channel-max=32767" in open_lines[0])
+
+
+class MaxFrameSmallTest(TestCase):
+    """System tests setting proton max-frame-size"""
+    @classmethod
+    def setUpClass(cls):
+        """Start a router and a messenger"""
+        super(MaxFrameSmallTest, cls).setUpClass()
+        name = "MaxFrameSmall"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxFrameSize': '2'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_frame_small(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxFrameSmall.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # if frame size <= 512 proton set min of 512
+            self.assertTrue(" max-frame-size=512" in open_lines[0])
+
+
+class MaxFrameDefaultTest(TestCase):
+    """System tests setting proton max-frame-size"""
+    @classmethod
+    def setUpClass(cls):
+        """Start a router and a messenger"""
+        super(MaxFrameDefaultTest, cls).setUpClass()
+        name = "MaxFrameDefault"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port()}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_frame_default(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxFrameDefault.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # if frame size not set then a default is used
+            self.assertTrue(" max-frame-size=16384" in open_lines[0])
+
+
+class MaxSessionFramesDefaultTest(TestCase):
+    """System tests setting proton max-frame-size"""
+    @classmethod
+    def setUpClass(cls):
+        """Start a router and a messenger"""
+        super(MaxSessionFramesDefaultTest, cls).setUpClass()
+        name = "MaxSessionFramesDefault"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port()}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_session_frames_default(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxSessionFramesDefault.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # if frame size not set then a default is used
+            self.assertTrue(" max-frame-size=16384" in open_lines[0])
+            begin_lines = [s for s in log_lines if "-> @begin" in s]
+            # incoming-window is from the config
+            self.assertTrue(" incoming-window=100," in begin_lines[0])
+
+
+class MaxFrameMaxSessionFramesTooBigTest(TestCase):
+    """
+    System tests setting proton negotiated size max-frame-size and incoming-window
+    when the product of the two is > 2^31-1. There must be a warning and the incoming
+    window will be reduced to 2^31-1 / max-frame-size
+    """
+    @classmethod
+    def setUpClass(cls):
+        '''Start a router'''
+        super(MaxFrameMaxSessionFramesTooBigTest, cls).setUpClass()
+        name = "MaxFrameMaxSessionFramesTooBig"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxFrameSize': '1000000', 'maxSessionFrames': '5000000'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_frame_max_session_too_big(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxFrameMaxSessionFramesTooBig.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # max-frame is from the config
+            self.assertTrue(' max-frame-size=1000000,' in open_lines[0])
+            begin_lines = [s for s in log_lines if "-> @begin" in s]
+            # incoming-window is truncated
+            self.assertTrue(" incoming-window=2147," in begin_lines[0])
+            warning_lines = [s for s in log_lines if "(warning)" in s]
+            self.assertTrue(len(warning_lines) == 1)
+            self.assertTrue("requested maxSessionFrames truncated from 5000000 to 2147" in warning_lines[0])
+
+
+class MaxFrameMaxSessionFramesZeroTest(TestCase):
+    """
+    System tests setting proton negotiated size max-frame-size and incoming-window
+    when they are both zero. Frame size is bumped up to the minimum and capacity is
+    bumped up to have an incoming window of 1
+    """
+    @classmethod
+    def setUpClass(cls):
+        '''Start a router'''
+        super(MaxFrameMaxSessionFramesZeroTest, cls).setUpClass()
+        name = "MaxFrameMaxSessionFramesZero"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR'}),
+
+            ('listener', {'host': '0.0.0.0', 'port': cls.tester.get_port(), 'maxFrameSize': '0', 'maxSessionFrames': '0'}),
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_max_frame_max_session_zero(self):
+        # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        bc = BlockingConnection(self.router.addresses[0])
+        bc.create_receiver("xxx")
+        bc.close()
+
+        with  open('../setUpClass/MaxFrameMaxSessionFramesZero.log', 'r') as router_log:
+            log_lines = router_log.read().split("\n")
+            open_lines = [s for s in log_lines if "-> @open" in s]
+            # max-frame gets set to protocol min
+            self.assertTrue(' max-frame-size=512,' in open_lines[0])
+            begin_lines = [s for s in log_lines if "-> @begin" in s]
+            # incoming-window is promoted to 1
+            self.assertTrue(" incoming-window=1," in begin_lines[0])
+
+
+if __name__ == '__main__':
+    unittest.main(main_module())


### PR DESCRIPTION
This patch allows listener and connector settings for session capacity and for max sessions.

It does _not_ allow a setting for max-message-size. Proton does not provide an interface for changing max message size. This issue is tracked at [PROTON-1311](https://issues.apache.org/jira/browse/PROTON-1311)

Work is progressing on self tests for this feature. Proton python and wrapper interfaces tend to hide sessions and make finding session state difficult.