### PR TITLE
DISPATCH-613 - Remove semi-column not needed after macro definition. …

### DIFF
--- a/src/bitmask.c
+++ b/src/bitmask.c
@@ -34,7 +34,7 @@ struct qd_bitmask_t {
 };
 
 ALLOC_DECLARE(qd_bitmask_t);
-ALLOC_DEFINE(qd_bitmask_t);
+ALLOC_DEFINE(qd_bitmask_t)
 
 #define MASK_INDEX(num)  (num / 64)
 #define MASK_ONEHOT(num) (((uint64_t) 1) << (num % 64))

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -28,7 +28,7 @@ static size_t buffer_size = 512;
 static int    size_locked = 0;
 
 ALLOC_DECLARE(qd_buffer_t);
-ALLOC_DEFINE_CONFIG(qd_buffer_t, sizeof(qd_buffer_t), &buffer_size, 0);
+ALLOC_DEFINE_CONFIG(qd_buffer_t, sizeof(qd_buffer_t), &buffer_size, 0)
 
 
 void qd_buffer_set_size(size_t size)

--- a/src/compose.c
+++ b/src/compose.c
@@ -25,8 +25,8 @@
 #include <memory.h>
 #include <string.h>
 
-ALLOC_DEFINE(qd_composite_t);
-ALLOC_DEFINE(qd_composed_field_t);
+ALLOC_DEFINE(qd_composite_t)
+ALLOC_DEFINE(qd_composed_field_t)
 
 
 static void bump_count(qd_composed_field_t *field)

