### PR TITLE
DISPATCH-767 - Added code to support multi frame message streaming

### DIFF
--- a/include/qpid/dispatch/buffer.h
+++ b/include/qpid/dispatch/buffer.h
@@ -32,10 +32,13 @@ typedef struct qd_buffer_t qd_buffer_t;
 
 DEQ_DECLARE(qd_buffer_t, qd_buffer_list_t);
 
+extern size_t BUFFER_SIZE;
+
 /** A raw byte buffer .*/
 struct qd_buffer_t {
     DEQ_LINKS(qd_buffer_t);
     unsigned int size;          ///< Size of data content
+    unsigned int fanout;        // The number of receivers for this buffer
 };
 
 /**
@@ -116,6 +119,23 @@ void qd_buffer_list_free_buffers(qd_buffer_list_t *list);
  * @return total number of bytes of data in the buffer list
  */
 unsigned int qd_buffer_list_length(const qd_buffer_list_t *list);
+
+/*
+ * Increase the fanout by 1. How many receivers should this buffer be sent to.
+ */
+void qd_buffer_add_fanout(qd_buffer_t *buf);
+
+/**
+ * Return the buffer's fanout.
+ */
+size_t qd_buffer_fanout(qd_buffer_t *buf);
+
+/**
+ * Advance the buffer by len. Does not manipulate the contents of the buffer
+ * @param buf A pointer to an allocated buffer
+ * @param len The number of octets that by which the buffer should be advanced.
+ */
+unsigned char *qd_buffer_at(qd_buffer_t *buf, size_t len);
 
 
 ///@}

--- a/include/qpid/dispatch/buffer.h
+++ b/include/qpid/dispatch/buffer.h
@@ -27,6 +27,7 @@
  */
 
 #include <qpid/dispatch/ctools.h>
+#include <qpid/dispatch/atomic.h>
 
 typedef struct qd_buffer_t qd_buffer_t;
 
@@ -38,7 +39,7 @@ extern size_t BUFFER_SIZE;
 struct qd_buffer_t {
     DEQ_LINKS(qd_buffer_t);
     unsigned int size;          ///< Size of data content
-    unsigned int fanout;        // The number of receivers for this buffer
+    sys_atomic_t fanout;        // The number of receivers for this buffer
 };
 
 /**

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -201,9 +201,9 @@ int  qd_message_get_phase_annotation(const qd_message_t *msg);
 void qd_message_set_ingress_annotation(qd_message_t *msg, qd_composed_field_t *ingress_field);
 
 /**
- * Receive message data via a delivery.  This function may be called more than once on the same
- * delivery if the message spans multiple frames.  Once a complete message has been received, this
- * function shall return the message.
+ * Receive message data frame by frame via a delivery.  This function may be called more than once on the same
+ * delivery if the message spans multiple frames. Always returns a message. The message buffers are filled up to the point with the data that was been received so far.
+ * The buffer keeps filling up on successive calls to this function.
  *
  * @param delivery An incoming delivery from a link
  * @return A pointer to the complete message or 0 if the message is not yet complete.
@@ -295,6 +295,61 @@ qd_parsed_field_t *qd_message_get_trace      (qd_message_t *msg);
  * @return the phase as an integer
  */
 int                qd_message_get_phase_val  (qd_message_t *msg);
+
+/*
+ * Should the message be discarded.
+ * A message can be discarded if the disposition is released or rejected.
+ *
+ * @param msg A pointer to the message.
+ **/
+bool qd_message_is_discard(qd_message_t *msg);
+
+/**
+ *Set the discard field on the message to to the passed in boolean value.
+ *
+ * @param msg A pointer to the message.
+ * @param discard - the boolean value of discard.
+ */
+void qd_message_set_discard(qd_message_t *msg, bool discard);
+
+/**
+ * Has the message been completely received?
+ * Return true if the message is fully received
+ * Returns false if only the partial message has been received, if there is more of the message to be received.
+ *
+ * @param msg A pointer to the message.
+ */
+bool qd_message_receive_complete(qd_message_t *msg);
+
+/**
+ * Returns true if the message has been completely received AND the message has been completely sent.
+ */
+bool qd_message_send_complete(qd_message_t *msg);
+
+/**
+ * Returns true if the delivery tag has already been sent.
+ */
+bool qd_message_tag_sent(qd_message_t *msg);
+
+
+/**
+ * Returns true if the delivery tag has already been sent.
+ */
+void qd_message_set_tag_sent(qd_message_t *msg, bool tag_sent);
+
+/**
+ * Get the number of receivers for this message.
+ *
+ * @param msg A pointer to the message.
+ */
+size_t qd_message_fanout(qd_message_t *msg);
+
+/**
+ * Increase the fanout of the message by 1.
+ *
+ * @param msg A pointer to the message.
+ */
+void qd_message_add_fanout(qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -333,7 +333,7 @@ bool qd_message_tag_sent(qd_message_t *msg);
 
 
 /**
- * Returns true if the delivery tag has already been sent.
+ * Sets if the delivery tag has already been sent out or not.
  */
 void qd_message_set_tag_sent(qd_message_t *msg, bool tag_sent);
 

--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -541,8 +541,10 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
 qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *msg, bool settled,
                                                 const uint8_t *tag, int tag_length,
                                                 uint64_t disposition, pn_data_t* disposition_state);
