### PR TITLE
DISPATCH-209 -- revamp of second three-router test.

### DIFF
--- a/tests/system_tests_three_routers.py
+++ b/tests/system_tests_three_routers.py
@@ -39,56 +39,113 @@ class RouterTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Start a router and a messenger"""
+        """Start a router and a sender-listener client"""
         super(RouterTest, cls).setUpClass()
 
-        def router(name, connection_1, connection_2=None):
+        def router ( name, connection_1, connection_2=None ):
 
             config = [
-                ('router', {'mode': 'interior', 'id': 'QDR.%s'%name}),
-
-                ('listener', {'port': cls.tester.get_port(), 'stripAnnotations': 'no'}),
-
-                ('address', {'prefix': 'closest',   'distribution': 'closest'}),
-                ('address', {'prefix': 'spread',    'distribution': 'balanced'}),
-                ('address', {'prefix': 'multicast', 'distribution': 'multicast'})
+                ('router',
+                  {'mode' : 'interior',
+                   'id'   : 'QDR.%s' % name
+                  }
+                ),
+                ('listener',
+                  {'port'             : cls.tester.get_port(),
+                   'stripAnnotations' : 'no'
+                  }
+                ),
+                ('address',
+                    { 'prefix'       : 'closest',
+                      'distribution' : 'closest'
+                    }
+                ),
             ]
-            config.append(connection_1)
+            config.append ( connection_1 )
             if None != connection_2:
-                config.append(connection_2)
+                config.append ( connection_2 )
 
-            config = Qdrouterd.Config(config)
+            config = Qdrouterd.Config ( config )
 
-            cls.routers.append(cls.tester.qdrouterd(name, config, wait=True))
+            cls.routers.append ( cls.tester.qdrouterd(name, config, wait=True) )
 
         cls.routers = []
 
-        inter_router_port_1 = cls.tester.get_port()
-        inter_router_port_2 = cls.tester.get_port()
-
-        #   A <--- B <--- C
-        router('A', ('listener', {'role': 'inter-router', 'port': inter_router_port_1}) )
-
-        router('B', ('listener', {'role': 'inter-router', 'port': inter_router_port_2}),
-                    ('connector', {'name': 'connectorToA', 'role': 'inter-router', 'port': inter_router_port_1, 'verifyHostName': 'no'}))
-
-        router('C', ('connector', {'name': 'connectorToB', 'role': 'inter-router', 'port': inter_router_port_2, 'verifyHostName': 'no'}))
-
-        cls.routers[0].wait_router_connected('QDR.C')
-        cls.routers[1].wait_router_connected('QDR.B')
-        cls.routers[2].wait_router_connected('QDR.A')
+        inter_router_port_A = cls.tester.get_port()
+        inter_router_port_B = cls.tester.get_port()
+        port_for_sender     = cls.tester.get_port()
 
 
+        #   receiver <--- A <--- B <--- C <--- sender
+        router ( 'A',
+                   ( 'listener',
+                       {'role': 'inter-router',
+                        'port': inter_router_port_A
+                       }
+                   )
+               )
 
+        router ( 'B',
+                   ( 'listener',
+                       { 'role': 'inter-router',
+                         'port': inter_router_port_B
+                       }
+                   ),
+                   ( 'connector',
+                       { 'name': 'connectorToA',
+                         'role': 'inter-router',
+                         'port': inter_router_port_A,
+                         'verifyHostName': 'no'
+                       }
+                   )
+               )
+
+        router ( 'C',
+                   ( 'connector',
+                       { 'name': 'connectorToB',
+                         'role': 'inter-router',
+                         'port': inter_router_port_B,
+                         'verifyHostName': 'no'
+                       }
+                   ),
+                   ( 'listener',
+                       { 'role': 'normal',
+                         'port': port_for_sender
+                       }
+                   )
+               )
+
+
+        cls.router_A = cls.routers[0]
+        cls.router_B = cls.routers[1]
+        cls.router_C = cls.routers[2]
+
+        #----------------------------------------------
+        # Wait until everybody can see everybody,
+        # to minimize the time when the network
+        # doesn't know how to route my messages.
+        #----------------------------------------------
+        cls.router_C.wait_router_connected('QDR.B')
+        cls.router_B.wait_router_connected('QDR.A')
+        cls.router_A.wait_router_connected('QDR.C')
+
+        cls.send_addr = cls.router_C.addresses[1]
+        cls.recv_addr = cls.router_A.addresses[0]
+
+
+    #------------------------------------------------
+    # In these tests, first address will be used
+    # by the sender, second by the receiver.
+    #------------------------------------------------
     def test_01_targeted_sender(self):
-        test = TargetedSenderTest(self.routers[0].addresses[0], self.routers[2].addresses[0])
+        test = TargetedSenderTest ( self.send_addr, self.recv_addr )
         test.run()
         self.assertEqual(None, test.error)
 
-#    def test_02_anonymous_sender(self):
-#        test = AnonymousSenderTest(self.routers[0].addresses[0], self.routers[2].addresses[0])
-#        test.run()
-#        self.assertEqual(None, test.error)
+    def test_02_anonymous_sender(self):
+        test = AnonymousSenderTest ( self.send_addr, self.recv_addr )
+        test.run()
+        self.assertEqual(None, test.error)
 
 
 class Timeout(object):
@@ -119,7 +176,6 @@ class TargetedSenderTest(MessagingHandler):
         self.conn2.close()
 
     def on_start(self, event):
-        # receiver <--- A <--- B <---- C <--- sender
         self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
         self.conn1 = event.container.connect(self.address1)
         self.conn2 = event.container.connect(self.address2)
@@ -127,11 +183,16 @@ class TargetedSenderTest(MessagingHandler):
         self.receiver = event.container.create_receiver(self.conn2, self.dest)
         self.receiver.flow(self.n_expected)
 
+
+    def send(self):
+      while self.sender.credit > 0 and self.n_sent < self.n_expected:
+        msg = Message(body=self.n_sent)
+        self.sender.send(msg)
+        self.n_sent += 1
+
     def on_sendable(self, event):
         if self.n_sent < self.n_expected:
-            msg = Message(body=self.n_sent)
-            event.sender.send(msg)
-            self.n_sent += 1
+            self.send()
 
     def on_accepted(self, event):
         self.n_accepted += 1
@@ -148,7 +209,6 @@ class TargetedSenderTest(MessagingHandler):
         Container(self).run()
 
 
-
 class AnonymousSenderTest(MessagingHandler):
     def __init__(self, address1, address2):
         super(AnonymousSenderTest, self).__init__(prefetch=0)
@@ -160,8 +220,10 @@ class AnonymousSenderTest(MessagingHandler):
         self.receiver   = None
         self.n_expected = 10
         self.n_sent     = 0
+        self.n_released = 0
         self.n_received = 0
         self.n_accepted = 0
+        self.not_ready  = 0
 
     def timeout(self):
         self.error = "Timeout Expired %d messages received." % self.n_received
@@ -178,9 +240,17 @@ class AnonymousSenderTest(MessagingHandler):
     # the sent message counter, forcing a resend for each drop.
     # And also pause for a moment, since we know that the network is
     # not yet ready.
-    def on_released(self, event):
+    # If we still get some released messages, the routers are not ready
+    # yet -- but the one we are connected to will still cheerfully send
+    # us credit, and we will still get sendable events.  Don't keep
+    # sending batches of messages that get released.  It is possible to
+    # keep things so busy that the network doesn't get ready before our
+    # timeout, and we fail.  Mark the net as not ready, and then impose a
+    # delay when we get the next 'sendable' event.
+    def on_released ( self, event ):
+        self.n_released += 1
         self.n_sent -= 1
-        time.sleep(0.1)
+        self.not_ready = 1
 
     def on_link_opened(self, event):
         if event.receiver:
@@ -191,6 +261,7 @@ class AnonymousSenderTest(MessagingHandler):
             # close to being able to send.  (See comment above.)
             self.sender = event.container.create_sender(self.conn1, None)
 
+
     def on_start(self, event):
         self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
         self.conn1 = event.container.connect(self.address1)
@@ -198,12 +269,25 @@ class AnonymousSenderTest(MessagingHandler):
         self.receiver = event.container.create_receiver(self.conn2, self.dest)
         self.receiver.flow(self.n_expected)
 
-    def on_sendable(self, event):
-        if self.n_sent < self.n_expected:
-            # Add the destination addr to each message.
+    def send(self):
+        while self.sender.credit > 0 and self.n_sent < self.n_expected:
             msg = Message(body=self.n_sent, address=self.dest)
-            event.sender.send(msg)
+            self.sender.send(msg)
             self.n_sent += 1
+        # Another very rare failure mode is to keep sending so fast that we
+        # never get the accept events, and timeout.  So -- pause a bit after
+        # we have sent all messages.
+        if self.n_sent >= self.n_expected:
+            time.sleep(1.0)
+
+    def on_sendable(self, event):
+        if event.sender == self.sender:
+            # Here is where we impose the delay, waiting for the network to
+            # get ready, if we have recently had some messages released.
+            if self.not_ready:
+                time.sleep(1.0)
+                self.not_ready = 0
+            self.send()
 
     def on_accepted(self, event):
         self.n_accepted += 1
@@ -211,10 +295,10 @@ class AnonymousSenderTest(MessagingHandler):
     def on_message(self, event):
         self.n_received += 1
         if self.n_received == self.n_expected:
-            self.receiver.close()
-            self.conn1.close()
-            self.conn2.close()
-            self.timer.cancel()
+          self.receiver.close()
+          self.conn1.close()
+          self.conn2.close()
+          self.timer.cancel()
 
     def run(self):
         Container(self).run()


### PR DESCRIPTION
This new version of three-router test #2 survived a 1000-iteration test with no failures.

The main changes are

  1. handle on_sendable event and the sending of messages better.  (Before I was only sending 1 message per on_sendable event, instead of sending until credit exhausteed.)

  2. indirectly detect when the network is not yet ready for me to send (in spite of on_sendable event) and pause for 1 second to allow it to propagate endpoint info everywhere.