### PR TITLE
DISPATCH-749 - unmap_all_addresses unmaps just half of addresses

### DIFF
--- a/python/qpid_dispatch_internal/router/node.py
+++ b/python/qpid_dispatch_internal/router/node.py
@@ -533,8 +533,8 @@ class RouterNode(object):
 
     def unmap_all_addresses(self):
         self.mobile_address_sequence = 0
-        for addr in self.mobile_addresses:
-            self.unmap_address(addr)
+        while self.mobile_addresses:
+            self.unmap_address(self.mobile_addresses[0])
 
 
     def overwrite_addresses(self, addrs):


### PR DESCRIPTION
iterating over a list being updated needs deep copy of the list

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>