### PR TITLE
DISPATCH-598 - Added code to temporarily fix the crash that is being …

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -435,6 +435,14 @@ int pn_event_handler(void *handler_context, void *conn_context, pn_event_t *even
         break;
     case PN_SESSION_LOCAL_CLOSE :
         ssn = pn_event_session(event);
+
+        pn_link = pn_link_head(conn, PN_LOCAL_ACTIVE | PN_REMOTE_CLOSED);
+        while (pn_link) {
+                qd_link_t *qd_link = (qd_link_t*) pn_link_get_context(pn_link);
+                qd_link->pn_link = 0;
+                pn_link = pn_link_next(pn_link, PN_LOCAL_ACTIVE | PN_REMOTE_CLOSED);
+        }
+
         if (pn_session_state(ssn) == (PN_LOCAL_CLOSED | PN_REMOTE_CLOSED)) {
             add_session_to_free_list(&qd_conn->free_link_session_list,ssn);
         }


### PR DESCRIPTION
…caused when PN_LINK_REMOTE_CLOSE and PN_SESSION_REMOTE_CLOSE events come in on the same collector loop. A more comprehensive fix is being worked on for the 0.9 release