--- a/src/container.c
+++ b/src/container.c
@@ -47,7 +47,7 @@ struct qd_node_t {
 
 DEQ_DECLARE(qd_node_t, qd_node_list_t);
 ALLOC_DECLARE(qd_node_t);
-ALLOC_DEFINE(qd_node_t);
+ALLOC_DEFINE(qd_node_t)
 
 /** Encapsulates a proton link for sending and receiving messages */
 struct qd_link_t {
@@ -62,7 +62,7 @@ struct qd_link_t {
 };
 
 ALLOC_DECLARE(qd_link_t);
-ALLOC_DEFINE(qd_link_t);
+ALLOC_DEFINE(qd_link_t)
 
 
 typedef struct qdc_node_type_t {

--- a/src/hash.c
+++ b/src/hash.c
@@ -35,7 +35,7 @@ typedef struct qd_hash_item_t {
 } qd_hash_item_t;
 
 ALLOC_DECLARE(qd_hash_item_t);
-ALLOC_DEFINE(qd_hash_item_t);
+ALLOC_DEFINE(qd_hash_item_t)
 DEQ_DECLARE(qd_hash_item_t, items_t);
 
 
@@ -60,7 +60,7 @@ struct qd_hash_handle_t {
 };
 
 ALLOC_DECLARE(qd_hash_handle_t);
-ALLOC_DEFINE(qd_hash_handle_t);
+ALLOC_DEFINE(qd_hash_handle_t)
 
 
 qd_hash_t *qd_hash(int bucket_exponent, int batch_size, int value_is_const)

--- a/src/iovec.c
+++ b/src/iovec.c
@@ -32,7 +32,7 @@ struct qd_iovec_t {
 
 
 ALLOC_DECLARE(qd_iovec_t);
-ALLOC_DEFINE(qd_iovec_t);
+ALLOC_DEFINE(qd_iovec_t)
 
 
 qd_iovec_t *qd_iovec(int vector_count)

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -52,7 +52,7 @@ typedef struct qd_hash_segment_t {
 
 DEQ_DECLARE(qd_hash_segment_t, qd_hash_segment_list_t);
 ALLOC_DECLARE(qd_hash_segment_t);
-ALLOC_DEFINE(qd_hash_segment_t);
+ALLOC_DEFINE(qd_hash_segment_t)
 
 struct qd_iterator_t {
     pointer_t               start_pointer;      // Pointer to the raw data
@@ -74,7 +74,7 @@ struct qd_iterator_t {
 };
 
 ALLOC_DECLARE(qd_iterator_t);
-ALLOC_DEFINE(qd_iterator_t);
+ALLOC_DEFINE(qd_iterator_t)
 
 typedef enum {
     STATE_START,

--- a/src/log.c
+++ b/src/log.c
@@ -58,7 +58,7 @@ struct qd_log_entry_t {
 };
 
 ALLOC_DECLARE(qd_log_entry_t);
-ALLOC_DEFINE(qd_log_entry_t);
+ALLOC_DEFINE(qd_log_entry_t)
 
 DEQ_DECLARE(qd_log_entry_t, qd_log_list_t);
 static qd_log_list_t         entries = {0};

--- a/src/message.c
+++ b/src/message.c
@@ -59,8 +59,8 @@ static const unsigned char * const TAGS_ANY                     = (unsigned char
 
 PN_HANDLE(PN_DELIVERY_CTX);
 
-ALLOC_DEFINE_CONFIG(qd_message_t, sizeof(qd_message_pvt_t), 0, 0);
-ALLOC_DEFINE(qd_message_content_t);
+ALLOC_DEFINE_CONFIG(qd_message_t, sizeof(qd_message_pvt_t), 0, 0)
+ALLOC_DEFINE(qd_message_content_t)
 
 typedef void (*buffer_process_t) (void *context, const unsigned char *base, int length);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -35,7 +35,7 @@ struct qd_parsed_field_t {
 };
 
 ALLOC_DECLARE(qd_parsed_field_t);
-ALLOC_DEFINE(qd_parsed_field_t);
+ALLOC_DEFINE(qd_parsed_field_t)
 
 /**
  * size = the number of bytes following the tag

--- a/src/posix/driver.c
+++ b/src/posix/driver.c
@@ -133,10 +133,10 @@ struct qdpn_connector_t {
 };
 
 ALLOC_DECLARE(qdpn_listener_t);
-ALLOC_DEFINE(qdpn_listener_t);
+ALLOC_DEFINE(qdpn_listener_t)
 
 ALLOC_DECLARE(qdpn_connector_t);
-ALLOC_DEFINE(qdpn_connector_t);
+ALLOC_DEFINE(qdpn_connector_t)
 
 /* Impls */
 

--- a/src/router_core/agent.c
+++ b/src/router_core/agent.c
@@ -34,7 +34,7 @@ static void qdr_manage_delete_CT(qdr_core_t *core, qdr_action_t *action, bool di
 static void qdr_manage_update_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 
 ALLOC_DECLARE(qdr_query_t);
-ALLOC_DEFINE(qdr_query_t);
+ALLOC_DEFINE(qdr_query_t)
 
 //==================================================================================
 // Internal Functions

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -30,8 +30,8 @@ static void qdr_link_inbound_first_attach_CT(qdr_core_t *core, qdr_action_t *act
 static void qdr_link_inbound_second_attach_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 static void qdr_link_inbound_detach_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 
-ALLOC_DEFINE(qdr_connection_t);
-ALLOC_DEFINE(qdr_connection_work_t);
+ALLOC_DEFINE(qdr_connection_t)
+ALLOC_DEFINE(qdr_connection_work_t)
 
 //==================================================================================
 // Internal Functions

--- a/src/router_core/error.c
+++ b/src/router_core/error.c
@@ -27,7 +27,7 @@ struct qdr_error_t {
 };
 
 ALLOC_DECLARE(qdr_error_t);
-ALLOC_DEFINE(qdr_error_t);
+ALLOC_DEFINE(qdr_error_t)
 
 qdr_error_t *qdr_error_from_pn(pn_condition_t *pn)
 {

--- a/src/router_core/management_agent.c
+++ b/src/router_core/management_agent.c
@@ -85,7 +85,7 @@ typedef struct qd_management_context_t {
 } qd_management_context_t ;
 
 ALLOC_DECLARE(qd_management_context_t);
-ALLOC_DEFINE(qd_management_context_t);
+ALLOC_DEFINE(qd_management_context_t)
 
 /**
  * Convenience function to create and initialize context (qd_management_context_t)

--- a/src/router_core/route_control.c
+++ b/src/router_core/route_control.c
@@ -22,9 +22,9 @@
 #include <stdio.h>
 #include <qpid/dispatch/iterator.h>
 
-ALLOC_DEFINE(qdr_link_route_t);
-ALLOC_DEFINE(qdr_auto_link_t);
-ALLOC_DEFINE(qdr_conn_identifier_t);
+ALLOC_DEFINE(qdr_link_route_t)
+ALLOC_DEFINE(qdr_auto_link_t)
+ALLOC_DEFINE(qdr_conn_identifier_t)
 
 const char CONTAINER_PREFIX = 'C';
 const char CONNECTION_PREFIX = 'L';

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -21,17 +21,17 @@
 #include <stdio.h>
 #include <strings.h>
 
-ALLOC_DEFINE(qdr_address_t);
-ALLOC_DEFINE(qdr_address_config_t);
-ALLOC_DEFINE(qdr_node_t);
-ALLOC_DEFINE(qdr_delivery_t);
-ALLOC_DEFINE(qdr_delivery_ref_t);
-ALLOC_DEFINE(qdr_link_t);
-ALLOC_DEFINE(qdr_router_ref_t);
-ALLOC_DEFINE(qdr_link_ref_t);
-ALLOC_DEFINE(qdr_general_work_t);
-ALLOC_DEFINE(qdr_connection_ref_t);
-ALLOC_DEFINE(qdr_connection_info_t);
+ALLOC_DEFINE(qdr_address_t)
+ALLOC_DEFINE(qdr_address_config_t)
+ALLOC_DEFINE(qdr_node_t)
+ALLOC_DEFINE(qdr_delivery_t)
+ALLOC_DEFINE(qdr_delivery_ref_t)
+ALLOC_DEFINE(qdr_link_t)
+ALLOC_DEFINE(qdr_router_ref_t)
+ALLOC_DEFINE(qdr_link_ref_t)
+ALLOC_DEFINE(qdr_general_work_t)
+ALLOC_DEFINE(qdr_connection_ref_t)
+ALLOC_DEFINE(qdr_connection_info_t)
 
 static void qdr_general_handler(void *context);
 
@@ -155,7 +155,7 @@ void qdr_router_node_free(qdr_core_t *core, qdr_node_t *rnode)
 }
 
 ALLOC_DECLARE(qdr_field_t);
-ALLOC_DEFINE(qdr_field_t);
+ALLOC_DEFINE(qdr_field_t)
 
 qdr_field_t *qdr_field(const char *text)
 {

--- a/src/router_core/router_core_thread.c
+++ b/src/router_core/router_core_thread.c
@@ -27,7 +27,7 @@
  * This module owns, manages, and uses the router-link list and the address hash table
  */
 
-ALLOC_DEFINE(qdr_action_t);
+ALLOC_DEFINE(qdr_action_t)
 
 
 static void qdr_activate_connections_CT(qdr_core_t *core)

--- a/src/router_core/terminus.c
+++ b/src/router_core/terminus.c
@@ -35,7 +35,7 @@ struct qdr_terminus_t {
 };
 
 ALLOC_DECLARE(qdr_terminus_t);
-ALLOC_DEFINE(qdr_terminus_t);
+ALLOC_DEFINE(qdr_terminus_t)
 
 const char* QDR_COORDINATOR_ADDRESS = "$coordinator";
 

--- a/src/server.c
+++ b/src/server.c
@@ -121,11 +121,11 @@ static __thread qd_server_t *thread_server = 0;
 
 #define HEARTBEAT_INTERVAL 1000
 
-ALLOC_DEFINE(qd_work_item_t);
-ALLOC_DEFINE(qd_listener_t);
-ALLOC_DEFINE(qd_connector_t);
-ALLOC_DEFINE(qd_deferred_call_t);
-ALLOC_DEFINE(qd_connection_t);
+ALLOC_DEFINE(qd_work_item_t)
+ALLOC_DEFINE(qd_listener_t)
+ALLOC_DEFINE(qd_connector_t)
+ALLOC_DEFINE(qd_deferred_call_t)
+ALLOC_DEFINE(qd_connection_t)
 
 const char *QD_CONNECTION_TYPE = "connection";
 const char *MECH_EXTERNAL = "EXTERNAL";

--- a/src/timer.c
+++ b/src/timer.c
@@ -32,7 +32,7 @@ static qd_timer_list_t  scheduled_timers;
 static qd_timestamp_t   time_base;
 
 ALLOC_DECLARE(qd_timer_t);
-ALLOC_DEFINE(qd_timer_t);
+ALLOC_DEFINE(qd_timer_t)
 
 /// For tests only
 sys_mutex_t* qd_timer_lock() { return lock; }

--- a/src/trace_mask.c
+++ b/src/trace_mask.c
@@ -30,7 +30,7 @@ typedef struct {
 } qdtm_router_t;
 
 ALLOC_DECLARE(qdtm_router_t);
-ALLOC_DEFINE(qdtm_router_t);
+ALLOC_DEFINE(qdtm_router_t)
 
 struct qd_tracemask_t {
     sys_rwlock_t   *lock;

--- a/tests/alloc_test.c
+++ b/tests/alloc_test.c
@@ -30,7 +30,7 @@ typedef struct {
 qd_alloc_config_t config = {3, 7, 10};
 
 ALLOC_DECLARE(object_t);
-ALLOC_DEFINE_CONFIG(object_t, sizeof(object_t), 0, &config);
+ALLOC_DEFINE_CONFIG(object_t, sizeof(object_t), 0, &config)
 
 
 static char* check_stats(qd_alloc_stats_t *stats, uint64_t ah, uint64_t fh, uint64_t ht, uint64_t rt, uint64_t rg)


### PR DESCRIPTION
…This is causing compilation errors in Solaris