### PR TITLE
DISPATCH-780 - Send amqp:unauthorized-access when link is disallowed because of target / source name

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -596,7 +596,7 @@ bool qd_policy_approve_amqp_sender_link(pn_link_t *pn_link, qd_connection_t *qd_
             (lookup ? "ALLOW" : "DENY"), target, qd_conn->user_id, hostip, vhost);
 
         if (!lookup) {
-            _qd_policy_deny_amqp_receiver_link(pn_link, qd_conn);
+            _qd_policy_deny_amqp_sender_link(pn_link, qd_conn);
             return false;
         }
     } else {
@@ -607,7 +607,7 @@ bool qd_policy_approve_amqp_sender_link(pn_link_t *pn_link, qd_connection_t *qd_
             "%s AMQP Attach anonymous sender for user '%s', rhost '%s', vhost '%s'",
             (lookup ? "ALLOW" : "DENY"), qd_conn->user_id, hostip, vhost);
         if (!lookup) {
-            _qd_policy_deny_amqp_receiver_link(pn_link, qd_conn);
+            _qd_policy_deny_amqp_sender_link(pn_link, qd_conn);
             return false;
         }
     }

--- a/src/policy_internal.h
+++ b/src/policy_internal.h
@@ -46,26 +46,27 @@ void qd_policy_deny_amqp_session(pn_session_t *ssn, qd_connection_t *qd_conn);
  * The link is closed and the denial is logged but not counted.
  * @param[in] link proton link being closed
  * @param[in] qd_conn the qd conection
+ * @param[in] condition the AMQP error with which to close the link
  */ 
-void _qd_policy_deny_amqp_link(pn_link_t *link, qd_connection_t *qd_conn);
+void _qd_policy_deny_amqp_link(pn_link_t *link, qd_connection_t *qd_conn, const char *condition);
 
 
 /** Internal function to deny a sender amqp link
  * The link is closed and the denial is logged but not counted.
  * @param[in] link proton link to close
  * @param[in] qd_conn the qd conection
- * @param[in] s_or_r 'sender' or 'receiver' for logging
+ * @param[in] condition the AMQP error with which to close the link
  */ 
-void _qd_policy_deny_amqp_sender_link(pn_link_t *pn_link, qd_connection_t *qd_conn);
+void _qd_policy_deny_amqp_sender_link(pn_link_t *pn_link, qd_connection_t *qd_conn, const char *condition);
 
 
 /** Internal function to deny a receiver amqp link
  * The link is closed and the denial is logged but not counted.
  * @param[in] link proton link to close
  * @param[in] qd_conn the qd conection
- * @param[in] s_or_r 'sender' or 'receiver' for logging
+ * @param[in] condition the AMQP error with which to close the link
  */ 
-void _qd_policy_deny_amqp_receiver_link(pn_link_t *pn_link, qd_connection_t *qd_conn);
+void _qd_policy_deny_amqp_receiver_link(pn_link_t *pn_link, qd_connection_t *qd_conn, const char *condition);
 
 
 /** Perform user name substitution into proposed link name.


### PR DESCRIPTION
Added a new parameter to methods `_qd_policy_deny_amqp_link`, `_qd_policy_deny_amqp_sender_link` and `_qd_policy_deny_amqp_receiver_link`. 

This allows to pass the correct error condition from `qd_policy_approve_amqp_sender_link` or  `qd_policy_approve_amqp_receiver_link` and send it to thew client when the link is closed.