+qdr_delivery_t *qdr_deliver_continue(qdr_delivery_t *delivery);
+qdr_delivery_t *qdr_delivery_delete_settled(qdr_delivery_t *dlv);
 
-void qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit);
+int qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit);
 
 void qdr_link_flow(qdr_core_t *core, qdr_link_t *link, int credit, bool drain_mode);
 
@@ -589,6 +591,10 @@ void qdr_delivery_tag(const qdr_delivery_t *delivery, const char **tag, int *len
 qd_message_t *qdr_delivery_message(const qdr_delivery_t *delivery);
 qdr_error_t *qdr_delivery_error(const qdr_delivery_t *delivery);
 void qdr_delivery_write_extension_state(qdr_delivery_t *dlv, pn_delivery_t* pdlv, bool update_disposition);
+bool qdr_delivery_send_complete(const qdr_delivery_t *delivery);
+bool qdr_delivery_tag_sent(const qdr_delivery_t *delivery);
+void qdr_delivery_set_tag_sent(const qdr_delivery_t *delivery, bool tag_sent);
+bool qdr_delivery_receive_complete(const qdr_delivery_t *delivery);
 
 /**
  ******************************************************************************

--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -595,6 +595,7 @@ bool qdr_delivery_send_complete(const qdr_delivery_t *delivery);
 bool qdr_delivery_tag_sent(const qdr_delivery_t *delivery);
 void qdr_delivery_set_tag_sent(const qdr_delivery_t *delivery, bool tag_sent);
 bool qdr_delivery_receive_complete(const qdr_delivery_t *delivery);
+void qdr_delivery_set_cleared_proton_ref(qdr_delivery_t *dlv, bool cleared_proton_ref);
 
 /**
  ******************************************************************************

--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -542,7 +542,6 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
                                                 const uint8_t *tag, int tag_length,
                                                 uint64_t disposition, pn_data_t* disposition_state);
 qdr_delivery_t *qdr_deliver_continue(qdr_delivery_t *delivery);
-qdr_delivery_t *qdr_delivery_delete_settled(qdr_delivery_t *dlv);
 
 int qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit);
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -46,7 +46,7 @@ qd_buffer_t *qd_buffer(void)
 
     DEQ_ITEM_INIT(buf);
     buf->size   = 0;
-    buf->fanout = 0;
+    sys_atomic_init(&buf->fanout, 0);
     return buf;
 }
 
@@ -90,7 +90,7 @@ void qd_buffer_insert(qd_buffer_t *buf, size_t len)
 
 void qd_buffer_add_fanout(qd_buffer_t *buf)
 {
-    buf->fanout++;
+    sys_atomic_inc(&buf->fanout);
 }
 
 size_t qd_buffer_fanout(qd_buffer_t *buf)

--- a/src/message.c
+++ b/src/message.c
@@ -838,6 +838,13 @@ qd_message_t *qd_message()
     DEQ_INIT(msg->ma_trace);
     DEQ_INIT(msg->ma_ingress);
     msg->ma_phase = 0;
+    msg->ma_phase      = 0;
+    msg->sent_depth    = QD_DEPTH_NONE;
+    msg->cursor.buffer = 0;
+    msg->cursor.offset = 0;
+    msg->send_complete = false;
+    msg->tag_sent      = false;
+
     msg->content = new_qd_message_content_t();
 
     if (msg->content == 0) {
@@ -846,6 +853,8 @@ qd_message_t *qd_message()
     }
 
     ZERO(msg->content);
+    msg->content->receive_complete = false;
+    msg->content->discard          = false;
     msg->content->lock = sys_mutex();
     sys_atomic_init(&msg->content->ref_count, 1);
     msg->content->parse_depth = QD_DEPTH_NONE;
@@ -912,6 +921,12 @@ qd_message_t *qd_message_copy(qd_message_t *in_msg)
     copy->strip_annotations_in  = msg->strip_annotations_in;
 
     copy->content = content;
+
+    copy->sent_depth    = QD_DEPTH_NONE;
+    copy->cursor.buffer = 0;
+    copy->cursor.offset = 0;
+    copy->send_complete = false;
+    copy->tag_sent      = false;
 
     qd_message_message_annotations((qd_message_t*) copy);
 
@@ -999,11 +1014,84 @@ void qd_message_set_ingress_annotation(qd_message_t *in_msg, qd_composed_field_t
     qd_compose_free(ingress_field);
 }
 
+bool qd_message_is_discard(qd_message_t *msg)
+{
+    if (!msg)
+        return false;
+    qd_message_pvt_t *pvt_msg = (qd_message_pvt_t*) msg;
+    return pvt_msg->content->discard;
+}
+
+void qd_message_set_discard(qd_message_t *msg, bool discard)
+{
+    if (!msg)
+        return;
+
+    qd_message_pvt_t *pvt_msg = (qd_message_pvt_t*) msg;
+    pvt_msg->content->discard = discard;
+}
+
+size_t qd_message_fanout(qd_message_t *in_msg)
+{
+    if (!in_msg)
+        return 0;
+    qd_message_pvt_t *msg = (qd_message_pvt_t*) in_msg;
+    return msg->content->fanout;
+}
+
+void qd_message_add_fanout(qd_message_t *in_msg)
+{
+    assert(in_msg);
+    qd_message_pvt_t *msg = (qd_message_pvt_t*) in_msg;
+    msg->content->fanout++;
+}
+
+bool qd_message_receive_complete(qd_message_t *in_msg)
+{
+    if (!in_msg)
+        return false;
+    qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
+    return msg->content->receive_complete;
+}
+
+bool qd_message_send_complete(qd_message_t *in_msg)
+{
+    if (!in_msg)
+        return false;
+
+    qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
+    return msg->send_complete;
+}
+
+bool qd_message_tag_sent(qd_message_t *in_msg)
+{
+    if (!in_msg)
+        return false;
+
+    qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
+    return msg->tag_sent;
+}
+
+void qd_message_set_tag_sent(qd_message_t *in_msg, bool tag_sent)
+{
+    if (!in_msg)
+        return;
+
+    qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
+    msg->tag_sent = tag_sent;
+}
+
+qd_field_location_t qd_message_cursor(qd_message_pvt_t *in_msg)
+{
+    qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
+    return msg->cursor;
+}
+
 qd_message_t *qd_message_receive(pn_delivery_t *delivery)
 {
     pn_link_t        *link = pn_delivery_link(delivery);
     ssize_t           rc;
-    qd_buffer_t      *buf;
+    qd_buffer_t      *buf = 0;
 
     pn_record_t *record    = pn_delivery_attachments(delivery);
     qd_message_pvt_t *msg  = (qd_message_pvt_t*) pn_record_get(record, PN_DELIVERY_CTX);
@@ -1023,26 +1111,47 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
     }
 
     //
-    // Get a reference to the tail buffer on the message.  This is the buffer into which
-    // we will store incoming message data.  If there is no buffer in the message, allocate
-    // an empty one and add it to the message.
+    // The discard flag indicates if we should continue receiving the message.
+    // This is pertinent in the case of large messages. When large messages are being received, we try to send out part of the
+    // message that has been received so far. If we not able to send it anywhere, there is no need to keep creating buffers
     //
-    buf = DEQ_TAIL(msg->content->buffers);
-    if (!buf) {
-        buf = qd_buffer();
-        DEQ_INSERT_TAIL(msg->content->buffers, buf);
+    bool discard = qd_message_is_discard((qd_message_t*)msg);
+
+    //
+    // Get a reference to the tail buffer on the message.  This is the buffer into which
+    // we will store incoming message data.  If there is no buffer in the message, this is the
+    // first time we are here and we need to allocate an empty one and add it to the message.
+    //
+    if (!discard) {
+        buf = DEQ_TAIL(msg->content->buffers);
+        if (!buf) {
+            buf = qd_buffer();
+            DEQ_INSERT_TAIL(msg->content->buffers, buf);
+        }
     }
 
     while (1) {
-        //
-        // Try to receive enough data to fill the remaining space in the tail buffer.
-        //
-        rc = pn_link_recv(link, (char*) qd_buffer_cursor(buf), qd_buffer_capacity(buf));
+        if (discard) {
+            char dummy[BUFFER_SIZE];
+            rc = pn_link_recv(link, dummy, BUFFER_SIZE);
+        }
+        else {
+            //
+            // Try to receive enough data to fill the remaining space in the tail buffer.
+            //
+
+            rc = pn_link_recv(link, (char*) qd_buffer_cursor(buf), qd_buffer_capacity(buf));
+        }
 
         //
         // If we receive PN_EOS, we have come to the end of the message.
         //
         if (rc == PN_EOS) {
+            //
+            // We have received the entire message since rc == PN_EOS, set the receive_complete flag to true
+            //
+            msg->content->receive_complete = true;
+
             //
             // Clear the value in the record with key PN_DELIVERY_CTX
             //
@@ -1053,9 +1162,10 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
             // will only happen if the size of the message content is an exact multiple
             // of the buffer size.
             //
-
-            if (qd_buffer_size(buf) == 0) {
+            if (buf && qd_buffer_size(buf) == 0) {
+                sys_mutex_lock(msg->content->lock);
                 DEQ_REMOVE_TAIL(msg->content->buffers);
+                sys_mutex_unlock(msg->content->lock);
                 qd_buffer_free(buf);
             }
 
@@ -1063,6 +1173,8 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
         }
 
         if (rc > 0) {
+            if (discard)
+                continue;
             //
             // We have received a positive number of bytes for the message.  Advance
             // the cursor in the buffer.
@@ -1073,17 +1185,21 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
             // If the buffer is full, allocate a new empty buffer and append it to the
             // tail of the message's list.
             //
+            sys_mutex_lock(msg->content->lock);
             if (qd_buffer_capacity(buf) == 0) {
                 buf = qd_buffer();
                 DEQ_INSERT_TAIL(msg->content->buffers, buf);
             }
+            sys_mutex_unlock(msg->content->lock);
+
         } else
             //
             // We received zero bytes, and no PN_EOS.  This means that we've received
             // all of the data available up to this point, but it does not constitute
             // the entire message.  We'll be back later to finish it up.
+            // Return the message so that the caller can start sending out whatever we have received so far
             //
-            break;
+            return (qd_message_t*) msg;
     }
 
     return 0;
@@ -1226,98 +1342,160 @@ void qd_message_send(qd_message_t *in_msg,
 {
     qd_message_pvt_t     *msg     = (qd_message_pvt_t*) in_msg;
     qd_message_content_t *content = msg->content;
-    qd_buffer_t          *buf     = DEQ_HEAD(content->buffers);
-    unsigned char        *cursor;
+    qd_buffer_t          *buf     = 0;
     pn_link_t            *pnl     = qd_link_pn(link);
 
-    qd_buffer_list_t new_ma;
-    qd_buffer_list_t new_ma_trailer;
-    DEQ_INIT(new_ma);
-    DEQ_INIT(new_ma_trailer);
+    int                  fanout   = qd_message_fanout(in_msg);
 
-    // Process  the message annotations if any
-    compose_message_annotations(msg, &new_ma, &new_ma_trailer, strip_annotations);
+    if (msg->sent_depth < QD_DEPTH_MESSAGE_ANNOTATIONS) {
 
-    //
-    // Send header if present
-    //
-    cursor = qd_buffer_base(buf);
-    if (content->section_message_header.length > 0) {
-        buf    = content->section_message_header.buffer;
-        cursor = content->section_message_header.offset + qd_buffer_base(buf);
-        advance(&cursor, &buf,
-                content->section_message_header.length + content->section_message_header.hdr_length,
-                send_handler, (void*) pnl);
+        qd_buffer_list_t new_ma;
+        qd_buffer_list_t new_ma_trailer;
+        DEQ_INIT(new_ma);
+        DEQ_INIT(new_ma_trailer);
+
+        // Process  the message annotations if any
+        compose_message_annotations(msg, &new_ma, &new_ma_trailer, strip_annotations);
+
+        //
+        // Start with the very first buffer;
+        //
+        buf = DEQ_HEAD(content->buffers);
+
+
+        //
+        // Send header if present
+        //
+        unsigned char *cursor = qd_buffer_base(buf);
+        int header_consume = content->section_message_header.length + content->section_message_header.hdr_length;
+        if (content->section_message_header.length > 0) {
+            buf    = content->section_message_header.buffer;
+            cursor = content->section_message_header.offset + qd_buffer_base(buf);
+            advance(&cursor, &buf, header_consume, send_handler, (void*) pnl);
+        }
+
+        //
+        // Send delivery annotation if present
+        //
+        int da_consume = content->section_delivery_annotation.length + content->section_delivery_annotation.hdr_length;
+        if (content->section_delivery_annotation.length > 0) {
+            buf    = content->section_delivery_annotation.buffer;
+            cursor = content->section_delivery_annotation.offset + qd_buffer_base(buf);
+            advance(&cursor, &buf, da_consume, send_handler, (void*) pnl);
+        }
+
+        //
+        // Send new message annotations map start if any
+        //
+        qd_buffer_t *da_buf = DEQ_HEAD(new_ma);
+        while (da_buf) {
+            char *to_send = (char*) qd_buffer_base(da_buf);
+            pn_link_send(pnl, to_send, qd_buffer_size(da_buf));
+            da_buf = DEQ_NEXT(da_buf);
+        }
+        qd_buffer_list_free_buffers(&new_ma);
+
+        //
+        // Annotations possibly include an opaque blob of user annotations
+        //
+        if (content->field_user_annotations.length > 0) {
+            qd_buffer_t *buf2      = content->field_user_annotations.buffer;
+            unsigned char *cursor2 = content->field_user_annotations.offset + qd_buffer_base(buf);
+            advance(&cursor2, &buf2,
+                    content->field_user_annotations.length,
+                    send_handler, (void*) pnl);
+        }
+
+        //
+        // Annotations may include the v1 new_ma_trailer
+        //
+        qd_buffer_t *ta_buf = DEQ_HEAD(new_ma_trailer);
+        while (ta_buf) {
+            char *to_send = (char*) qd_buffer_base(ta_buf);
+            pn_link_send(pnl, to_send, qd_buffer_size(ta_buf));
+            ta_buf = DEQ_NEXT(ta_buf);
+        }
+        qd_buffer_list_free_buffers(&new_ma_trailer);
+
+
+        //
+        // Skip over replaced message annotations
+        //
+        int ma_consume = content->section_message_annotation.hdr_length + content->section_message_annotation.length;
+        if (content->section_message_annotation.length > 0)
+            advance(&cursor, &buf, ma_consume, 0, 0);
+
+
+        msg->cursor.buffer = buf;
+
+        //
+        // If this message has no header and no delivery annotations and no message annotations, set the offset to 0.
+        //
+        if (header_consume == 0 && da_consume == 0 && ma_consume ==0)
+            msg->cursor.offset = 0;
+        else
+            msg->cursor.offset = cursor - qd_buffer_base(buf);
+
+        msg->sent_depth = QD_DEPTH_MESSAGE_ANNOTATIONS;
+
     }
 
-    //
-    // Send delivery annotation if present
-    //
-    if (content->section_delivery_annotation.length > 0) {
-        buf    = content->section_delivery_annotation.buffer;
-        cursor = content->section_delivery_annotation.offset + qd_buffer_base(buf);
-        advance(&cursor, &buf,
-                content->section_delivery_annotation.length + content->section_delivery_annotation.hdr_length,
-                send_handler, (void*) pnl);
-    }
+    buf = msg->cursor.buffer;
 
-    //
-    // Send new message annotations map start if any
-    //
-    qd_buffer_t *da_buf = DEQ_HEAD(new_ma);
-    while (da_buf) {
-        char *to_send = (char*) qd_buffer_base(da_buf);
-        pn_link_send(pnl, to_send, qd_buffer_size(da_buf));
-        da_buf = DEQ_NEXT(da_buf);
-    }
-    qd_buffer_list_free_buffers(&new_ma);
-
-    //
-    // Annotations possibly include an opaque blob of user annotations
-    //
-    if (content->field_user_annotations.length > 0) {
-        qd_buffer_t *buf2      = content->field_user_annotations.buffer;
-        unsigned char *cursor2 = content->field_user_annotations.offset + qd_buffer_base(buf);
-        advance(&cursor2, &buf2,
-                content->field_user_annotations.length,
-                send_handler, (void*) pnl);
-    }
-
-    //
-    // Annotations may include the v1 new_ma_trailer
-    //
-    qd_buffer_t *ta_buf = DEQ_HEAD(new_ma_trailer);
-    while (ta_buf) {
-        char *to_send = (char*) qd_buffer_base(ta_buf);
-        pn_link_send(pnl, to_send, qd_buffer_size(ta_buf));
-        ta_buf = DEQ_NEXT(ta_buf);
-    }
-    qd_buffer_list_free_buffers(&new_ma_trailer);
-
-
-    //
-    // Skip over replaced message annotations
-    //
-    if (content->section_message_annotation.length > 0)
-        advance(&cursor, &buf,
-                content->section_message_annotation.hdr_length + content->section_message_annotation.length,
-                0, 0);
-
-    //
-    // Send remaining partial buffer
-    //
-    if (buf) {
-        size_t len = qd_buffer_size(buf) - (cursor - qd_buffer_base(buf));
-        advance(&cursor, &buf, len, send_handler, (void*) pnl);
-    }
-
-    // Fall through to process the remaining buffers normally
-    // Note that 'advance' will have moved us to the next buffer in the chain.
-
+    if (!buf)
+        return;
 
     while (buf) {
-        pn_link_send(pnl, (char*) qd_buffer_base(buf), qd_buffer_size(buf));
-        buf = DEQ_NEXT(buf);
+        size_t buf_size = qd_buffer_size(buf);
+
+        // This will send the remaining data in the buffer if any.
+        int num_bytes_to_send = buf_size - msg->cursor.offset;
+        if (num_bytes_to_send > 0)
+            pn_link_send(pnl, (char*) qd_buffer_at(buf, msg->cursor.offset), num_bytes_to_send);
+
+        // If the entire message has already been received,  taking out this lock is not that expensive
+        // because there is no contention for this lock.
+        sys_mutex_lock(msg->content->lock);
+
+        qd_buffer_t *next_buf = DEQ_NEXT(buf);
+        if (next_buf) {
+            // There is a next buffer, the previous buffer has been fully sent by now.
+            qd_buffer_add_fanout(buf);
+            if (fanout == qd_buffer_fanout(buf)) {
+                qd_buffer_t *local_buf = DEQ_HEAD(content->buffers);
+                while (local_buf && local_buf != next_buf) {
+                    DEQ_REMOVE_HEAD(content->buffers);
+                    qd_buffer_free(local_buf);
+                    local_buf = DEQ_HEAD(content->buffers);
+                }
+            }
+            msg->cursor.buffer = next_buf;
+            msg->cursor.offset = 0;
+        }
+        else {
+            if (qd_message_receive_complete(in_msg)) {
+                //
+                // There is no next_buf and there is no more of the message coming, this means
+                // that we have completely sent out the message.
+                //
+                msg->send_complete = true;
+                msg->cursor.buffer = 0;
+                msg->cursor.offset = 0;
+
+            }
+            else {
+                //
+                // There is more of the message to come, update your cursor pointers
+                // you will come back into this function to deliver more as bytes arrive
+                //
+                msg->cursor.buffer = buf;
+                msg->cursor.offset = buf_size;
+            }
+        }
+
+        sys_mutex_unlock(msg->content->lock);
+
+        buf = next_buf;
     }
 }
 
@@ -1546,6 +1724,7 @@ void qd_message_compose_1(qd_message_t *msg, const char *to, qd_buffer_list_t *b
 {
     qd_composed_field_t  *field   = qd_compose(QD_PERFORMATIVE_HEADER, 0);
     qd_message_content_t *content = MSG_CONTENT(msg);
+    content->receive_complete     = true;
 
     qd_compose_start_list(field);
     qd_compose_insert_bool(field, 0);     // durable
@@ -1594,6 +1773,8 @@ void qd_message_compose_1(qd_message_t *msg, const char *to, qd_buffer_list_t *b
 void qd_message_compose_2(qd_message_t *msg, qd_composed_field_t *field)
 {
     qd_message_content_t *content       = MSG_CONTENT(msg);
+    content->receive_complete     = true;
+
     qd_buffer_list_t     *field_buffers = qd_compose_buffers(field);
 
     content->buffers = *field_buffers;
@@ -1604,6 +1785,7 @@ void qd_message_compose_2(qd_message_t *msg, qd_composed_field_t *field)
 void qd_message_compose_3(qd_message_t *msg, qd_composed_field_t *field1, qd_composed_field_t *field2)
 {
     qd_message_content_t *content        = MSG_CONTENT(msg);
+    content->receive_complete     = true;
     qd_buffer_list_t     *field1_buffers = qd_compose_buffers(field1);
     qd_buffer_list_t     *field2_buffers = qd_compose_buffers(field2);
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -110,12 +110,12 @@ typedef struct {
 
     bool                 discard;                        // Should this message be discarded?
     bool                 receive_complete;               // true if the message has been completely received, false otherwise
-    unsigned int         fanout;                         // The number of receivers for this message. This number does not include in-process subscribers.
+    sys_atomic_t         fanout;                         // The number of receivers for this message. This number does not include in-process subscribers.
 } qd_message_content_t;
 
 typedef struct {
     DEQ_LINKS(qd_message_t);   // Deque linkage that overlays the qd_message_t
-    qd_field_location_t   cursor;          // A pointer to the current location of the outgoing byte stream.
+    qd_iterator_pointer_t cursor;          // A pointer to the current location of the outgoing byte stream.
     qd_message_depth_t    message_depth;   // What is the depth of the message that has been received so far
     qd_message_depth_t    sent_depth;      // How much of the message has been sent?  QD_DEPTH_NONE means nothing has been sent so far, QD_DEPTH_HEADER means the header has already been sent, dont send it again and so on.
     bool                  send_complete;   // Has the message been completely received and completely sent?
@@ -136,7 +136,7 @@ ALLOC_DECLARE(qd_message_content_t);
 /** Initialize logging */
 void qd_message_initialize();
 
-qd_field_location_t qd_message_cursor(qd_message_pvt_t *msg);
+qd_iterator_pointer_t qd_message_cursor(qd_message_pvt_t *msg);
 
 ///@}
 

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -238,6 +238,7 @@ int qdr_connection_process(qdr_connection_t *conn)
         if (ref) {
             link = ref->link;
             qdr_del_link_ref(&conn->links_with_work, ref->link, QDR_LINK_LIST_CLASS_WORK);
+
             link_work = DEQ_HEAD(link->work_list);
             if (link_work) {
                 DEQ_REMOVE_HEAD(link->work_list);
@@ -611,11 +612,13 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
     qdr_delivery_ref_list_t updated_deliveries;
     qdr_delivery_list_t     undelivered;
     qdr_delivery_list_t     unsettled;
+    qdr_delivery_list_t     settled;
     qdr_link_work_list_t    work_list;
 
     sys_mutex_lock(conn->work_lock);
     DEQ_MOVE(link->work_list, work_list);
     DEQ_MOVE(link->updated_deliveries, updated_deliveries);
+
     DEQ_MOVE(link->undelivered, undelivered);
     qdr_delivery_t *d = DEQ_HEAD(undelivered);
     while (d) {
@@ -628,6 +631,14 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
     d = DEQ_HEAD(unsettled);
     while (d) {
         assert(d->where == QDR_DELIVERY_IN_UNSETTLED);
+        d->where = QDR_DELIVERY_NOWHERE;
+        d = DEQ_NEXT(d);
+    }
+
+    DEQ_MOVE(link->settled, settled);
+    d = DEQ_HEAD(settled);
+    while (d) {
+        assert(d->where == QDR_DELIVERY_IN_SETTLED);
         d->where = QDR_DELIVERY_NOWHERE;
         d = DEQ_NEXT(d);
     }
@@ -734,6 +745,31 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
         qdr_delivery_decref_CT(core, dlv);
 
         dlv = DEQ_HEAD(unsettled);
+    }
+
+    //Free/unlink/decref the settled deliveries.
+    dlv = DEQ_HEAD(settled);
+    while (dlv) {
+        DEQ_REMOVE_HEAD(settled);
+        peer = qdr_delivery_first_peer_CT(dlv);
+        qdr_delivery_t *next_peer = 0;
+        while (peer) {
+            next_peer = qdr_delivery_next_peer_CT(dlv);
+            qdr_delivery_unlink_peers_CT(core, dlv, peer);
+            peer = next_peer;
+        }
+
+        //
+        // Account for the lost reference from the Proton delivery
+        //
+        if (!dlv->cleared_proton_ref) {
+            dlv->cleared_proton_ref = true;
+            qdr_delivery_decref_CT(core, dlv);
+        }
+
+        // This decref is for the removing the delivery from the settled list
+        qdr_delivery_decref_CT(core, dlv);
+        dlv = DEQ_HEAD(settled);
     }
 
     //

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -755,6 +755,7 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
         qdr_delivery_t *next_peer = 0;
         while (peer) {
             next_peer = qdr_delivery_next_peer_CT(dlv);
+            printf("refcount peer - %p - %i\n", (void *)peer, peer->ref_count);
             qdr_delivery_unlink_peers_CT(core, dlv, peer);
             peer = next_peer;
         }

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -253,8 +253,7 @@ int qdr_forward_multicast_CT(qdr_core_t      *core,
     //        implemented in the future.
     //
     if (!presettled) {
-            if (receive_complete)
-                in_delivery->settled = true;
+        in_delivery->settled = true;
         //
         // If the router is configured to reject unsettled multicasts, settle and reject this delivery.
         //

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -304,6 +304,15 @@ qdr_address_t *qdr_add_local_address_CT(qdr_core_t *core, char aclass, const cha
     return addr;
 }
 
+bool qdr_is_addr_treatment_multicast(qdr_address_t *addr)
+{
+    if (addr) {
+        if (addr->treatment == QD_TREATMENT_MULTICAST_FLOOD || addr->treatment == QD_TREATMENT_MULTICAST_ONCE)
+            return true;
+    }
+    return false;
+}
+
 void qdr_core_remove_address(qdr_core_t *core, qdr_address_t *addr)
 {
     // Remove the address from the list and hash index

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -490,7 +490,7 @@ struct qdr_address_config_t {
 ALLOC_DECLARE(qdr_address_config_t);
 DEQ_DECLARE(qdr_address_config_t, qdr_address_config_list_t);
 void qdr_core_remove_address_config(qdr_core_t *core, qdr_address_config_t *addr);
-
+bool qdr_is_addr_treatment_multicast(qdr_address_t *addr);
 
 //
 // Connection Information

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -434,7 +434,6 @@ static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
         pn_delivery_set_context(pnd, delivery);
         qdr_delivery_set_context(delivery, pnd);
         qdr_delivery_incref(delivery);
-
     } else {
         //
         // If there is no delivery, the message is now and will always be unroutable because there is no address.
@@ -482,6 +481,7 @@ static void AMQP_disposition_handler(void* context, qd_link_t *link, pn_delivery
     if (pn_delivery_settled(pnd)) {
         pn_delivery_set_context(pnd, 0);
         qdr_delivery_set_context(delivery, 0);
+        qdr_delivery_set_cleared_proton_ref(delivery, true);
 
         //
         // Don't decref the delivery here.  Rather, we will _give_ the reference to the core.
@@ -1137,6 +1137,7 @@ static void CORE_delivery_update(void *context, qdr_delivery_t *dlv, uint64_t di
         qdr_delivery_set_context(dlv, 0);
         pn_delivery_set_context(pnd, 0);
         pn_delivery_settle(pnd);
+        qdr_delivery_set_cleared_proton_ref(dlv, true);
         qdr_delivery_decref(router->router_core, dlv);
     }
 }


### PR DESCRIPTION
1. Added new core API function qdr_deliver_continue() that will continue
delivering a large message
2. Modified qdr_link_process_deliveries() to not remove deliveries from
the undelivered list until they are fully delivered
3. Modified qd_message_receive() to recieve partial messages.
4. Modified qd_message_send() to be able to handle streaming send. This
function can now be called multiple times for the same message. It keeps
internal pointers to the point upto which the message has been sent and
is able to continue where it left off. Message content buffers are freed
as soon as the message has been sent to all recipients.
5. Added peer linkage for large settled deliveries and added a settled
list to handle with abrupt connection terminations when large messages
are being transmitted.
6. Added unit tests to test large messages.