### PR TITLE
DISPATCH-737: Fix qdstat problems when only username and password are specified

### DIFF
--- a/python/qpid_dispatch/management/client.py
+++ b/python/qpid_dispatch/management/client.py
@@ -96,7 +96,7 @@ class Node(object):
                                   timeout=timeout,
                                   ssl_domain=ssl_domain,
                                   sasl_enabled=sasl_enabled,
-                                  allowed_mechs=str(sasl.mechs) if sasl else None,
+                                  allowed_mechs=str(sasl.mechs) if sasl and sasl.mechs != None else None,
                                   user=str(sasl.user) if sasl else None,
                                   password=str(sasl.password) if sasl else None)
 

--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -132,7 +132,9 @@ def opts_url(opts):
     return url
 
 def opts_sasl(opts):
-    mechs, user, password, sasl_password_file = opts.sasl_mechanisms, opts.sasl_username, opts.sasl_password, opts.sasl_password_file
+    url = Url(opts.bus)
+    mechs, user, password, sasl_password_file = opts.sasl_mechanisms, (opts.sasl_username or url.username), (opts.sasl_password or url.password), opts.sasl_password_file
+
     if not (mechs or user or password or sasl_password_file):
         return None
 


### PR DESCRIPTION
Tis fixes two issues:
- when username and password are specified in the URL they are ignored when evaluating whether SASL should be used
- When no SASL mechanism is specified the empty string passed to Proton is interpreted as "no mechs enabled". When None is used instead, Proton will select the suitable mechs automatically