### PR TITLE
crolke dev annotations - work in progress PR for review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ include_directories(
     )
 
 if (NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
- add_compile_options(-Werror)
+ #add_compile_options(-Werror)
  add_compile_options(-Wall)
  include(CheckCCompilerFlag)
  check_c_compiler_flag(-Wpedantic HAS_PEDANTIC_FLAG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ include_directories(
     )
 
 if (NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
- #add_compile_options(-Werror)
+ add_compile_options(-Werror)
  add_compile_options(-Wall)
  include(CheckCCompilerFlag)
  check_c_compiler_flag(-Wpedantic HAS_PEDANTIC_FLAG)

--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -112,6 +112,7 @@ extern const char * const QD_MA_TRACE;    ///< Trace
 extern const char * const QD_MA_TO;       ///< To-Override
 extern const char * const QD_MA_PHASE;    ///< Phase for override address
 extern const char * const QD_MA_CLASS;    ///< Message-Class
+extern const char * const QD_MA_ANNOTATIONS; ///< v2 annotation map key
 /// @}
 
 /** @name Container Capabilities */

--- a/include/qpid/dispatch/compose.h
+++ b/include/qpid/dispatch/compose.h
@@ -249,12 +249,18 @@ void qd_compose_insert_buffers(qd_composed_field_t *field, qd_buffer_list_t *lis
 void qd_compose_insert_buffers_or_null(qd_composed_field_t *field, qd_buffer_list_t *list);
 
 /**
- * Insert a raw buffer chain's contents into a map.
- * Bump map element count by given size.
+ * Administratively insert a raw buffer chain's contents into a map.
+ * Bump map element count and size in bytes to reflect opaque that caller will insert later.
+ * 
+ * Note the the bytes are never actually copied into the composed field.
+ * 
+ * @param field A field created by qd_compose().
+ * @param count The number of map elements in the buffer chain.
+ * @param size The number of bytes in the buffer chain
  */
-void qd_compose_insert_opaque_elements(qd_composed_field_t   *field,
-                                       uint32_t               count,
-                                       qd_iterator_pointer_t *raw_ptr);
+void qd_compose_insert_opaque_elements(qd_composed_field_t *field,
+                                       uint32_t             count,
+                                       uint32_t             size);
 
 ///@}
 

--- a/include/qpid/dispatch/compose.h
+++ b/include/qpid/dispatch/compose.h
@@ -237,6 +237,25 @@ void qd_compose_take_buffers(qd_composed_field_t *field,
  */
 void qd_compose_insert_buffers(qd_composed_field_t *field, qd_buffer_list_t *list);
 
+/**
+ * Append a buffer list into a composed field.  If field is a container type
+ * (list, map), the container's count will be incremented by one.
+ * If the buffer list is empty then insert a null.
+ *
+ * @param field A field created by ::qd_compose().
+ * @param list A list of buffers containing a single completely encoded data
+ * object.  Ownership of these buffers is given to field.
+ */
+void qd_compose_insert_buffers_or_null(qd_composed_field_t *field, qd_buffer_list_t *list);
+
+/**
+ * Insert a raw buffer chain's contents into a map.
+ * Bump map element count by given size.
+ */
+void qd_compose_insert_opaque_elements(qd_composed_field_t   *field,
+                                       uint32_t               count,
+                                       qd_iterator_pointer_t *raw_ptr);
+
 ///@}
 
 #endif

--- a/include/qpid/dispatch/iterator.h
+++ b/include/qpid/dispatch/iterator.h
@@ -105,6 +105,18 @@ typedef enum {
     ITER_VIEW_ADDRESS_WITH_SPACE
 } qd_iterator_view_t;
 
+
+/**
+ * qd_iterator_pointer_t
+ * 
+ * Pointer type identifies arbitrary data in a buffer list.
+ */
+typedef struct {
+    qd_buffer_t   *buffer;
+    unsigned char *cursor;
+    int            remaining;
+} qd_iterator_pointer_t;
+
 /** @} */
 /** \name global
  * Global Methods
@@ -398,6 +410,19 @@ void qd_iterator_hash_view_segments(qd_iterator_t *iter);
  * @return True iff there is another segment hash to be compared
  */
 bool qd_iterator_next_segment(qd_iterator_t *iter, uint32_t *hash);
+
+/**
+ * Return the parsed field's cursor position in the raw iter
+ * view pointer buffer chain. This is used to copy opaque 
+ * contents out of a buffer chain.
+ * 
+ * @param field Parsed iter that has been partially parsed and still has data in its view.
+ * @param ptr Caller's pointer object which is to receive cursor position
+ * @return none
+ */
+void qd_iterator_get_view_cursor(
+    const qd_iterator_t *iter,
+    qd_iterator_pointer_t *ptr);
 
 /** @} */
 /** @} */

--- a/include/qpid/dispatch/iterator.h
+++ b/include/qpid/dispatch/iterator.h
@@ -424,6 +424,14 @@ void qd_iterator_get_view_cursor(
     const qd_iterator_t *iter,
     qd_iterator_pointer_t *ptr);
 
+/**
+ * Return iterator's raw size
+ * 
+ * @param iter A field iterator
+ * @return the start.pointer.size
+ */
+int qd_iterator_get_raw_size(const qd_iterator_t *iter);
+
 /** @} */
 /** @} */
 

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -145,6 +145,21 @@ qd_message_t *qd_message_copy(qd_message_t *msg);
 qd_parsed_field_t *qd_message_message_annotations(qd_message_t *msg);
 
 /**
+ * Retrieve the message annotations from a message.
+ *
+ * IMPORTANT: The pointer returned by this function remains owned by the message.
+ *            The caller MUST NOT free the parsed field.
+ * 
+ * The v1 scheme returned the map object that had all the annotations. This
+ * v2 scheme returns only the map value element, a list, that has all router values
+ *
+ * @param msg Pointer to a received message.
+ * @return Pointer to the parsed field for the message annotations.  If the message doesn't
+ *         have message annotations, the return value shall be NULL.
+ */
+qd_parsed_field_t *qd_message_v2_annotations(qd_message_t *msg);
+
+/**
  * Set the value for the QD_MA_TRACE field in the outgoing message annotations
  * for the message.
  *

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -313,6 +313,22 @@ qd_parsed_field_t *qd_message_get_trace      (qd_message_t *msg);
  */
 int                qd_message_get_phase_val  (qd_message_t *msg);
 
+/**
+ * Set annotation scheme of received message with annotation scheme used by remote peer
+ * 
+ * @param msg A pointer to the message
+ * @param annotation_v1 true if remote host sent messages with v1 annotation scheme
+ */
+void               qd_message_set_annotation_scheme  (qd_message_t *msg, bool annotation_v1);
+
+/**
+ * Get annotation scheme used by remote peer when message was created
+ * 
+ * @param msg A pointer to the message
+ * @return true if v1 scheme was used
+ */
+bool               qd_message_get_annotation_scheme  (const qd_message_t *msg);
+
 ///@}
 
 #endif

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -273,11 +273,44 @@ int qd_message_repr_len();
 
 qd_log_source_t* qd_message_log_source();
 
-
+/**
+ * Accessor for message field ingress
+ * 
+ * @param msg A pointer to the message
+ * @return the parsed field
+ */
 qd_parsed_field_t *qd_message_get_ingress    (qd_message_t *msg);
+
+/**
+ * Accessor for message field phase
+ * 
+ * @param msg A pointer to the message
+ * @return the parsed field
+ */
 qd_parsed_field_t *qd_message_get_phase      (qd_message_t *msg);
+
+/**
+ * Accessor for message field to_override
+ * 
+ * @param msg A pointer to the message
+ * @return the parsed field
+ */
 qd_parsed_field_t *qd_message_get_to_override(qd_message_t *msg);
+
+/**
+ * Accessor for message field trace
+ * 
+ * @param msg A pointer to the message
+ * @return the parsed field
+ */
 qd_parsed_field_t *qd_message_get_trace      (qd_message_t *msg);
+
+/**
+ * Accessor for message field phase
+ * 
+ * @param msg A pointer to the message
+ * @return the phase as an integer
+ */
 int                qd_message_get_phase_val  (qd_message_t *msg);
 
 ///@}

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -273,6 +273,13 @@ int qd_message_repr_len();
 
 qd_log_source_t* qd_message_log_source();
 
+
+qd_parsed_field_t *qd_message_get_ingress    (qd_message_t *msg);
+qd_parsed_field_t *qd_message_get_phase      (qd_message_t *msg);
+qd_parsed_field_t *qd_message_get_to_override(qd_message_t *msg);
+qd_parsed_field_t *qd_message_get_trace      (qd_message_t *msg);
+int                qd_message_get_phase_val  (qd_message_t *msg);
+
 ///@}
 
 #endif

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -107,6 +107,14 @@ typedef enum {
     QD_FIELD_REPLY_TO_GROUP_ID
 } qd_message_field_t;
 
+/** Annotation schemes used by remote connection peers */
+typedef enum {
+    QD_ANNO_SCHEME_NONE,
+    QD_ANNO_SCHEME_V1,
+    QD_ANNO_SCHEME_V2
+} qd_message_annotation_scheme_t;
+
+
 
 /**
  * Allocate a new message.
@@ -133,31 +141,14 @@ void qd_message_free(qd_message_t *msg);
 qd_message_t *qd_message_copy(qd_message_t *msg);
 
 /**
- * Retrieve the message annotations from a message.
+ * Retrieve the message annotations from a message and place them in message storage.
  *
  * IMPORTANT: The pointer returned by this function remains owned by the message.
  *            The caller MUST NOT free the parsed field.
  *
  * @param msg Pointer to a received message.
- * @return Pointer to the parsed field for the message annotations.  If the message doesn't
- *         have message annotations, the return value shall be NULL.
  */
-qd_parsed_field_t *qd_message_message_annotations(qd_message_t *msg);
-
-/**
- * Retrieve the message annotations from a message.
- *
- * IMPORTANT: The pointer returned by this function remains owned by the message.
- *            The caller MUST NOT free the parsed field.
- * 
- * The v1 scheme returned the map object that had all the annotations. This
- * v2 scheme returns only the map value element, a list, that has all router values
- *
- * @param msg Pointer to a received message.
- * @return Pointer to the parsed field for the message annotations.  If the message doesn't
- *         have message annotations, the return value shall be NULL.
- */
-qd_parsed_field_t *qd_message_v2_annotations(qd_message_t *msg);
+void qd_message_message_annotations(qd_message_t *msg);
 
 /**
  * Set the value for the QD_MA_TRACE field in the outgoing message annotations
@@ -260,7 +251,7 @@ ssize_t qd_message_field_copy(qd_message_t *msg, qd_message_field_t field, char 
 //
 
 // Convenience Functions
-void qd_message_compose_1(qd_message_t *msg, const char *to, qd_buffer_list_t *buffers);
+void qd_message_compose_1(qd_message_t *msg, const char *to, qd_buffer_list_t *buffers, int hello_version);
 void qd_message_compose_2(qd_message_t *msg, qd_composed_field_t *content);
 void qd_message_compose_3(qd_message_t *msg, qd_composed_field_t *content1, qd_composed_field_t *content2);
 
@@ -314,20 +305,27 @@ qd_parsed_field_t *qd_message_get_trace      (qd_message_t *msg);
 int                qd_message_get_phase_val  (qd_message_t *msg);
 
 /**
- * Set annotation scheme of received message with annotation scheme used by remote peer
+ * Translate a remote hello protocol version number into which annotation scheme to use
  * 
- * @param msg A pointer to the message
- * @param annotation_v1 true if remote host sent messages with v1 annotation scheme
+ * @param hello_version The remote version
+ * @return which scheme to use
  */
-void               qd_message_set_annotation_scheme  (qd_message_t *msg, bool annotation_v1);
+qd_message_annotation_scheme_t qd_message_hello_ver_to_annotation_scheme  (int hello_version);
 
 /**
- * Get annotation scheme used by remote peer when message was created
- * 
- * @param msg A pointer to the message
- * @return true if v1 scheme was used
+ * Return annotation scheme for a received message
+ * @param msg the incoming qd_message_t * qd_message()
+ * @return the scheme that the remote router used to encode the annotations
  */
-bool               qd_message_get_annotation_scheme  (const qd_message_t *msg);
+qd_message_annotation_scheme_t qd_message_get_annotation_scheme (const qd_message_t *msg);
+
+/**
+ * Force the message's incoming hello protocol version for locally-generated test messages
+ * @param msg the message
+ * @param version the hello protocol version
+ */
+void qd_message_set_hello_version (qd_message_t *msg, int version);
+
 
 ///@}
 

--- a/include/qpid/dispatch/parse.h
+++ b/include/qpid/dispatch/parse.h
@@ -262,6 +262,18 @@ const char* qd_parse_v2_annotations(
     uint32_t           *count,
     qd_parsed_field_t **v2);
 
+/**
+ * Return the parsed field's cursor position in the raw iter
+ * view pointer buffer chain. This is used to copy opaque 
+ * contents out of a buffer chain.
+ * 
+ * @param field Parsed field that has been partially parsed and still has data in its raw_iter view.
+ * @param ptr Caller's pointer object which is to receive cursor position
+ */
+void qd_parse_get_view_cursor(
+    const qd_parsed_field_t *field,
+    qd_iterator_pointer_t *ptr);
+
 ///@}
 
 #endif

--- a/include/qpid/dispatch/parse.h
+++ b/include/qpid/dispatch/parse.h
@@ -229,7 +229,39 @@ int qd_parse_is_scalar(qd_parsed_field_t *field);
  */
 qd_parsed_field_t *qd_parse_value_by_key(qd_parsed_field_t *field, const char *key);
 
+/**
+ * Parse a message annotation map field delimited by a field iterator.
+ * Compare the first key in the map and if it matches then return the
+ * child iterator for the first value in the map.
+ *
+ * The incoming iter is only parsed to move beyond the first key/value pair in
+ * the message annotation map. The raw_iter iterator identifies the remainder of
+ * the annotations.
+ * 
+ * * If there is a key match then the value is returned. The raw_iter addresses
+ *   the map field beyond the key value pair. The returned count is two less than
+ *   the incoming map had at the start.
+ * * If there is no key match then no value is returned. The raw_iter is reset
+ *   and addresses the whole original map. The returned count is equal to the size
+ *   of the incoming map.
+ * 
+ * IMPORTANT: The returned iterator is owned by the field and *must not* be
+ * freed by the caller of this function.
+ *
+ * @param ma_iter_in Field iterator for the annotation map field being parsed.
+ * @param key_name Key name for first map entry
+ * @param all_annotations Parsed field structure that was iterated to find the v2 data
+ * @param count Number of AMQP map entries in all_annotations->raw_iter after the v2 values have been extracted
+ * @param v2_anno Parsed field for the v2 annotation data
+ * @return error string pointer. null if no error
+ */
+const char* qd_parse_v2_annotations(
+    qd_iterator_t      *ma_iter_in,
+    const char         *key_name,
+    qd_parsed_field_t **all_annotations,
+    uint32_t           *count,
+    qd_parsed_field_t **v2);
+
 ///@}
 
 #endif
-

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -525,9 +525,15 @@ const char* qd_connection_name(const qd_connection_t *c);
 
 
 /**
+
  * Get the remote host IP address of the connection.
  */
 const char* qd_connection_remote_ip(const qd_connection_t *c);
+
+/**
+ * Does this connection source messages using v1 annotation scheme?
+ */
+bool qd_connection_uses_v1_annotations(const qd_connection_t *c);
 
 /**
  * @}

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -531,9 +531,9 @@ const char* qd_connection_name(const qd_connection_t *c);
 const char* qd_connection_remote_ip(const qd_connection_t *c);
 
 /**
- * Does this connection source messages using v1 annotation scheme?
+ * Get the hello protocol version used by the remote router on this connection
  */
-bool qd_connection_uses_v1_annotations(const qd_connection_t *c);
+int qd_connection_hello_protocol_version(const qd_connection_t *c);
 
 /**
  * @}

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -28,7 +28,7 @@ const char * const QD_MA_TRACE   = "x-opt-qd.trace";
 const char * const QD_MA_TO      = "x-opt-qd.to";
 const char * const QD_MA_PHASE   = "x-opt-qd.phase";
 const char * const QD_MA_CLASS   = "x-opt-qd.class";
-const char * const QD_MA_ANNOTATIONS = "x-opt-qd.annotations";
+const char * const QD_MA_ANNOTATIONS = "x-opt-qd2.annotations";
 
 const char * const QD_CAPABILITY_ROUTER_CONTROL  = "qd.router";
 const char * const QD_CAPABILITY_ROUTER_DATA     = "qd.router-data";

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -28,6 +28,7 @@ const char * const QD_MA_TRACE   = "x-opt-qd.trace";
 const char * const QD_MA_TO      = "x-opt-qd.to";
 const char * const QD_MA_PHASE   = "x-opt-qd.phase";
 const char * const QD_MA_CLASS   = "x-opt-qd.class";
+const char * const QD_MA_ANNOTATIONS = "x-opt-qd.annotations";
 
 const char * const QD_CAPABILITY_ROUTER_CONTROL  = "qd.router";
 const char * const QD_CAPABILITY_ROUTER_DATA     = "qd.router-data";

--- a/src/compose.c
+++ b/src/compose.c
@@ -568,7 +568,7 @@ void qd_compose_insert_opaque_elements(qd_composed_field_t   *field,
 
     while (buf_in && remaining) {
         // compute how many bytes left in current buffer and copy them
-        size_t to_copy = qd_buffer_base(buf_in) + qd_buffer_capacity(buf_in) - seq;
+        size_t to_copy = qd_buffer_base(buf_in) + qd_buffer_size(buf_in) - seq;
         if (to_copy > remaining)
             to_copy = remaining;
         if (to_copy > 0) {

--- a/src/compose.c
+++ b/src/compose.c
@@ -554,30 +554,10 @@ void qd_compose_insert_buffers_or_null(qd_composed_field_t *field,
 }
 
 
-void qd_compose_insert_opaque_elements(qd_composed_field_t   *field,
-                                       uint32_t               count,
-                                       qd_iterator_pointer_t *raw_ptr)
+void qd_compose_insert_opaque_elements(qd_composed_field_t *field,
+                                       uint32_t             count,
+                                       uint32_t             size)
 {
-    //static void qd_insert(qd_composed_field_t *field, const uint8_t *seq, size_t len)
-    qd_buffer_t *buf_in    = raw_ptr->buffer;
-    uint8_t *    seq       = raw_ptr->cursor;
-    size_t       remaining = raw_ptr->remaining;
-
-    if (buf_in == 0 || remaining == 0)
-        return;
-
-    while (buf_in && remaining) {
-        // compute how many bytes left in current buffer and copy them
-        size_t to_copy = qd_buffer_base(buf_in) + qd_buffer_size(buf_in) - seq;
-        if (to_copy > remaining)
-            to_copy = remaining;
-        if (to_copy > 0) {
-            qd_insert(field, seq, to_copy);
-            remaining -= to_copy;
-        }
-        buf_in = DEQ_NEXT(buf_in);
-        seq = qd_buffer_base(buf_in);
-    }
-    
     bump_count_by_n(field, count);
+    bump_length(field, size);
 }

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -463,6 +463,7 @@ void qd_iterator_reset_view(qd_iterator_t *iter, qd_iterator_view_t view)
 }
 
 
+
 qd_iterator_view_t qd_iterator_get_view(const qd_iterator_t *iter)
 {
     return iter ? iter->view : ITER_VIEW_ALL;

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -862,3 +862,9 @@ void qd_iterator_get_view_cursor(
     ptr->cursor    = iter->view_pointer.cursor;
     ptr->remaining = iter->view_pointer.remaining;
 }
+
+
+int qd_iterator_get_raw_size(const qd_iterator_t *iter)
+{
+    return iter->start_pointer.remaining;
+}

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -463,7 +463,6 @@ void qd_iterator_reset_view(qd_iterator_t *iter, qd_iterator_view_t view)
 }
 
 
-
 qd_iterator_view_t qd_iterator_get_view(const qd_iterator_t *iter)
 {
     return iter ? iter->view : ITER_VIEW_ALL;
@@ -852,4 +851,14 @@ bool qd_iterator_next_segment(qd_iterator_t *iter, uint32_t *hash)
     free_qd_hash_segment_t(hash_segment);
 
     return true;
+}
+
+
+void qd_iterator_get_view_cursor(
+    const qd_iterator_t *iter,
+    qd_iterator_pointer_t *ptr)
+{
+    ptr->buffer    = iter->view_pointer.buffer;
+    ptr->cursor    = iter->view_pointer.cursor;
+    ptr->remaining = iter->view_pointer.remaining;
 }

--- a/src/message.c
+++ b/src/message.c
@@ -1335,7 +1335,6 @@ void qd_message_send(qd_message_t *in_msg,
     //
     // Send delivery annotation if present
     //
-    cursor = qd_buffer_base(buf);
     if (content->section_delivery_annotation.length > 0) {
         buf    = content->section_delivery_annotation.buffer;
         cursor = content->section_delivery_annotation.offset + qd_buffer_base(buf);

--- a/src/message.c
+++ b/src/message.c
@@ -939,6 +939,38 @@ qd_parsed_field_t *qd_message_message_annotations(qd_message_t *in_msg)
 }
 
 
+qd_parsed_field_t *qd_message_v2_annotations(qd_message_t *in_msg)
+{
+    qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
+    qd_message_content_t *content = msg->content;
+
+    // caluculate the return value only once
+    if (content->ma_all_annotations)
+        return content->ma_v2;
+
+    // return 0 if annotations are absent
+    content->ma_field_iter_in = qd_message_field_iterator(in_msg, QD_FIELD_MESSAGE_ANNOTATION);
+    if (content->ma_field_iter_in == 0)
+        return 0;
+
+    const char * errorptr = qd_parse_v2_annotations(
+        content->ma_field_iter_in,
+        QD_MA_ANNOTATIONS,
+        &content->ma_all_annotations,
+        &content->ma_count,
+        &content->ma_v2);
+
+    if (errorptr)  // TBD: what now?
+        fprintf(stdout, "message.c parse error: %s\n", errorptr);
+    
+    // parsed_field ma_v2 holds the v2 annotation object
+    // ma_all_annotations->raw_iter.view_pointer {buffer, cursor, remaining} 
+    // describes the remaining annotations blob.
+    
+    return content->ma_v2;
+}
+
+
 void qd_message_set_trace_annotation(qd_message_t *in_msg, qd_composed_field_t *trace_field)
 {
     qd_message_pvt_t *msg = (qd_message_pvt_t*) in_msg;

--- a/src/message.c
+++ b/src/message.c
@@ -927,7 +927,11 @@ qd_message_t *qd_message_copy(qd_message_t *in_msg)
 
     copy->content = content;
 
-    qd_message_message_annotations((qd_message_t*) copy);
+    if (USE_ANNO_V1) {
+        (void) qd_message_message_annotations(in_msg);
+    } else {
+        (void) qd_message_v2_annotations(in_msg);
+    }
 
     sys_atomic_inc(&content->ref_count);
 
@@ -1320,6 +1324,18 @@ void qd_message_send(qd_message_t *in_msg,
     //
     // Send delivery annotation if present
     //
+    if (content->section_delivery_annotation.length > 0) {
+        buf    = content->section_delivery_annotation.buffer;
+        cursor = content->section_delivery_annotation.offset + qd_buffer_base(buf);
+        advance(&cursor, &buf,
+                content->section_delivery_annotation.length + content->section_delivery_annotation.hdr_length,
+                send_handler, (void*) pnl);
+    }
+
+    //
+    // Send delivery annotation if present
+    //
+    cursor = qd_buffer_base(buf);
     if (content->section_delivery_annotation.length > 0) {
         buf    = content->section_delivery_annotation.buffer;
         cursor = content->section_delivery_annotation.offset + qd_buffer_base(buf);

--- a/src/message.c
+++ b/src/message.c
@@ -1256,9 +1256,7 @@ static void compose_message_annotations2(qd_message_pvt_t *msg, qd_buffer_list_t
         qd_compose_start_list(out_ma);
         qd_compose_insert_buffers_or_null(out_ma, &msg->ma_to_override);
         qd_compose_insert_int(out_ma, msg->ma_phase);
-        //qd_compose_start_list(out_ma);
         qd_compose_insert_buffers_or_null(out_ma, &msg->ma_ingress);
-        //qd_compose_end_list(out_ma);
         qd_compose_insert_buffers_or_null(out_ma, &msg->ma_trace);
         qd_compose_end_list(out_ma);
     }

--- a/src/message.c
+++ b/src/message.c
@@ -40,9 +40,6 @@
 // Match this definition in router_node.c
 static const bool USE_ANNO_V1 = false;
 
-// Turn on/off chat
-static const bool BLAB = false;
-
 const char *STR_AMQP_NULL = "null";
 const char *STR_AMQP_TRUE = "T";
 const char *STR_AMQP_FALSE = "F";
@@ -981,7 +978,7 @@ qd_parsed_field_t *qd_message_v2_annotations(qd_message_t *in_msg)
         return 0;
 
     // parse message into v2 vs. remaining annotations parts
-    const char * errorptr = qd_parse_v2_annotations(
+    (void) qd_parse_v2_annotations(
         content->ma_field_iter_in,
         QD_MA_ANNOTATIONS,
         &content->ma_all_annotations,
@@ -998,11 +995,7 @@ qd_parsed_field_t *qd_message_v2_annotations(qd_message_t *in_msg)
         content->field_user_annotations.parsed = true;
     }
 
-    if (BLAB && errorptr)
-        fprintf(stdout, "DEBUGGING: message.c parse error: %s\n", errorptr);
     if (!content->ma_v2) {
-        if (BLAB)
-            fprintf(stdout, "DEBUGGING: Message has no v2 annotations\n");
         return content->ma_v2;
     }
     // parsed_field ma_v2 holds the v2 annotation object

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -134,6 +134,7 @@ typedef struct {
     qd_buffer_list_t      ma_trace;        // trace list in outgoing message annotations
     qd_buffer_list_t      ma_ingress;      // ingress field in outgoing message annotations
     int                   ma_phase;        // phase for the override address
+    bool                  ma_v1_inbound;   // incoming message sourced with v1 annotation scheme
 } qd_message_pvt_t;
 
 ALLOC_DECLARE(qd_message_t);

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -94,36 +94,21 @@ typedef struct {
     qd_buffer_t         *parse_buffer;
     unsigned char       *parse_cursor;
     qd_message_depth_t   parse_depth;
-                                                          // v1 annotations
-    qd_parsed_field_t   *parsed_message_annotations;
-
-                                                          // v2 annotations
-                                                          // The annotations are split on message ingress.
-                                                          // The first element in the map is the interrouter
-                                                          // annotation we care about.
-                                                          // The remainder of the annotations are an opaque
-                                                          // blob of pass-through map values that never get examined.
-                                                          // In order to pass the blob along we need
-                                                          // to track how many elements are in the map and how
-                                                          // many bytes they consume.
-
-    bool                 ma_v2_parsed;                    // have parsed annotations in incoming message
+                                                          // common annotations
+    bool                 ma_parsed;                       // have parsed annotations in incoming message
     qd_iterator_t       *ma_field_iter_in;                // 'message field iterator' for msg.FIELD_MESSAGE_ANNOTATION
 
-    qd_parsed_field_t   *ma_all_annotations;              // Map field partially parsed to find v2 annotations at
-                                                          // the beginnning. After parsing this field holds 'count' 
-                                                          // map items addressed by raw_iter.
-    uint32_t             ma_count;                        // Number of map elements in ma_all_annotations->raw_iter 
-                                                          // after the ma_v2 field and its key have been extracted.
-    qd_parsed_field_t   *ma_v2;                           // Incoming message v2 annotation object or null.
-                                                          // Parsed out of the beginning of the ma_all_annotations field
-                                                          // and this element is not included in ma_count.
+    qd_parsed_field_t   *annotations;
 
-    qd_parsed_field_t   *ma_ingress_2;
-    qd_parsed_field_t   *ma_phase_2;
-    qd_parsed_field_t   *ma_to_override_2;
-    qd_parsed_field_t   *ma_trace_2;
-    int                  ma_phase;
+    qd_iterator_pointer_t ma_user_annotation_blob;        // Original user annotations
+                                                          // with router annotations stripped
+    uint32_t             ma_count;                        // Number of map elements in blob
+                                                          // after the router fields stripped
+    qd_parsed_field_t   *ma_pf_ingress;
+    qd_parsed_field_t   *ma_pf_phase;
+    qd_parsed_field_t   *ma_pf_to_override;
+    qd_parsed_field_t   *ma_pf_trace;
+    int                  ma_int_phase;
 
 } qd_message_content_t;
 
@@ -134,7 +119,7 @@ typedef struct {
     qd_buffer_list_t      ma_trace;        // trace list in outgoing message annotations
     qd_buffer_list_t      ma_ingress;      // ingress field in outgoing message annotations
     int                   ma_phase;        // phase for the override address
-    bool                  ma_v1_inbound;   // incoming message sourced with v1 annotation scheme
+    int                   hello_ver_in;    // incoming router hello version.
 } qd_message_pvt_t;
 
 ALLOC_DECLARE(qd_message_t);

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -96,7 +96,7 @@ typedef struct {
                                                           // v1 annotations
     qd_parsed_field_t   *parsed_message_annotations;
                                                           // v2 annotations
-                                                          // The annotations are split on message egress.
+                                                          // The annotations are split on message ingress.
                                                           // The first element in the map is the interrouter
                                                           // annotation we care about.
                                                           // The remainder of the annotations are an opaque

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -93,7 +93,32 @@ typedef struct {
     qd_buffer_t         *parse_buffer;
     unsigned char       *parse_cursor;
     qd_message_depth_t   parse_depth;
+                                                          // v1 annotations
     qd_parsed_field_t   *parsed_message_annotations;
+                                                          // v2 annotations
+                                                          // The annotations are split on message egress.
+                                                          // The first element in the map is the interrouter
+                                                          // annotation we care about.
+                                                          // The remainder of the annotations are an opaque
+                                                          // blob of pass-through map values that never get examined.
+                                                          // In order to pass the blob along we need
+                                                          // to track how many elements are in the map and how
+                                                          // many bytes they consume.
+
+    qd_iterator_t       *ma_field_iter_in;                // Entire MESSAGE_ANNOTATION map field
+
+    qd_iterator_t       *ma_v2_annotation_in;             // Incoming message v2 annotation object or
+                                                          // null if there are no incoming router v2 annotations.
+                                                          // The field annotations are in a map and the key
+                                                          // is a fixed value which is not represented here.
+                                                          // This element is the value.
+
+    qd_buffer_t        *ma_v2_blob_buffer;                // starting buffer of pass through annotations (see iterator pointer_t type)
+                                                          // Null if there is no pass-through blob.
+    char               *ma_v2_blob_cursor;                // first byte of remaining blob bytes
+    int                 ma_v2_blob_remaining;             // number of bytes to pass through
+    int                 ma_v2_blob_count;                 // number of map items in the pass-through blob.
+
 } qd_message_content_t;
 
 typedef struct {

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -75,6 +75,7 @@ typedef struct {
     qd_field_location_t  section_application_properties;  // The application properties list
     qd_field_location_t  section_body;                    // The message body: Data
     qd_field_location_t  section_footer;                  // The footer
+    qd_field_location_t  field_user_annotations;        // Opaque user message annotations. Tail of annotation map
     qd_field_location_t  field_message_id;                // The string value of the message-id
     qd_field_location_t  field_user_id;                   // The string value of the user-id
     qd_field_location_t  field_to;                        // The string value of the to field

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -66,7 +66,7 @@ typedef struct {
 
 typedef struct {
     sys_mutex_t         *lock;
-    sys_atomic_t         ref_count;                       // The number of messages referencing thisqd_parsed_map_remainder_t
+    sys_atomic_t         ref_count;                       // The number of messages referencing this
     qd_buffer_list_t     buffers;                         // The buffer chain containing the message
     qd_field_location_t  section_message_header;          // The message header list
     qd_field_location_t  section_delivery_annotation;     // The delivery annotation map
@@ -110,7 +110,7 @@ typedef struct {
     qd_iterator_t       *ma_field_iter_in;                // 'message field iterator' for msg.FIELD_MESSAGE_ANNOTATION
 
     qd_parsed_field_t   *ma_all_annotations;              // Map field partially parsed to find v2 annotations at
-                                                          // the beginnning. After parsing thie field holds 'count' 
+                                                          // the beginnning. After parsing this field holds 'count' 
                                                           // map items addressed by raw_iter.
     uint32_t             ma_count;                        // Number of map elements in ma_all_annotations->raw_iter 
                                                           // after the ma_v2 field and its key have been extracted.

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -95,6 +95,7 @@ typedef struct {
     qd_message_depth_t   parse_depth;
                                                           // v1 annotations
     qd_parsed_field_t   *parsed_message_annotations;
+
                                                           // v2 annotations
                                                           // The annotations are split on message ingress.
                                                           // The first element in the map is the interrouter
@@ -105,15 +106,23 @@ typedef struct {
                                                           // to track how many elements are in the map and how
                                                           // many bytes they consume.
 
+    bool                 ma_v2_parsed;                    // have parsed annotations in incoming message
     qd_iterator_t       *ma_field_iter_in;                // 'message field iterator' for msg.FIELD_MESSAGE_ANNOTATION
 
-    qd_parsed_field_t   *ma_all_annotations;              // map field partially parsed to find v2 annotations at
-                                                          // the beginnning. Holds 'count' map items addressed by
-                                                          // raw_iter.
-    uint32_t             ma_count;                        // number of map elements in ma_all_annotations->raw_iter 
+    qd_parsed_field_t   *ma_all_annotations;              // Map field partially parsed to find v2 annotations at
+                                                          // the beginnning. After parsing thie field holds 'count' 
+                                                          // map items addressed by raw_iter.
+    uint32_t             ma_count;                        // Number of map elements in ma_all_annotations->raw_iter 
                                                           // after the ma_v2 field and its key have been extracted.
     qd_parsed_field_t   *ma_v2;                           // Incoming message v2 annotation object or null.
-                                                          // parsed out of the beginning of the ma_all_annotations field
+                                                          // Parsed out of the beginning of the ma_all_annotations field
+                                                          // and this element is not included in ma_count.
+
+    qd_parsed_field_t   *ma_ingress_2;
+    qd_parsed_field_t   *ma_phase_2;
+    qd_parsed_field_t   *ma_to_override_2;
+    qd_parsed_field_t   *ma_trace_2;
+    int                  ma_phase;
 
 } qd_message_content_t;
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -66,7 +66,7 @@ typedef struct {
 
 typedef struct {
     sys_mutex_t         *lock;
-    sys_atomic_t         ref_count;                       // The number of messages referencing this
+    sys_atomic_t         ref_count;                       // The number of messages referencing thisqd_parsed_map_remainder_t
     qd_buffer_list_t     buffers;                         // The buffer chain containing the message
     qd_field_location_t  section_message_header;          // The message header list
     qd_field_location_t  section_delivery_annotation;     // The delivery annotation map
@@ -105,19 +105,15 @@ typedef struct {
                                                           // to track how many elements are in the map and how
                                                           // many bytes they consume.
 
-    qd_iterator_t       *ma_field_iter_in;                // Entire MESSAGE_ANNOTATION map field
+    qd_iterator_t       *ma_field_iter_in;                // 'message field iterator' for msg.FIELD_MESSAGE_ANNOTATION
 
-    qd_iterator_t       *ma_v2_annotation_in;             // Incoming message v2 annotation object or
-                                                          // null if there are no incoming router v2 annotations.
-                                                          // The field annotations are in a map and the key
-                                                          // is a fixed value which is not represented here.
-                                                          // This element is the value.
-
-    qd_buffer_t        *ma_v2_blob_buffer;                // starting buffer of pass through annotations (see iterator pointer_t type)
-                                                          // Null if there is no pass-through blob.
-    char               *ma_v2_blob_cursor;                // first byte of remaining blob bytes
-    int                 ma_v2_blob_remaining;             // number of bytes to pass through
-    int                 ma_v2_blob_count;                 // number of map items in the pass-through blob.
+    qd_parsed_field_t   *ma_all_annotations;              // map field partially parsed to find v2 annotations at
+                                                          // the beginnning. Holds 'count' map items addressed by
+                                                          // raw_iter.
+    uint32_t             ma_count;                        // number of map elements in ma_all_annotations->raw_iter 
+                                                          // after the ma_v2 field and its key have been extracted.
+    qd_parsed_field_t   *ma_v2;                           // Incoming message v2 annotation object or null.
+                                                          // parsed out of the beginning of the ma_all_annotations field
 
 } qd_message_content_t;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -21,6 +21,7 @@
 #include <qpid/dispatch/ctools.h>
 #include <qpid/dispatch/parse.h>
 #include <qpid/dispatch/amqp.h>
+#include <stdio.h>
 
 DEQ_DECLARE(qd_parsed_field_t, qd_parsed_field_list_t);
 
@@ -480,4 +481,93 @@ qd_parsed_field_t *qd_parse_value_by_key(qd_parsed_field_t *field, const char *k
     }
 
     return 0;
+}
+
+const char *qd_parse_v2_annotations(
+    qd_iterator_t      *ma_iter_in,
+    const char         *key_name,
+    qd_parsed_field_t **all_annotations,
+    uint32_t           *count,
+    qd_parsed_field_t **v2) {
+
+    // This code looks a lot like qd_parse_internal except:
+    // * there is no intent of parsing beyond the first map entry.
+    // * this code does not recurse or parse the whole map
+    // * this code leaves the iter->raw_iter addressing the unparsed
+    //   portion of the incoming annotations map
+    
+    *all_annotations = 0;
+    *count           = 0;
+    *v2              = 0;
+    
+    if (!ma_iter_in)
+        return 0;
+    
+    *all_annotations = new_qd_parsed_field_t();
+    if (!*all_annotations)
+        return 0;
+
+    DEQ_ITEM_INIT(*all_annotations);
+    DEQ_INIT((*all_annotations)->children);
+    (*all_annotations)->parent   = 0;
+    (*all_annotations)->raw_iter = 0;
+    (*all_annotations)->typed_iter = 0;
+
+    uint32_t size            = 0;
+    uint32_t length_of_count = 0;
+    uint32_t length_of_size  = 0;
+
+    (*all_annotations)->parse_error = get_type_info(ma_iter_in, &(*all_annotations)->tag, 
+                                                    &size, count, &length_of_size,
+                                                    &length_of_count);
+    if ((*all_annotations)->parse_error)
+        return (*all_annotations)->parse_error;
+
+    if (*count != 4)
+        fprintf(stdout, "Count = %d\n", *count);
+    
+    if (!qd_parse_is_map((*all_annotations))) {
+        (*all_annotations)->parse_error = "Message annotations field is not a map";
+        return (*all_annotations)->parse_error;
+    }
+
+    (*all_annotations)->raw_iter = qd_iterator_sub(ma_iter_in, size - length_of_count);
+    qd_iterator_advance(ma_iter_in, size - length_of_count);
+    
+    // Process first key in map. Is this the v2 key?
+    qd_parsed_field_t *key_field = qd_parse_internal((*all_annotations)->raw_iter, (*all_annotations));
+    if (!key_field) {
+        (*all_annotations)->parse_error = "Failed to parse first map key";
+        return (*all_annotations)->parse_error;
+    }
+    if (!qd_parse_ok(key_field)) {
+        (*all_annotations)->parse_error = key_field->parse_error;
+        return (*all_annotations)->parse_error;
+    }
+
+    qd_iterator_t *key_iter = qd_parse_raw(key_field);
+    if (qd_iterator_equal(key_iter, (const unsigned char *)key_name)) {
+        // This map entry holds the v2 annotations
+        fprintf(stdout, "I see the key where it belongs!\n");
+    } else {
+        // No v2 annotations in this message
+        qd_iterator_reset((*all_annotations)->raw_iter);
+        return 0;
+    }
+    
+    // v2 key is present. get the v2 value
+    *v2 = qd_parse_internal((*all_annotations)->raw_iter, (*all_annotations));
+    if (!qd_parse_ok(*v2)) {
+        qd_iterator_reset((*all_annotations)->raw_iter);
+        (*all_annotations)->parse_error = (*v2)->parse_error;
+        fprintf(stdout, "Failed to parse v2 value = %s\n", (*v2)->parse_error);
+        return (*all_annotations)->parse_error;
+    }
+    
+    // Just extracted the parsed field holding the v2 annotations from the incoming
+    // message. Set the remainder map field count.
+    *count -= 2;
+    fprintf(stdout, "Just extracted router annotation. Map has %d entries left.\n", *count);
+    return 0;
+
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -538,10 +538,12 @@ const char *qd_parse_v2_annotations(
     qd_parsed_field_t *key_field = qd_parse_internal((*all_annotations)->raw_iter, (*all_annotations));
     if (!key_field) {
         (*all_annotations)->parse_error = "Failed to parse first map key";
+        qd_iterator_reset((*all_annotations)->raw_iter);
         return (*all_annotations)->parse_error;
     }
     if (!qd_parse_ok(key_field)) {
         (*all_annotations)->parse_error = key_field->parse_error;
+        qd_iterator_reset((*all_annotations)->raw_iter);
         return (*all_annotations)->parse_error;
     }
 
@@ -569,5 +571,4 @@ const char *qd_parse_v2_annotations(
     *count -= 2;
     fprintf(stdout, "Just extracted router annotation. Map has %d entries left.\n", *count);
     return 0;
-
 }

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -339,6 +339,9 @@ static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
         bool                 strip        = qdr_link_strip_annotations_in(rlink);
         qd_iterator_t *ingress_iter = router_annotate_message(router, in_ma, msg, &link_exclusions, strip);
 
+        (void) qd_message_v2_annotations(msg);
+        /// HACKqd_parse_free(xxx);
+        
         if (anonymous_link) {
             qd_iterator_t *addr_iter = 0;
             int phase = 0;

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -207,6 +207,97 @@ static qd_iterator_t *router_annotate_message(qd_router_t       *router,
 }
 
 
+// HACK ALERT
+static qd_iterator_t *router_annotate_message2(qd_router_t       *router,
+                                               qd_message_t      *msg,
+                                               qd_bitmask_t     **link_exclusions,
+                                               bool               strip_inbound_annotations)
+{
+    qd_iterator_t *ingress_iter = 0;
+
+    bool s = strip_inbound_annotations;
+
+    qd_parsed_field_t *trace   = s ? 0 : qd_message_get_trace(msg);
+    qd_parsed_field_t *ingress = s ? 0 : qd_message_get_ingress(msg);
+    qd_parsed_field_t *to      = s ? 0 : qd_message_get_to_override(msg);
+    qd_parsed_field_t *phase   = s ? 0 : qd_message_get_phase(msg);
+
+    *link_exclusions = 0;
+
+    //
+    // QD_MA_TRACE:
+    // If there is a trace field, append this router's ID to the trace.
+    // If the router ID is already in the trace the msg has looped.
+    //
+    qd_composed_field_t *trace_field = qd_compose_subfield(0);
+    qd_compose_start_list(trace_field);
+    if (trace) {
+        if (qd_parse_is_list(trace)) {
+            //
+            // Create a link-exclusion map for the items in the trace.  This map will
+            // contain a one-bit for each link that leads to a neighbor router that
+            // the message has already passed through.
+            //
+            *link_exclusions = qd_tracemask_create(router->tracemask, trace);
+
+            //
+            // Append this router's ID to the trace.
+            //
+            uint32_t idx = 0;
+            qd_parsed_field_t *trace_item = qd_parse_sub_value(trace, idx);
+            while (trace_item) {
+                qd_iterator_t *iter = qd_parse_raw(trace_item);
+                qd_iterator_reset_view(iter, ITER_VIEW_ALL);
+                qd_compose_insert_string_iterator(trace_field, iter);
+                idx++;
+                trace_item = qd_parse_sub_value(trace, idx);
+            }
+        }
+    }
+
+    qd_compose_insert_string(trace_field, node_id);
+    qd_compose_end_list(trace_field);
+    qd_message_set_trace_annotation(msg, trace_field);
+
+    //
+    // QD_MA_TO:
+    // Preserve the existing value.
+    //
+    if (to) {
+        qd_composed_field_t *to_field = qd_compose_subfield(0);
+        qd_compose_insert_string_iterator(to_field, qd_parse_raw(to));
+        qd_message_set_to_override_annotation(msg, to_field);
+    }
+
+    //
+    // QD_MA_PHASE:
+    // Preserve the existing value.
+    //
+    if (phase) {
+        qd_message_set_phase_annotation(msg, qd_message_get_phase_val(msg));
+    }
+
+    //
+    // QD_MA_INGRESS:
+    // If there is no ingress field, annotate the ingress as
+    // this router else keep the original field.
+    //
+    qd_composed_field_t *ingress_field = qd_compose_subfield(0);
+    if (ingress && qd_parse_is_scalar(ingress)) {
+        ingress_iter = qd_parse_raw(ingress);
+        qd_compose_insert_string_iterator(ingress_field, ingress_iter);
+    } else
+        qd_compose_insert_string(ingress_field, node_id);
+    qd_message_set_ingress_annotation(msg, ingress_field);
+
+    //
+    // Return the iterator to the ingress field _if_ it was present.
+    // If we added the ingress, return NULL.
+    //
+    return ingress_iter;
+}
+
+
 /**
  * Inbound Delivery Handler
  */
@@ -339,9 +430,6 @@ static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
         bool                 strip        = qdr_link_strip_annotations_in(rlink);
         qd_iterator_t *ingress_iter = router_annotate_message(router, in_ma, msg, &link_exclusions, strip);
 
-        (void) qd_message_v2_annotations(msg);
-        /// HACKqd_parse_free(xxx);
-        
         if (anonymous_link) {
             qd_iterator_t *addr_iter = 0;
             int phase = 0;
@@ -357,6 +445,248 @@ static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
                 }
             }
 
+            //
+            // Still no destination address?  Use the TO field from the message properties.
+            //
+            if (!addr_iter) {
+                addr_iter = qd_message_field_iterator(msg, QD_FIELD_TO);
+
+                //
+                // If the address came from the TO field and we need to apply a tenant-space,
+                // set the to-override with the annotated address.
+                //
+                if (addr_iter && tenant_space) {
+                    qd_iterator_reset_view(addr_iter, ITER_VIEW_ADDRESS_WITH_SPACE);
+                    qd_iterator_annotate_space(addr_iter, tenant_space, tenant_space_len);
+                    qd_composed_field_t *to_override = qd_compose_subfield(0);
+                    qd_compose_insert_string_iterator(to_override, addr_iter);
+                    qd_message_set_to_override_annotation(msg, to_override);
+                }
+            }
+
+            if (addr_iter) {
+                qd_iterator_reset_view(addr_iter, ITER_VIEW_ADDRESS_HASH);
+                if (phase > 0)
+                    qd_iterator_annotate_phase(addr_iter, '0' + (char) phase);
+                delivery = qdr_link_deliver_to(rlink, msg, ingress_iter, addr_iter, pn_delivery_settled(pnd),
+                                               link_exclusions);
+            }
+        } else {
+            //
+            // This is a targeted link, not anonymous.
+            //
+            const char *term_addr = pn_terminus_get_address(qd_link_remote_target(link));
+            if (!term_addr)
+                term_addr = pn_terminus_get_address(qd_link_source(link));
+
+            if (term_addr) {
+                qd_composed_field_t *to_override = qd_compose_subfield(0);
+                if (tenant_space) {
+                    qd_iterator_t *aiter = qd_iterator_string(term_addr, ITER_VIEW_ADDRESS_WITH_SPACE);
+                    qd_iterator_annotate_space(aiter, tenant_space, tenant_space_len);
+                    qd_compose_insert_string_iterator(to_override, aiter);
+                    qd_iterator_free(aiter);
+                } else
+                    qd_compose_insert_string(to_override, term_addr);
+                qd_message_set_to_override_annotation(msg, to_override);
+                int phase = qdr_link_phase(rlink);
+                if (phase != 0)
+                    qd_message_set_phase_annotation(msg, phase);
+            }
+            delivery = qdr_link_deliver(rlink, msg, ingress_iter, pn_delivery_settled(pnd), link_exclusions);
+        }
+
+        if (delivery) {
+            if (pn_delivery_settled(pnd))
+                pn_delivery_settle(pnd);
+            else {
+                pn_delivery_set_context(pnd, delivery);
+                qdr_delivery_set_context(delivery, pnd);
+                qdr_delivery_incref(delivery);
+            }
+        } else {
+            //
+            // The message is now and will always be unroutable because there is no address.
+            //
+            pn_link_flow(pn_link, 1);
+            pn_delivery_update(pnd, PN_REJECTED);
+            pn_delivery_settle(pnd);
+            qd_message_free(msg);
+        }
+
+        //
+        // Rules for delivering messages:
+        //
+        // For addressed (non-anonymous) links:
+        //   to-override must be set (done in the core?)
+        //   uses qdr_link_deliver to hand over to the core
+        //
+        // For anonymous links:
+        //   If there's a to-override in the annotations, use that address
+        //   Or, use the 'to' field in the message properties
+        //
+
+
+
+    } else {
+        //
+        // Message is invalid.  Reject the message and don't involve the router core.
+        //
+        pn_link_flow(pn_link, 1);
+        pn_delivery_update(pnd, PN_REJECTED);
+        pn_delivery_settle(pnd);
+        qd_message_free(msg);
+    }
+}
+
+
+/**
+ * Inbound Delivery Handler
+ */
+// HACK ALERT
+static void AMQP_rx_handler2(void* context, qd_link_t *link, pn_delivery_t *pnd)
+{
+    qd_router_t    *router   = (qd_router_t*) context;
+    pn_link_t      *pn_link  = qd_link_pn(link);
+    qdr_link_t     *rlink    = (qdr_link_t*) qd_link_get_context(link);
+    qd_connection_t  *conn   = qd_link_connection(link);
+    const qd_server_config_t *cf = qd_connection_config(conn);
+    qdr_delivery_t *delivery = 0;
+    qd_message_t   *msg;
+
+    //
+    // Receive the message into a local representation.  If the returned message
+    // pointer is NULL, we have not yet received a complete message.
+    //
+    // Note:  In the link-routing case, consider cutting the message through.  There's
+    //        no reason to wait for the whole message to be received before starting to
+    //        send it.
+    //
+    msg = qd_message_receive(pnd);
+
+    if (!msg)
+        return;
+
+    if (cf->log_message) {
+        char repr[qd_message_repr_len()];
+        char* message_repr = qd_message_repr((qd_message_t*)msg,
+                                             repr,
+                                             sizeof(repr),
+                                             cf->log_bits);
+        if (message_repr) {
+            qd_log(qd_message_log_source(), QD_LOG_TRACE, "Link %s received %s",
+                   pn_link_name(pn_link),
+                   message_repr);
+        }
+    }
+
+    //            
+    // Consume the delivery.
+    //
+    pn_link_advance(pn_link);
+
+    //
+    // If there's no router link, free the message and finish.  It's likely that the link
+    // is closing.
+    //
+    if (!rlink) {
+        qd_message_free(msg);
+        return;
+    }
+
+    //
+    // Handle the link-routed case
+    //
+    if (qdr_link_is_routed(rlink)) {
+        pn_delivery_tag_t dtag = pn_delivery_tag(pnd);
+        delivery = qdr_link_deliver_to_routed_link(rlink, msg, pn_delivery_settled(pnd), (uint8_t*) dtag.start, dtag.size,
+                                                   pn_disposition_type(pn_delivery_remote(pnd)), pn_disposition_data(pn_delivery_remote(pnd)));
+
+        if (delivery) {
+            if (pn_delivery_settled(pnd))
+                pn_delivery_settle(pnd);
+            else {
+                pn_delivery_set_context(pnd, delivery);
+                qdr_delivery_set_context(delivery, pnd);
+                qdr_delivery_incref(delivery);
+            }
+        }
+        return;
+    }
+
+    //
+    // Determine if the incoming link is anonymous.  If the link is addressed,
+    // there are some optimizations we can take advantage of.
+    //
+    bool anonymous_link = qdr_link_is_anonymous(rlink);
+
+    //
+    // Determine if the user of this connection is allowed to proxy the
+    // user_id of messages. A message user_id is proxied when the
+    // property value differs from the authenticated user name of the connection.
+    // If the user is not allowed to proxy the user_id then the message user_id
+    // must be blank or it must be equal to the connection user name.
+    //
+    bool              check_user   = false;
+    qdr_connection_t *qdr_conn     = (qdr_connection_t*) qd_connection_get_context(conn);
+    int               tenant_space_len;
+    const char       *tenant_space = qdr_connection_get_tenant_space(qdr_conn, &tenant_space_len);
+    if (conn->policy_settings) 
+        check_user = !conn->policy_settings->allowUserIdProxy;
+
+    //
+    // Validate the content of the delivery as an AMQP message.  This is done partially, only
+    // to validate that we can find the fields we need to route the message.
+    //
+    // If the link is anonymous, we must validate through the message properties to find the
+    // 'to' field.  If the link is not anonymous, we don't need the 'to' field as we will be
+    // using the address from the link target.
+    //
+    qd_message_depth_t  validation_depth = (anonymous_link || check_user) ? QD_DEPTH_PROPERTIES : QD_DEPTH_MESSAGE_ANNOTATIONS;
+    bool                valid_message    = qd_message_check(msg, validation_depth);
+
+    if (valid_message) {
+        if (check_user) {
+            // This connection must not allow proxied user_id
+            qd_iterator_t *userid_iter  = qd_message_field_iterator(msg, QD_FIELD_USER_ID);
+            if (userid_iter) {
+                // The user_id property has been specified
+                if (qd_iterator_remaining(userid_iter) > 0) {
+                    // user_id property in message is not blank
+                    if (!qd_iterator_equal(userid_iter, (const unsigned char *)conn->user_id)) {
+                        // This message is rejected: attempted user proxy is disallowed
+                        qd_log(router->log_source, QD_LOG_DEBUG, "Message rejected due to user_id proxy violation. User:%s", conn->user_id);
+                        pn_link_flow(pn_link, 1);
+                        pn_delivery_update(pnd, PN_REJECTED);
+                        pn_delivery_settle(pnd);
+                        qd_message_free(msg);
+                        qd_iterator_free(userid_iter);
+                        return;
+                    }
+                }
+                qd_iterator_free(userid_iter);
+            }
+        }
+
+        qd_parsed_field_t   *in_ma     = qd_message_v2_annotations(msg);
+        qd_bitmask_t        *link_exclusions;
+        bool                 strip        = qdr_link_strip_annotations_in(rlink);
+        qd_iterator_t *ingress_iter = router_annotate_message2(router, msg, &link_exclusions, strip);
+
+        if (anonymous_link) {
+            qd_iterator_t *addr_iter = 0;
+            int phase = 0;
+
+            //
+            // If the message has delivery annotations, get the to-override field from the annotations.
+            //
+            if (in_ma) {
+                qd_parsed_field_t *ma_to = qd_message_get_to_override(msg);
+                if (ma_to) {
+                    addr_iter = qd_iterator_dup(qd_parse_raw(ma_to));
+                    phase = qd_message_get_phase_val(msg);
+                }
+            }
             //
             // Still no destination address?  Use the TO field from the message properties.
             //

--- a/src/server.c
+++ b/src/server.c
@@ -1257,3 +1257,7 @@ const char* qd_connection_remote_ip(const qd_connection_t *c) {
 void qd_connection_handle(qd_connection_t *c, pn_event_t *e) {
     handle(c->server, e);
 }
+
+bool qd_connection_uses_v1_annotations(const qd_connection_t *c) {
+    return c->annotations_v1;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -1258,6 +1258,6 @@ void qd_connection_handle(qd_connection_t *c, pn_event_t *e) {
     handle(c->server, e);
 }
 
-bool qd_connection_uses_v1_annotations(const qd_connection_t *c) {
-    return c->annotations_v1;
+int qd_connection_hello_protocol_version(const qd_connection_t *c) {
+    return c->hello_protocol_ver;
 }

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -153,6 +153,7 @@ struct qd_connection_t {
     qd_deferred_call_list_t   deferred_calls;
     sys_mutex_t              *deferred_call_lock;
     bool                      policy_counted;
+    bool                      annotations_v1;
     char                     *role;  //The specified role of the connection, e.g. "normal", "inter-router", "route-container" etc.
     void (*wake)(qd_connection_t*); /* Wake method, different for HTTP vs. proactor */
     char rhost[NI_MAXHOST];     /* Remote host numeric IP for incoming connections */

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -153,7 +153,7 @@ struct qd_connection_t {
     qd_deferred_call_list_t   deferred_calls;
     sys_mutex_t              *deferred_call_lock;
     bool                      policy_counted;
-    bool                      annotations_v1;
+    int                       hello_protocol_ver;
     char                     *role;  //The specified role of the connection, e.g. "normal", "inter-router", "route-container" etc.
     void (*wake)(qd_connection_t*); /* Wake method, different for HTTP vs. proactor */
     char rhost[NI_MAXHOST];     /* Remote host numeric IP for incoming connections */


### PR DESCRIPTION
**DO NOT COMMIT THIS PULL REQUEST** It is for review only.

This work adds a new annotation scheme for inter-router annotations. The old method put a variable number (0..4) of key-value pairs into the message annotations map at the end of the map. The new method puts in a single list of four elements at the beginning of the message annotations map.

In order to be backwards compatible there is some amount of version sensing and translating between annotation formats. This could be improved in a number of ways.

This commit still fails two self tests: system_tests_one_router and system_tests_two_routers in their annotation handling sections. The V1 vs V2 annotation feature is not tested much at all. That is in the works after the general strategy is approved.