### PR TITLE
DISPATCH-476: Add support for groupId property for matching link routes and auto links

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -128,6 +128,7 @@ extern const char * const QD_CONNECTION_PROPERTY_PRODUCT_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_PRODUCT_VALUE;
 extern const char * const QD_CONNECTION_PROPERTY_VERSION_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_COST_KEY;
+extern const char * const QD_CONNECTION_PROPERTY_GROUP_KEY;
 /// @}
 
 /** @name AMQP error codes. */

--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -166,6 +166,7 @@ qdr_connection_t *qdr_connection_opened(qdr_core_t            *core,
                                         uint64_t               management_id,
                                         const char            *label,
                                         const char            *remote_container_id,
+                                        pn_bytes_t             group_id,
                                         bool                   strip_annotations_in,
                                         bool                   strip_annotations_out,
                                         int                    link_capacity);

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -902,6 +902,12 @@
                     "create": true,
                     "required": false
                 },
+                "groupId": {
+                    "type": "string",
+                    "description": "GroupID for the target container",
+                    "create": true,
+                    "required": false
+                },
                 "connection": {
                     "type": "string",
                     "description": "The name from a connector or listener",
@@ -955,6 +961,12 @@
                 "containerId": {
                     "type": "string",
                     "description": "ContainerID for the target container",
+                    "create": true,
+                    "required": false
+                },
+                "groupId": {
+                    "type": "string",
+                    "description": "GroupID for the target container",
                     "create": true,
                     "required": false
                 },

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -36,6 +36,7 @@ const char * const QD_CONNECTION_PROPERTY_PRODUCT_KEY   = "product";
 const char * const QD_CONNECTION_PROPERTY_PRODUCT_VALUE = "qpid-dispatch-router";
 const char * const QD_CONNECTION_PROPERTY_VERSION_KEY   = "version";
 const char * const QD_CONNECTION_PROPERTY_COST_KEY      = "qd.inter-router-cost";
+const char * const QD_CONNECTION_PROPERTY_GROUP_KEY     = "qd.route-container-group";
 
 const qd_amqp_error_t QD_AMQP_OK = { 200, "OK" };
 const qd_amqp_error_t QD_AMQP_CREATED = { 201, "Created" };

--- a/src/router_config.c
+++ b/src/router_config.c
@@ -306,6 +306,7 @@ qd_error_t qd_router_configure_link_route(qd_router_t *router, qd_entity_t *enti
     char *name      = 0;
     char *prefix    = 0;
     char *container = 0;
+    char *group     = 0;
     char *c_name    = 0;
     char *distrib   = 0;
     char *dir       = 0;
@@ -314,6 +315,7 @@ qd_error_t qd_router_configure_link_route(qd_router_t *router, qd_entity_t *enti
         name      = qd_entity_opt_string(entity, "name", 0);         QD_ERROR_BREAK();
         prefix    = qd_entity_get_string(entity, "prefix");          QD_ERROR_BREAK();
         container = qd_entity_opt_string(entity, "containerId", 0);  QD_ERROR_BREAK();
+        group     = qd_entity_opt_string(entity, "groupId", 0);      QD_ERROR_BREAK();
         c_name    = qd_entity_opt_string(entity, "connection", 0);   QD_ERROR_BREAK();
         distrib   = qd_entity_opt_string(entity, "distribution", 0); QD_ERROR_BREAK();
         dir       = qd_entity_opt_string(entity, "dir", 0);          QD_ERROR_BREAK();
@@ -337,6 +339,11 @@ qd_error_t qd_router_configure_link_route(qd_router_t *router, qd_entity_t *enti
         if (container) {
             qd_compose_insert_string(body, "containerId");
             qd_compose_insert_string(body, container);
+        }
+
+        if (group) {
+            qd_compose_insert_string(body, "groupId");
+            qd_compose_insert_string(body, group);
         }
 
         if (c_name) {
@@ -386,6 +393,7 @@ qd_error_t qd_router_configure_link_route(qd_router_t *router, qd_entity_t *enti
     free(name);
     free(prefix);
     free(container);
+    free(group);
     free(c_name);
     free(distrib);
     free(dir);
@@ -400,6 +408,7 @@ qd_error_t qd_router_configure_auto_link(qd_router_t *router, qd_entity_t *entit
     char *addr      = 0;
     char *dir       = 0;
     char *container = 0;
+    char *group     = 0;
     char *c_name    = 0;
     char *ext_addr  = 0;
 
@@ -408,6 +417,7 @@ qd_error_t qd_router_configure_auto_link(qd_router_t *router, qd_entity_t *entit
         addr      = qd_entity_get_string(entity, "addr");            QD_ERROR_BREAK();
         dir       = qd_entity_get_string(entity, "dir");             QD_ERROR_BREAK();
         container = qd_entity_opt_string(entity, "containerId", 0);  QD_ERROR_BREAK();
+        group     = qd_entity_opt_string(entity, "groupId", 0);      QD_ERROR_BREAK();
         c_name    = qd_entity_opt_string(entity, "connection", 0);   QD_ERROR_BREAK();
         ext_addr  = qd_entity_opt_string(entity, "externalAddr", 0); QD_ERROR_BREAK();
         long  phase     = qd_entity_opt_long(entity, "phase", -1);   QD_ERROR_BREAK();
@@ -441,6 +451,11 @@ qd_error_t qd_router_configure_auto_link(qd_router_t *router, qd_entity_t *entit
         if (container) {
             qd_compose_insert_string(body, "containerId");
             qd_compose_insert_string(body, container);
+        }
+
+        if (group) {
+            qd_compose_insert_string(body, "groupId");
+            qd_compose_insert_string(body, group);
         }
 
         if (c_name) {
@@ -486,6 +501,7 @@ qd_error_t qd_router_configure_auto_link(qd_router_t *router, qd_entity_t *entit
     free(addr);
     free(dir);
     free(container);
+    free(group);
     free(c_name);
     free(ext_addr);
 

--- a/src/router_core/agent_config_auto_link.h
+++ b/src/router_core/agent_config_auto_link.h
@@ -32,7 +32,7 @@ void qdra_config_auto_link_get_CT(qdr_core_t        *core,
                                 qd_field_iterator_t *identity,
                                 qdr_query_t         *query,
                                 const char          *qdr_config_auto_link_columns[]);
-#define QDR_CONFIG_AUTO_LINK_COLUMN_COUNT 12
+#define QDR_CONFIG_AUTO_LINK_COLUMN_COUNT 13
 
 const char *qdr_config_auto_link_columns[QDR_CONFIG_AUTO_LINK_COLUMN_COUNT + 1];
 

--- a/src/router_core/agent_config_link_route.h
+++ b/src/router_core/agent_config_link_route.h
@@ -33,7 +33,7 @@ void qdra_config_link_route_get_CT(qdr_core_t          *core,
                                    qdr_query_t         *query,
                                    const char          *qdr_config_link_route_columns[]);
 
-#define QDR_CONFIG_LINK_ROUTE_COLUMN_COUNT 9
+#define QDR_CONFIG_LINK_ROUTE_COLUMN_COUNT 10
 
 const char *qdr_config_link_route_columns[QDR_CONFIG_LINK_ROUTE_COLUMN_COUNT + 1];
 

--- a/src/router_core/route_control.h
+++ b/src/router_core/route_control.h
@@ -21,11 +21,15 @@
 
 #include "router_core_private.h"
 
+#define QDR_CONN_ID_MATCHER_CONN_LABEL   0
+#define QDR_CONN_ID_MATCHER_CONTAINER_ID 1
+#define QDR_CONN_ID_MATCHER_GROUP_ID     2
+
 qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
                                               qd_field_iterator_t    *name,
                                               qd_parsed_field_t      *prefix_field,
                                               qd_parsed_field_t      *conn_id,
-                                              bool                    is_container,
+                                              int matcher,
                                               qd_address_treatment_t  treatment,
                                               qd_direction_t          dir);
 
@@ -37,7 +41,7 @@ qdr_auto_link_t *qdr_route_add_auto_link_CT(qdr_core_t          *core,
                                             qd_direction_t       dir,
                                             int                  phase,
                                             qd_parsed_field_t   *conn_id,
-                                            bool                 is_container,
+                                            int matcher,
                                             qd_parsed_field_t   *external_addr);
 
 void qdr_route_del_auto_link_CT(qdr_core_t *core, qdr_auto_link_t *auto_link);
@@ -45,7 +49,7 @@ void qdr_route_del_auto_link_CT(qdr_core_t *core, qdr_auto_link_t *auto_link);
 void qdr_route_connection_opened_CT(qdr_core_t       *core,
                                     qdr_connection_t *conn,
                                     qdr_field_t      *field,
-                                    bool              is_container);
+                                    int              matcher);
 
 void qdr_route_connection_closed_CT(qdr_core_t *core, qdr_connection_t *conn);
 

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -113,9 +113,15 @@ void qdr_core_free(qdr_core_t *core)
 ALLOC_DECLARE(qdr_field_t);
 ALLOC_DEFINE(qdr_field_t);
 
+
 qdr_field_t *qdr_field(const char *text)
 {
     size_t length  = text ? strlen(text) : 0;
+    return qdr_field_with_length(text, length);
+}
+
+qdr_field_t *qdr_field_with_length(const char *text, size_t length)
+{
     size_t ilength = length;
 
     if (length == 0)

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -61,6 +61,7 @@ typedef struct {
 } qdr_field_t;
 
 qdr_field_t *qdr_field(const char *string);
+qdr_field_t *qdr_field_with_length(const char *string, size_t length);
 qdr_field_t *qdr_field_from_iter(qd_field_iterator_t *iter);
 qd_field_iterator_t *qdr_field_iterator(qdr_field_t *field);
 void qdr_field_free(qdr_field_t *field);
@@ -96,6 +97,7 @@ struct qdr_action_t {
             qdr_connection_t *conn;
             qdr_field_t      *connection_label;
             qdr_field_t      *container_id;
+            qdr_field_t      *group_id;
             qdr_link_t       *link;
             qdr_delivery_t   *delivery;
             qd_message_t     *msg;
@@ -505,10 +507,10 @@ DEQ_DECLARE(qdr_auto_link_t, qdr_auto_link_list_t);
 
 
 struct qdr_conn_identifier_t {
-    qd_hash_handle_t      *hash_handle;
-    qdr_connection_t      *open_connection;
-    qdr_link_route_list_t  link_route_refs;
-    qdr_auto_link_list_t   auto_link_refs;
+    qd_hash_handle_t          *hash_handle;
+    qdr_connection_ref_list_t  connection_refs;
+    qdr_link_route_list_t      link_route_refs;
+    qdr_auto_link_list_t       auto_link_refs;
 };
 
 ALLOC_DECLARE(qdr_conn_identifier_t);


### PR DESCRIPTION
This is a proposed alternative for supporting a mapping of multiple connections - multiple link
routes/autolinks by grouping them on a 'groupId' identifier. The corresponding group is selected based on a connection property 'qd.route-container-group'.

We have discussed this approach previously, and somewhat decided that we should take a different approach. I wanted to implement this approach as a way of learning more of the router internals, so consider this PR a POC that you can close if you think this feature is not useful, though I do think it gives a lot of flexibility with little increase in complexity.