### PR TITLE
DISPATCH-767 - Added code to support multi frame message streaming

### DIFF
--- a/include/qpid/dispatch/buffer.h
+++ b/include/qpid/dispatch/buffer.h
@@ -27,15 +27,19 @@
  */
 
 #include <qpid/dispatch/ctools.h>
+#include <qpid/dispatch/atomic.h>
 
 typedef struct qd_buffer_t qd_buffer_t;
 
 DEQ_DECLARE(qd_buffer_t, qd_buffer_list_t);
 
+extern size_t BUFFER_SIZE;
+
 /** A raw byte buffer .*/
 struct qd_buffer_t {
     DEQ_LINKS(qd_buffer_t);
     unsigned int size;          ///< Size of data content
+    sys_atomic_t bfanout;        // The number of receivers for this buffer
 };
 
 /**
@@ -116,6 +120,23 @@ void qd_buffer_list_free_buffers(qd_buffer_list_t *list);
  * @return total number of bytes of data in the buffer list
  */
 unsigned int qd_buffer_list_length(const qd_buffer_list_t *list);
+
+/*
+ * Increase the fanout by 1. How many receivers should this buffer be sent to.
+ */
+void qd_buffer_add_fanout(qd_buffer_t *buf);
+
+/**
+ * Return the buffer's fanout.
+ */
+size_t qd_buffer_fanout(qd_buffer_t *buf);
+
+/**
+ * Advance the buffer by len. Does not manipulate the contents of the buffer
+ * @param buf A pointer to an allocated buffer
+ * @param len The number of octets that by which the buffer should be advanced.
+ */
+unsigned char *qd_buffer_at(qd_buffer_t *buf, size_t len);
 
 
 ///@}

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -201,9 +201,9 @@ int  qd_message_get_phase_annotation(const qd_message_t *msg);
 void qd_message_set_ingress_annotation(qd_message_t *msg, qd_composed_field_t *ingress_field);
 
 /**
- * Receive message data via a delivery.  This function may be called more than once on the same
- * delivery if the message spans multiple frames.  Once a complete message has been received, this
- * function shall return the message.
+ * Receive message data frame by frame via a delivery.  This function may be called more than once on the same
+ * delivery if the message spans multiple frames. Always returns a message. The message buffers are filled up to the point with the data that was been received so far.
+ * The buffer keeps filling up on successive calls to this function.
  *
  * @param delivery An incoming delivery from a link
  * @return A pointer to the complete message or 0 if the message is not yet complete.
@@ -295,6 +295,61 @@ qd_parsed_field_t *qd_message_get_trace      (qd_message_t *msg);
  * @return the phase as an integer
  */
 int                qd_message_get_phase_val  (qd_message_t *msg);
+
+/*
+ * Should the message be discarded.
+ * A message can be discarded if the disposition is released or rejected.
+ *
+ * @param msg A pointer to the message.
+ **/
+bool qd_message_is_discard(qd_message_t *msg);
+
+/**
+ *Set the discard field on the message to to the passed in boolean value.
+ *
+ * @param msg A pointer to the message.
+ * @param discard - the boolean value of discard.
+ */
+void qd_message_set_discard(qd_message_t *msg, bool discard);
+
+/**
+ * Has the message been completely received?
+ * Return true if the message is fully received
+ * Returns false if only the partial message has been received, if there is more of the message to be received.
+ *
+ * @param msg A pointer to the message.
+ */
+bool qd_message_receive_complete(qd_message_t *msg);
+
+/**
+ * Returns true if the message has been completely received AND the message has been completely sent.
+ */
+bool qd_message_send_complete(qd_message_t *msg);
+
+/**
+ * Returns true if the delivery tag has already been sent.
+ */
+bool qd_message_tag_sent(qd_message_t *msg);
+
+
+/**
+ * Sets if the delivery tag has already been sent out or not.
+ */
+void qd_message_set_tag_sent(qd_message_t *msg, bool tag_sent);
+
+/**
+ * Get the number of receivers for this message.
+ *
+ * @param msg A pointer to the message.
+ */
+size_t qd_message_fanout(qd_message_t *msg);
+
+/**
+ * Increase the fanout of the message by 1.
+ *
+ * @param msg A pointer to the message.
+ */
+void qd_message_add_fanout(qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -541,8 +541,9 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
 qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *msg, bool settled,
                                                 const uint8_t *tag, int tag_length,
                                                 uint64_t disposition, pn_data_t* disposition_state);
+qdr_delivery_t *qdr_deliver_continue(qdr_delivery_t *delivery);
 
-void qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit);
+int qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit);
 
 void qdr_link_flow(qdr_core_t *core, qdr_link_t *link, int credit, bool drain_mode);
 
@@ -589,6 +590,11 @@ void qdr_delivery_tag(const qdr_delivery_t *delivery, const char **tag, int *len
 qd_message_t *qdr_delivery_message(const qdr_delivery_t *delivery);
 qdr_error_t *qdr_delivery_error(const qdr_delivery_t *delivery);
 void qdr_delivery_write_extension_state(qdr_delivery_t *dlv, pn_delivery_t* pdlv, bool update_disposition);
+bool qdr_delivery_send_complete(const qdr_delivery_t *delivery);
+bool qdr_delivery_tag_sent(const qdr_delivery_t *delivery);
+void qdr_delivery_set_tag_sent(const qdr_delivery_t *delivery, bool tag_sent);
+bool qdr_delivery_receive_complete(const qdr_delivery_t *delivery);
+void qdr_delivery_set_cleared_proton_ref(qdr_delivery_t *dlv, bool cleared_proton_ref);
 
 /**
  ******************************************************************************

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -24,17 +24,18 @@
 #include <string.h>
 
 
-static size_t buffer_size = 512;
-static int    size_locked = 0;
+size_t BUFFER_SIZE                 = 512;
+
+static int size_locked = 0;
 
 ALLOC_DECLARE(qd_buffer_t);
-ALLOC_DEFINE_CONFIG(qd_buffer_t, sizeof(qd_buffer_t), &buffer_size, 0);
+ALLOC_DEFINE_CONFIG(qd_buffer_t, sizeof(qd_buffer_t), &BUFFER_SIZE, 0);
 
 
 void qd_buffer_set_size(size_t size)
 {
     assert(!size_locked);
-    buffer_size = size;
+    BUFFER_SIZE = size;
 }
 
 
@@ -44,7 +45,8 @@ qd_buffer_t *qd_buffer(void)
     qd_buffer_t *buf = new_qd_buffer_t();
 
     DEQ_ITEM_INIT(buf);
-    buf->size = 0;
+    buf->size   = 0;
+    sys_atomic_init(&buf->bfanout, 0);
     return buf;
 }
 
@@ -70,7 +72,7 @@ unsigned char *qd_buffer_cursor(qd_buffer_t *buf)
 
 size_t qd_buffer_capacity(qd_buffer_t *buf)
 {
-    return buffer_size - buf->size;
+    return BUFFER_SIZE - buf->size;
 }
 
 
@@ -83,7 +85,26 @@ size_t qd_buffer_size(qd_buffer_t *buf)
 void qd_buffer_insert(qd_buffer_t *buf, size_t len)
 {
     buf->size += len;
-    assert(buf->size <= buffer_size);
+    assert(buf->size <= BUFFER_SIZE);
+}
+
+void qd_buffer_add_fanout(qd_buffer_t *buf)
+{
+    sys_atomic_inc(&buf->bfanout);
+}
+
+size_t qd_buffer_fanout(qd_buffer_t *buf)
+{
+    return buf->bfanout;
+}
+
+
+unsigned char *qd_buffer_at(qd_buffer_t *buf, size_t len)
+{
+    // If the len is greater than the buffer size, we might point to some garbage.
+    // We dont want that to happen, so do the assert.
+    assert(len <= BUFFER_SIZE);
+    return ((unsigned char*) &buf[1]) + len;
 }
 
 unsigned int qd_buffer_list_clone(qd_buffer_list_t *dst, const qd_buffer_list_t *src)

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -94,7 +94,6 @@ typedef struct {
     qd_buffer_t         *parse_buffer;
     unsigned char       *parse_cursor;
     qd_message_depth_t   parse_depth;
-
     bool                 ma_parsed;                       // have parsed annotations in incoming message
     qd_iterator_t       *ma_field_iter_in;                // 'message field iterator' for msg.FIELD_MESSAGE_ANNOTATION
 
@@ -107,11 +106,21 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
+    //qd_parsed_field_t   *parsed_message_annotations;
+
+    bool                 discard;                        // Should this message be discarded?
+    bool                 receive_complete;               // true if the message has been completely received, false otherwise
+    sys_atomic_t         fanout;                         // The number of receivers for this message. This number does not include in-process subscribers.
 } qd_message_content_t;
 
 typedef struct {
     DEQ_LINKS(qd_message_t);   // Deque linkage that overlays the qd_message_t
-    qd_message_content_t *content;
+    qd_iterator_pointer_t cursor;          // A pointer to the current location of the outgoing byte stream.
+    qd_message_depth_t    message_depth;   // What is the depth of the message that has been received so far
+    qd_message_depth_t    sent_depth;      // How much of the message has been sent?  QD_DEPTH_NONE means nothing has been sent so far, QD_DEPTH_HEADER means the header has already been sent, dont send it again and so on.
+    bool                  send_complete;   // Has the message been completely received and completely sent?
+    bool                  tag_sent;        // Tags are sent
+    qd_message_content_t *content;         // The actual content of the message. The content is never copied
     qd_buffer_list_t      ma_to_override;  // to field in outgoing message annotations.
     qd_buffer_list_t      ma_trace;        // trace list in outgoing message annotations
     qd_buffer_list_t      ma_ingress;      // ingress field in outgoing message annotations
@@ -126,6 +135,8 @@ ALLOC_DECLARE(qd_message_content_t);
 
 /** Initialize logging */
 void qd_message_initialize();
+
+qd_iterator_pointer_t qd_message_cursor(qd_message_pvt_t *msg);
 
 ///@}
 

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -238,6 +238,7 @@ int qdr_connection_process(qdr_connection_t *conn)
         if (ref) {
             link = ref->link;
             qdr_del_link_ref(&conn->links_with_work, ref->link, QDR_LINK_LIST_CLASS_WORK);
+
             link_work = DEQ_HEAD(link->work_list);
             if (link_work) {
                 DEQ_REMOVE_HEAD(link->work_list);
@@ -611,11 +612,13 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
     qdr_delivery_ref_list_t updated_deliveries;
     qdr_delivery_list_t     undelivered;
     qdr_delivery_list_t     unsettled;
+    qdr_delivery_list_t     settled;
     qdr_link_work_list_t    work_list;
 
     sys_mutex_lock(conn->work_lock);
     DEQ_MOVE(link->work_list, work_list);
     DEQ_MOVE(link->updated_deliveries, updated_deliveries);
+
     DEQ_MOVE(link->undelivered, undelivered);
     qdr_delivery_t *d = DEQ_HEAD(undelivered);
     while (d) {
@@ -628,6 +631,14 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
     d = DEQ_HEAD(unsettled);
     while (d) {
         assert(d->where == QDR_DELIVERY_IN_UNSETTLED);
+        d->where = QDR_DELIVERY_NOWHERE;
+        d = DEQ_NEXT(d);
+    }
+
+    DEQ_MOVE(link->settled, settled);
+    d = DEQ_HEAD(settled);
+    while (d) {
+        assert(d->where == QDR_DELIVERY_IN_SETTLED);
         d->where = QDR_DELIVERY_NOWHERE;
         d = DEQ_NEXT(d);
     }
@@ -734,6 +745,32 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
         qdr_delivery_decref_CT(core, dlv);
 
         dlv = DEQ_HEAD(unsettled);
+    }
+
+    //Free/unlink/decref the settled deliveries.
+    dlv = DEQ_HEAD(settled);
+    while (dlv) {
+        DEQ_REMOVE_HEAD(settled);
+        peer = qdr_delivery_first_peer_CT(dlv);
+        qdr_delivery_t *next_peer = 0;
+        while (peer) {
+            next_peer = qdr_delivery_next_peer_CT(dlv);
+            printf("refcount peer - %p - %i\n", (void *)peer, peer->ref_count);
+            qdr_delivery_unlink_peers_CT(core, dlv, peer);
+            peer = next_peer;
+        }
+
+        //
+        // Account for the lost reference from the Proton delivery
+        //
+        if (!dlv->cleared_proton_ref) {
+            dlv->cleared_proton_ref = true;
+            qdr_delivery_decref_CT(core, dlv);
+        }
+
+        // This decref is for the removing the delivery from the settled list
+        qdr_delivery_decref_CT(core, dlv);
+        dlv = DEQ_HEAD(settled);
     }
 
     //

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -304,6 +304,15 @@ qdr_address_t *qdr_add_local_address_CT(qdr_core_t *core, char aclass, const cha
     return addr;
 }
 
+bool qdr_is_addr_treatment_multicast(qdr_address_t *addr)
+{
+    if (addr) {
+        if (addr->treatment == QD_TREATMENT_MULTICAST_FLOOD || addr->treatment == QD_TREATMENT_MULTICAST_ONCE)
+            return true;
+    }
+    return false;
+}
+
 void qdr_core_remove_address(qdr_core_t *core, qdr_address_t *addr)
 {
     // Remove the address from the list and hash index

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -300,7 +300,8 @@ DEQ_DECLARE(qdr_router_ref_t, qdr_router_ref_list_t);
 typedef enum {
     QDR_DELIVERY_NOWHERE = 0,
     QDR_DELIVERY_IN_UNDELIVERED,
-    QDR_DELIVERY_IN_UNSETTLED
+    QDR_DELIVERY_IN_UNSETTLED,
+    QDR_DELIVERY_IN_SETTLED
 } qdr_delivery_where_t;
 
 typedef struct qdr_delivery_ref_t {
@@ -310,6 +311,17 @@ typedef struct qdr_delivery_ref_t {
 
 ALLOC_DECLARE(qdr_delivery_ref_t);
 DEQ_DECLARE(qdr_delivery_ref_t, qdr_delivery_ref_list_t);
+
+struct qdr_subscription_t {
+    DEQ_LINKS(qdr_subscription_t);
+    qdr_core_t    *core;
+    qdr_address_t *addr;
+    qdr_receive_t  on_message;
+    void          *on_message_context;
+};
+
+DEQ_DECLARE(qdr_subscription_t, qdr_subscription_list_t);
+
 
 struct qdr_delivery_t {
     DEQ_LINKS(qdr_delivery_t);
@@ -334,6 +346,7 @@ struct qdr_delivery_t {
     qdr_address_t          *tracking_addr;
     int                     tracking_addr_bit;
     qdr_link_work_t        *link_work;         ///< Delivery work item for this delivery
+    qdr_subscription_list_t subscriptions;
     qdr_delivery_ref_list_t peers;             /// Use this list if there if the delivery has more than one peer.
 
 };
@@ -375,6 +388,7 @@ struct qdr_link_t {
     qdr_auto_link_t         *auto_link;          ///< [ref] Auto_link that owns this link
     qdr_delivery_list_t      undelivered;        ///< Deliveries to be forwarded or sent
     qdr_delivery_list_t      unsettled;          ///< Unsettled deliveries
+    qdr_delivery_list_t      settled;            ///< Settled deliveries
     qdr_delivery_ref_list_t  updated_deliveries; ///< References to deliveries (in the unsettled list) with updates.
     bool                     admin_enabled;
     qdr_link_oper_status_t   oper_status;
@@ -418,18 +432,6 @@ DEQ_DECLARE(qdr_connection_ref_t, qdr_connection_ref_list_t);
 
 void qdr_add_connection_ref(qdr_connection_ref_list_t *ref_list, qdr_connection_t *conn);
 void qdr_del_connection_ref(qdr_connection_ref_list_t *ref_list, qdr_connection_t *conn);
-
-
-struct qdr_subscription_t {
-    DEQ_LINKS(qdr_subscription_t);
-    qdr_core_t    *core;
-    qdr_address_t *addr;
-    qdr_receive_t  on_message;
-    void          *on_message_context;
-};
-
-DEQ_DECLARE(qdr_subscription_t, qdr_subscription_list_t);
-
 
 struct qdr_address_t {
     DEQ_LINKS(qdr_address_t);
@@ -488,7 +490,7 @@ struct qdr_address_config_t {
 ALLOC_DECLARE(qdr_address_config_t);
 DEQ_DECLARE(qdr_address_config_t, qdr_address_config_list_t);
 void qdr_core_remove_address_config(qdr_core_t *core, qdr_address_config_t *addr);
-
+bool qdr_is_addr_treatment_multicast(qdr_address_t *addr);
 
 //
 // Connection Information
@@ -697,6 +699,7 @@ void qdr_delivery_release_CT(qdr_core_t *core, qdr_delivery_t *delivery);
 void qdr_delivery_failed_CT(qdr_core_t *core, qdr_delivery_t *delivery);
 bool qdr_delivery_settled_CT(qdr_core_t *core, qdr_delivery_t *delivery);
 void qdr_delivery_decref_CT(qdr_core_t *core, qdr_delivery_t *delivery);
+void qdr_forward_on_message_CT(qdr_core_t *core, qdr_subscription_t *sub, qdr_link_t *link, qd_message_t *msg);
 
 /**
  * Links the in_dlv to the out_dlv and increments ref counts of both deliveries

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -26,6 +26,7 @@ static void qdr_link_flow_CT(qdr_core_t *core, qdr_action_t *action, bool discar
 static void qdr_send_to_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 static void qdr_update_delivery_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 static void qdr_delete_delivery_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
+static void qdr_deliver_continue_CT(qdr_core_t *core, qdr_action_t *action, bool discard);
 
 //==================================================================================
 // Internal Functions
@@ -114,40 +115,82 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
 }
 
 
-void qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit)
+qdr_delivery_t *qdr_deliver_continue(qdr_delivery_t *in_dlv)
+{
+    qdr_action_t   *action = qdr_action(qdr_deliver_continue_CT, "deliver_continue");
+    action->args.connection.delivery = in_dlv;
+
+    // This incref is for the action reference
+    qdr_delivery_incref(in_dlv);
+    qdr_action_enqueue(in_dlv->link->core, action);
+    return in_dlv;
+}
+
+
+int qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit)
 {
     qdr_connection_t *conn = link->conn;
     qdr_delivery_t   *dlv;
     bool              drained = false;
     int               offer   = -1;
     bool              settled = false;
+    bool              send_complete = false;
+    int               num_deliveries_completed = 0;
 
     if (link->link_direction == QD_OUTGOING) {
         while (credit > 0 && !drained) {
             sys_mutex_lock(conn->work_lock);
             dlv = DEQ_HEAD(link->undelivered);
-            if (dlv) {
-                DEQ_REMOVE_HEAD(link->undelivered);
-                dlv->link_work = 0;
-                settled = dlv->settled;
-                if (!settled) {
-                    DEQ_INSERT_TAIL(link->unsettled, dlv);
-                    dlv->where = QDR_DELIVERY_IN_UNSETTLED;
-                } else
-                    dlv->where = QDR_DELIVERY_NOWHERE;
-
-                credit--;
-                link->total_deliveries++;
-                offer = DEQ_SIZE(link->undelivered);
-            } else
-                drained = true;
             sys_mutex_unlock(conn->work_lock);
-
             if (dlv) {
-                link->credit_to_core--;
+                settled = dlv->settled;
                 core->deliver_handler(core->user_context, link, dlv, settled);
-                if (settled)
-                    qdr_delivery_decref(core, dlv);
+                sys_mutex_lock(conn->work_lock);
+                send_complete = qdr_delivery_send_complete(dlv);
+                if (send_complete) {
+                    //
+                    // The entire message has been sent. It is now the appropriate time to have the delivery removed
+                    // from the head of the undelivered list and move it to the unsettled list if it is not settled.
+                    //
+                    DEQ_REMOVE_HEAD(link->undelivered);
+                    num_deliveries_completed ++;
+                    dlv->link_work = 0;
+
+                    if (settled) {
+                        dlv->where = QDR_DELIVERY_NOWHERE;
+
+                        // This decref is for removing this settled delivery from the undelivered list
+                        qdr_delivery_decref(core, dlv);
+
+                    } else {
+                        DEQ_INSERT_TAIL(link->unsettled, dlv);
+                        dlv->where = QDR_DELIVERY_IN_UNSETTLED;
+                    }
+
+                    credit--;
+                    link->credit_to_core--;
+                    link->total_deliveries++;
+                    offer = DEQ_SIZE(link->undelivered);
+                }
+                else {
+                    //
+                    // The message is still being received/sent.
+                    // 1. We cannot remove the delivery from the undelivered list.
+                    // This delivery needs to stay at the head of the undelivered list until the entire message has been sent out i.e other deliveries in the
+                    // undelivered list have to wait before this entire large delivery is sent out
+                    // 2. We need to call deliver_handler so any newly arrived bytes can be pushed out
+                    // 3. We need to break out of this loop otherwise a thread will keep spinning in here until the entire message has been sent out.
+                    //
+                    sys_mutex_unlock(conn->work_lock);
+
+                    //
+                    // Note here that we are not incrementing num_deliveries_processed. Since this delivery is still coming in or still being sent out,
+                    // we cannot consider this delivery as fully processed.
+                    //
+                    return num_deliveries_completed;
+                }
+                sys_mutex_unlock(conn->work_lock);
+
             }
         }
 
@@ -156,6 +199,8 @@ void qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit)
         else if (offer != -1)
             core->offer_handler(core->user_context, link, offer);
     }
+
+    return num_deliveries_completed;
 }
 
 
@@ -234,11 +279,48 @@ void qdr_delivery_set_context(qdr_delivery_t *delivery, void *context)
     delivery->context = context;
 }
 
+void qdr_delivery_set_cleared_proton_ref(qdr_delivery_t *dlv, bool cleared_proton_ref)
+{
+    dlv->cleared_proton_ref = cleared_proton_ref;
+}
+
 
 void *qdr_delivery_get_context(qdr_delivery_t *delivery)
 {
     return delivery->context;
 }
+
+
+bool qdr_delivery_send_complete(const qdr_delivery_t *delivery)
+{
+    if (!delivery)
+        return false;
+    return qd_message_send_complete(delivery->msg);
+}
+
+bool qdr_delivery_tag_sent(const qdr_delivery_t *delivery)
+{
+    if (!delivery)
+        return false;
+    return qd_message_tag_sent(delivery->msg);
+}
+
+void qdr_delivery_set_tag_sent(const qdr_delivery_t *delivery, bool tag_sent)
+{
+    if (!delivery)
+        return;
+
+    qd_message_set_tag_sent(delivery->msg, tag_sent);
+}
+
+
+bool qdr_delivery_receive_complete(const qdr_delivery_t *delivery)
+{
+    if (!delivery)
+        return false;
+    return qd_message_receive_complete(delivery->msg);
+}
+
 
 void qdr_delivery_incref(qdr_delivery_t *delivery)
 {
@@ -272,6 +354,8 @@ void qdr_delivery_tag(const qdr_delivery_t *delivery, const char **tag, int *len
 
 qd_message_t *qdr_delivery_message(const qdr_delivery_t *delivery)
 {
+    if (!delivery)
+        return 0;
     return delivery->msg;
 }
 
@@ -417,16 +501,25 @@ static void qdr_delete_delivery_internal_CT(qdr_core_t *core, qdr_delivery_t *de
             link->modified_deliveries++;
     }
 
+    //
+    // Free all the peer qdr_delivery_ref_t references
+    //
+    qdr_delivery_ref_t *ref = DEQ_HEAD(delivery->peers);
+    while (ref) {
+        qdr_del_delivery_ref(&delivery->peers, ref);
+        ref = DEQ_HEAD(delivery->peers);
+    }
+
     qd_bitmask_free(delivery->link_exclusion);
     qdr_error_free(delivery->error);
     free_qdr_delivery_t(delivery);
+
 }
 
 static bool qdr_delivery_has_peer_CT(qdr_delivery_t *dlv)
 {
     return dlv->peer || DEQ_SIZE(dlv->peers) > 0;
 }
-
 
 void qdr_delivery_link_peers_CT(qdr_delivery_t *in_dlv, qdr_delivery_t *out_dlv)
 {
@@ -466,17 +559,38 @@ void qdr_delivery_unlink_peers_CT(qdr_core_t *core, qdr_delivery_t *dlv, qdr_del
     // If there is no delivery or a peer, we cannot proceed.
     if (!dlv || !peer)
         return;
-    //
-    // Make sure that the passed in deliveries are indeed peers.
-    //
-    assert(dlv->peer == peer);
-    assert(peer->peer == dlv);
 
-    dlv->peer  = 0;
-    peer->peer = 0;
-
-    qdr_delivery_decref_CT(core, dlv);
-    qdr_delivery_decref_CT(core, peer);
+    if (dlv->peer) {
+        //
+        // This is the easy case. One delivery has only one peer. we can simply
+        // zero them out and directly decref.
+        //
+        assert(dlv->peer == peer);
+        dlv->peer  = 0;
+        peer->peer = 0;
+        qdr_delivery_decref_CT(core, dlv);
+        qdr_delivery_decref_CT(core, peer);
+    }
+    else {
+        //
+        // The dlv has more than one peer. We are going to find the peer of dlv that match with the passed in peer
+        // and delete that peer.
+        //
+        qdr_delivery_ref_t *dlv_ref = DEQ_HEAD(dlv->peers);
+        while (dlv_ref) {
+            qdr_delivery_t * peer_dlv = dlv_ref->dlv;
+            if (peer_dlv == peer) {
+                if (peer->peer)  {
+                    peer->peer = 0;
+                    qdr_delivery_decref_CT(core, dlv);
+                }
+                qdr_del_delivery_ref(&dlv->peers, dlv_ref);
+                qdr_delivery_decref_CT(core, peer);
+                break;
+            }
+            dlv_ref = DEQ_NEXT(dlv_ref);
+        }
+    }
 }
 
 
@@ -524,6 +638,7 @@ qdr_delivery_t *qdr_delivery_next_peer_CT(qdr_delivery_t *dlv)
 void qdr_delivery_decref_CT(qdr_core_t *core, qdr_delivery_t *dlv)
 {
     uint32_t ref_count = sys_atomic_dec(&dlv->ref_count);
+
     assert(ref_count > 0);
 
     if (ref_count == 1)
@@ -610,6 +725,7 @@ static long qdr_addr_path_count_CT(qdr_address_t *addr)
 
 static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery_t *dlv, qdr_address_t *addr)
 {
+    bool receive_complete = qd_message_receive_complete(qdr_delivery_message(dlv));
     if (addr && addr == link->owning_addr && qdr_addr_path_count_CT(addr) == 0) {
         //
         // We are trying to forward a delivery on an address that has no outbound paths
@@ -641,23 +757,48 @@ static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery
         //
         // If the delivery is not settled, release it.
         //
-        if (!dlv->settled)
+        if (!dlv->settled) {
             qdr_delivery_release_CT(core, dlv);
+
+            //
+            // Set the discard flag on the message only if the message is not completely received yet.
+            //
+            if (!receive_complete)
+                qd_message_set_discard(dlv->msg, true);
+        }
+
+        //
+        // Decrementing the delivery ref count for the action
+        //
         qdr_delivery_decref_CT(core, dlv);
         qdr_link_issue_credit_CT(core, link, 1, false);
     } else if (fanout > 0) {
-        if (dlv->settled) {
+        if (dlv->settled || qdr_is_addr_treatment_multicast(addr)) {
             //
             // The delivery is settled.  Keep it off the unsettled list and issue
             // replacement credit for it now.
             //
             qdr_link_issue_credit_CT(core, link, 1, false);
+            if (receive_complete) {
+                //
+                // This decref is for the action ref
+                //
+                qdr_delivery_decref_CT(core, dlv);
+            }
+            else {
+                //
+                // The message is still coming through since receive_complete is false. We have to put this delivery in the settled list.
+                // We need to do this because we have linked this delivery to a peer.
+                // If this connection goes down, we will have to unlink peer so that peer knows that its peer is not-existent anymore
+                // and need to tell the other side that the message has been aborted.
+                //
 
-            //
-            // If the delivery has no more references, free it now.
-            //
-            assert(!dlv->peer);
-            qdr_delivery_decref_CT(core, dlv);
+                //
+                // Again, don't bother decrementing then incrementing the ref_count, we are still using the action ref count
+                //
+                DEQ_INSERT_TAIL(link->settled, dlv);
+                dlv->where = QDR_DELIVERY_IN_SETTLED;
+            }
         } else {
             //
             // Again, don't bother decrementing then incrementing the ref_count
@@ -686,13 +827,15 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
     qdr_delivery_t *dlv  = action->args.connection.delivery;
     qdr_link_t     *link = dlv->link;
 
-    //
-    // If this is an attach-routed link, put the delivery directly onto the peer link
-    //
+
     if (link->connected_link) {
+        //
+        // If this is an attach-routed link, put the delivery directly onto the peer link
+        //
         qdr_delivery_t *peer = qdr_forward_new_delivery_CT(core, dlv, link->connected_link, dlv->msg);
 
         qdr_delivery_copy_extension_state(dlv, peer, true);
+
         //
         // Copy the delivery tag.  For link-routing, the delivery tag must be preserved.
         //
@@ -700,9 +843,9 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         memcpy(peer->tag, action->args.connection.tag, peer->tag_length);
 
         qdr_forward_deliver_CT(core, link->connected_link, peer);
-        qd_message_free(dlv->msg);
-        dlv->msg = 0;
+
         link->total_deliveries++;
+
         if (!dlv->settled) {
             DEQ_INSERT_TAIL(link->unsettled, dlv);
             dlv->where = QDR_DELIVERY_IN_UNSETTLED;
@@ -737,7 +880,7 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         }
 
         //
-        // Give the action reference to the qdr_link_forward function.
+        // Give the action reference to the qdr_link_forward function. Don't decref/incref.
         //
         qdr_link_forward_CT(core, link, dlv, addr);
     } else {
@@ -849,6 +992,99 @@ static void qdr_delete_delivery_CT(qdr_core_t *core, qdr_action_t *action, bool 
 {
     if (!discard)
         qdr_delete_delivery_internal_CT(core, action->args.delivery.delivery);
+}
+
+
+static void qdr_deliver_continue_peers_CT(qdr_core_t *core, qdr_delivery_t *in_dlv)
+{
+    qdr_delivery_t *peer = qdr_delivery_first_peer_CT(in_dlv);
+    while (peer) {
+        qdr_link_work_t *work = peer->link_work;
+        //
+        // Determines if the peer connection can be activated.
+        // For a large message, the peer delivery's link_work MUST be at the head of the peer link's work list. This link work is only removed
+        // after the streaming message has been sent.
+        //
+        if (work) {
+            sys_mutex_lock(peer->link->conn->work_lock);
+            if (work == DEQ_HEAD(peer->link->work_list)) {
+                qdr_add_link_ref(&peer->link->conn->links_with_work, peer->link, QDR_LINK_LIST_CLASS_WORK);
+                sys_mutex_unlock(peer->link->conn->work_lock);
+
+                //
+                // Activate the outgoing connection for later processing.
+                //
+                qdr_connection_activate_CT(core, peer->link->conn);
+            }
+            else {
+                sys_mutex_unlock(peer->link->conn->work_lock);
+
+            }
+        }
+
+        peer = qdr_delivery_next_peer_CT(in_dlv);
+    }
+}
+
+
+static void qdr_deliver_continue_CT(qdr_core_t *core, qdr_action_t *action, bool discard)
+{
+    if (discard)
+        return;
+
+    qdr_delivery_t *in_dlv  = action->args.connection.delivery;
+
+    // This decref is for the action reference
+    qdr_delivery_decref_CT(core, in_dlv);
+
+    //
+    // If it is already in the undelivered list or it has no peers, don't try to deliver this again.
+    //
+    if (in_dlv->where == QDR_DELIVERY_IN_UNDELIVERED || !qdr_delivery_has_peer_CT(in_dlv))
+        return;
+
+    qdr_deliver_continue_peers_CT(core, in_dlv);
+
+
+    if (qd_message_receive_complete(qdr_delivery_message(in_dlv))) {
+        //
+        // The entire message has now been received. Check to see if there are in process subscriptions that need to
+        // receive this message. in process subscriptions, at this time, can deal only with full messages.
+        //
+        qdr_subscription_t *sub = DEQ_HEAD(in_dlv->subscriptions);
+        while (sub) {
+            DEQ_REMOVE_HEAD(in_dlv->subscriptions);
+            qdr_forward_on_message_CT(core, sub, in_dlv ? in_dlv->link : 0, in_dlv->msg);
+            sub = DEQ_HEAD(in_dlv->subscriptions);
+        }
+
+        // This is a multicast delivery
+        if (qdr_is_addr_treatment_multicast(in_dlv->link->owning_addr)) {
+            assert(in_dlv->where == QDR_DELIVERY_IN_SETTLED);
+            //
+            // The router will settle on behalf of the receiver in the case of multicast and send out settled
+            // deliveries to the receivers.
+            //
+            in_dlv->disposition = PN_ACCEPTED;
+            qdr_delivery_push_CT(core, in_dlv);
+
+            //
+            // The in_dlv has one or more peers. These peers will have to be unlinked.
+            //
+            qdr_delivery_t *peer = qdr_delivery_first_peer_CT(in_dlv);
+            qdr_delivery_t *next_peer = 0;
+            while (peer) {
+                next_peer = qdr_delivery_next_peer_CT(in_dlv);
+                qdr_delivery_unlink_peers_CT(core, in_dlv, peer);
+                peer = next_peer;
+            }
+
+            // Remove the delivery from the settled list and decref the in_dlv.
+            in_dlv->where = QDR_DELIVERY_NOWHERE;
+            qdr_delivery_decref_CT(core, in_dlv); // This decref is for removing the delivery from the settled list.
+            DEQ_REMOVE(in_dlv->link->settled, in_dlv);
+        }
+    }
 }
 
 

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -186,51 +186,47 @@ static qd_iterator_t *router_annotate_message(qd_router_t       *router,
  */
 static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
 {
-    qd_router_t    *router   = (qd_router_t*) context;
-    pn_link_t      *pn_link  = qd_link_pn(link);
-    qdr_link_t     *rlink    = (qdr_link_t*) qd_link_get_context(link);
-    qd_connection_t  *conn   = qd_link_connection(link);
+    qd_router_t    *router       = (qd_router_t*) context;
+    pn_link_t      *pn_link      = qd_link_pn(link);
+    qdr_link_t     *rlink        = (qdr_link_t*) qd_link_get_context(link);
+    qd_connection_t  *conn       = qd_link_connection(link);
     const qd_server_config_t *cf = qd_connection_config(conn);
-    qdr_delivery_t *delivery = 0;
-    qd_message_t   *msg;
+    qdr_delivery_t *delivery     = pn_delivery_get_context(pnd);
 
     //
-    // Receive the message into a local representation.  If the returned message
-    // pointer is NULL, we have not yet received a complete message.
+    // Receive the message into a local representation.
     //
-    // Note:  In the link-routing case, consider cutting the message through.  There's
-    //        no reason to wait for the whole message to be received before starting to
-    //        send it.
-    //
-    msg = qd_message_receive(pnd);
+    qd_message_t   *msg   = qd_message_receive(pnd);
+    bool receive_complete = qd_message_receive_complete(msg);
 
-    if (!msg)
-        return;
+    if (receive_complete) {
+        //
+        // The entire message has been received and we are ready to consume the delivery by calling pn_link_advance().
+        //
+        pn_link_advance(pn_link);
 
-    if (cf->log_message) {
-        char repr[qd_message_repr_len()];
-        char* message_repr = qd_message_repr((qd_message_t*)msg,
-                                             repr,
-                                             sizeof(repr),
-                                             cf->log_bits);
-        if (message_repr) {
-            qd_log(qd_message_log_source(), QD_LOG_TRACE, "Link %s received %s",
-                   pn_link_name(pn_link),
-                   message_repr);
+        // Since the entire message has been received, we can print out its contents to the log if necessary.
+        if (cf->log_message) {
+            char repr[qd_message_repr_len()];
+            char* message_repr = qd_message_repr((qd_message_t*)msg,
+                                                 repr,
+                                                 sizeof(repr),
+                                                 cf->log_bits);
+            if (message_repr) {
+                qd_log(qd_message_log_source(), QD_LOG_TRACE, "Link %s received %s",
+                       pn_link_name(pn_link),
+                       message_repr);
+            }
         }
     }
-
-    //
-    // Consume the delivery.
-    //
-    pn_link_advance(pn_link);
 
     //
     // If there's no router link, free the message and finish.  It's likely that the link
     // is closing.
     //
     if (!rlink) {
-        qd_message_free(msg);
+        if (receive_complete) // The entire message has been received but there is nowhere to send it to, free it and do nothing.
+            qd_message_free(msg);
         return;
     }
 
@@ -239,20 +235,33 @@ static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
     //
     if (qdr_link_is_routed(rlink)) {
         pn_delivery_tag_t dtag = pn_delivery_tag(pnd);
-        delivery = qdr_link_deliver_to_routed_link(rlink, msg, pn_delivery_settled(pnd),
-                                                   (uint8_t*) dtag.start, dtag.size,
-                                                   pn_disposition_type(pn_delivery_remote(pnd)),
-                                                   pn_disposition_data(pn_delivery_remote(pnd)));
-
+        //
+        // A delivery object was already available via pn_delivery_get_context. This means a qdr_delivery was already created. Use it to continue delivery.
+        //
         if (delivery) {
-            if (pn_delivery_settled(pnd))
+            qdr_deliver_continue(delivery);
+
+            //
+            // Settle the proton delivery only if all the data has been received.
+            //
+            if (pn_delivery_settled(pnd) && receive_complete) {
                 pn_delivery_settle(pnd);
-            else {
-                pn_delivery_set_context(pnd, delivery);
-                qdr_delivery_set_context(delivery, pnd);
-                qdr_delivery_incref(delivery);
+                qdr_delivery_decref(router->router_core, delivery);
             }
         }
+        else {
+            delivery = qdr_link_deliver_to_routed_link(rlink,
+                                                       msg,
+                                                       pn_delivery_settled(pnd),
+                                                       (uint8_t*) dtag.start,
+                                                       dtag.size,
+                                                       pn_disposition_type(pn_delivery_remote(pnd)),
+                                                       pn_disposition_data(pn_delivery_remote(pnd)));
+            pn_delivery_set_context(pnd, delivery);
+            qdr_delivery_set_context(delivery, pnd);
+            qdr_delivery_incref(delivery);
+        }
+
         return;
     }
 
@@ -294,134 +303,142 @@ static void AMQP_rx_handler(void* context, qd_link_t *link, pn_delivery_t *pnd)
     qd_message_depth_t  validation_depth = (anonymous_link || check_user) ? QD_DEPTH_PROPERTIES : QD_DEPTH_MESSAGE_ANNOTATIONS;
     bool                valid_message    = qd_message_check(msg, validation_depth);
 
-    if (valid_message) {
-        if (check_user) {
-            // This connection must not allow proxied user_id
-            qd_iterator_t *userid_iter  = qd_message_field_iterator(msg, QD_FIELD_USER_ID);
-            if (userid_iter) {
-                // The user_id property has been specified
-                if (qd_iterator_remaining(userid_iter) > 0) {
-                    // user_id property in message is not blank
-                    if (!qd_iterator_equal(userid_iter, (const unsigned char *)conn->user_id)) {
-                        // This message is rejected: attempted user proxy is disallowed
-                        qd_log(router->log_source, QD_LOG_DEBUG, "Message rejected due to user_id proxy violation. User:%s", conn->user_id);
-                        pn_link_flow(pn_link, 1);
-                        pn_delivery_update(pnd, PN_REJECTED);
-                        pn_delivery_settle(pnd);
-                        qd_message_free(msg);
-                        qd_iterator_free(userid_iter);
-                        return;
-                    }
-                }
-                qd_iterator_free(userid_iter);
-            }
-        }
+    if (!valid_message && receive_complete) {
+        //
+        // The entire message has been received and the message is still invalid.  Reject the message.
+        //
+        qd_message_set_discard(msg, true);
+        pn_link_flow(pn_link, 1);
+        pn_delivery_update(pnd, PN_REJECTED);
+        pn_delivery_settle(pnd);
+        qd_message_free(msg);
+    }
 
-        qd_message_message_annotations(msg);
-        qd_bitmask_t        *link_exclusions;
+    if (!valid_message) {
+        return;
+    }
 
-        qd_iterator_t *ingress_iter = router_annotate_message(router, msg, &link_exclusions);
+    if (delivery) {
+        qdr_deliver_continue(delivery);
 
-        if (anonymous_link) {
-            qd_iterator_t *addr_iter = 0;
-            int phase = 0;
-            
-            //
-            // If the message has delivery annotations, get the to-override field from the annotations.
-            //
-            qd_parsed_field_t *ma_to = qd_message_get_to_override(msg);
-            if (ma_to) {
-                addr_iter = qd_iterator_dup(qd_parse_raw(ma_to));
-                phase = qd_message_get_phase_val(msg);
-            }
-
-            //
-            // Still no destination address?  Use the TO field from the message properties.
-            //
-            if (!addr_iter) {
-                addr_iter = qd_message_field_iterator(msg, QD_FIELD_TO);
-
-                //
-                // If the address came from the TO field and we need to apply a tenant-space,
-                // set the to-override with the annotated address.
-                //
-                if (addr_iter && tenant_space) {
-                    qd_iterator_reset_view(addr_iter, ITER_VIEW_ADDRESS_WITH_SPACE);
-                    qd_iterator_annotate_space(addr_iter, tenant_space, tenant_space_len);
-                    qd_composed_field_t *to_override = qd_compose_subfield(0);
-                    qd_compose_insert_string_iterator(to_override, addr_iter);
-                    qd_message_set_to_override_annotation(msg, to_override);
-                }
-            }
-
-            if (addr_iter) {
-                qd_iterator_reset_view(addr_iter, ITER_VIEW_ADDRESS_HASH);
-                if (phase > 0)
-                    qd_iterator_annotate_phase(addr_iter, '0' + (char) phase);
-                delivery = qdr_link_deliver_to(rlink, msg, ingress_iter, addr_iter, pn_delivery_settled(pnd),
-                                               link_exclusions);
-            }
-        } else {
-            //
-            // This is a targeted link, not anonymous.
-            //
-            const char *term_addr = pn_terminus_get_address(qd_link_remote_target(link));
-            if (!term_addr)
-                term_addr = pn_terminus_get_address(qd_link_source(link));
-
-            if (term_addr) {
-                qd_composed_field_t *to_override = qd_compose_subfield(0);
-                if (tenant_space) {
-                    qd_iterator_t *aiter = qd_iterator_string(term_addr, ITER_VIEW_ADDRESS_WITH_SPACE);
-                    qd_iterator_annotate_space(aiter, tenant_space, tenant_space_len);
-                    qd_compose_insert_string_iterator(to_override, aiter);
-                    qd_iterator_free(aiter);
-                } else
-                    qd_compose_insert_string(to_override, term_addr);
-                qd_message_set_to_override_annotation(msg, to_override);
-                int phase = qdr_link_phase(rlink);
-                if (phase != 0)
-                    qd_message_set_phase_annotation(msg, phase);
-            }
-            delivery = qdr_link_deliver(rlink, msg, ingress_iter, pn_delivery_settled(pnd), link_exclusions);
-        }
-
-        if (delivery) {
-            if (pn_delivery_settled(pnd))
-                pn_delivery_settle(pnd);
-            else {
-                pn_delivery_set_context(pnd, delivery);
-                qdr_delivery_set_context(delivery, pnd);
-                qdr_delivery_incref(delivery);
-            }
-        } else {
-            //
-            // The message is now and will always be unroutable because there is no address.
-            //
-            pn_link_flow(pn_link, 1);
-            pn_delivery_update(pnd, PN_REJECTED);
+        if (pn_delivery_settled(pnd) && receive_complete) {
             pn_delivery_settle(pnd);
-            qd_message_free(msg);
+            qdr_delivery_decref(router->router_core, delivery);
+        }
+        return;
+    }
+
+    if (check_user) {
+        // This connection must not allow proxied user_id
+        qd_iterator_t *userid_iter  = qd_message_field_iterator(msg, QD_FIELD_USER_ID);
+        if (userid_iter) {
+            // The user_id property has been specified
+            if (qd_iterator_remaining(userid_iter) > 0) {
+                // user_id property in message is not blank
+                if (!qd_iterator_equal(userid_iter, (const unsigned char *)conn->user_id)) {
+                    // This message is rejected: attempted user proxy is disallowed
+                    qd_log(router->log_source, QD_LOG_DEBUG, "Message rejected due to user_id proxy violation. User:%s", conn->user_id);
+                    pn_link_flow(pn_link, 1);
+                    pn_delivery_update(pnd, PN_REJECTED);
+                    pn_delivery_settle(pnd);
+                    qd_message_free(msg);
+                    qd_iterator_free(userid_iter);
+                    return;
+                }
+            }
+            qd_iterator_free(userid_iter);
+        }
+    }
+
+    qd_message_message_annotations(msg);
+    qd_bitmask_t        *link_exclusions;
+
+    qd_iterator_t *ingress_iter = router_annotate_message(router, msg, &link_exclusions);
+
+    if (anonymous_link) {
+        qd_iterator_t *addr_iter = 0;
+        int phase = 0;
+
+        //
+        // If the message has delivery annotations, get the to-override field from the annotations.
+        //
+        qd_parsed_field_t *ma_to = qd_message_get_to_override(msg);
+        if (ma_to) {
+            addr_iter = qd_iterator_dup(qd_parse_raw(ma_to));
+            phase = qd_message_get_phase_annotation(msg);
         }
 
         //
-        // Rules for delivering messages:
+        // Still no destination address?  Use the TO field from the message properties.
         //
-        // For addressed (non-anonymous) links:
-        //   to-override must be set (done in the core?)
-        //   uses qdr_link_deliver to hand over to the core
-        //
-        // For anonymous links:
-        //   If there's a to-override in the annotations, use that address
-        //   Or, use the 'to' field in the message properties
-        //
+        if (!addr_iter) {
+            addr_iter = qd_message_field_iterator(msg, QD_FIELD_TO);
 
+            //
+            // If the address came from the TO field and we need to apply a tenant-space,
+            // set the to-override with the annotated address.
+            //
+            if (addr_iter && tenant_space) {
+                qd_iterator_reset_view(addr_iter, ITER_VIEW_ADDRESS_WITH_SPACE);
+                qd_iterator_annotate_space(addr_iter, tenant_space, tenant_space_len);
+                qd_composed_field_t *to_override = qd_compose_subfield(0);
+                qd_compose_insert_string_iterator(to_override, addr_iter);
+                qd_message_set_to_override_annotation(msg, to_override);
+            }
+        }
 
-
+        if (addr_iter) {
+            qd_iterator_reset_view(addr_iter, ITER_VIEW_ADDRESS_HASH);
+            if (phase > 0)
+                qd_iterator_annotate_phase(addr_iter, '0' + (char) phase);
+            delivery = qdr_link_deliver_to(rlink, msg, ingress_iter, addr_iter, pn_delivery_settled(pnd),
+                                           link_exclusions);
+        }
     } else {
         //
-        // Message is invalid.  Reject the message and don't involve the router core.
+        // This is a targeted link, not anonymous.
         //
+        const char *term_addr = pn_terminus_get_address(qd_link_remote_target(link));
+        if (!term_addr)
+            term_addr = pn_terminus_get_address(qd_link_source(link));
+
+        if (term_addr) {
+            qd_composed_field_t *to_override = qd_compose_subfield(0);
+            if (tenant_space) {
+                qd_iterator_t *aiter = qd_iterator_string(term_addr, ITER_VIEW_ADDRESS_WITH_SPACE);
+                qd_iterator_annotate_space(aiter, tenant_space, tenant_space_len);
+                qd_compose_insert_string_iterator(to_override, aiter);
+                qd_iterator_free(aiter);
+            } else
+                qd_compose_insert_string(to_override, term_addr);
+            qd_message_set_to_override_annotation(msg, to_override);
+            int phase = qdr_link_phase(rlink);
+            if (phase != 0)
+                qd_message_set_phase_annotation(msg, phase);
+        }
+        delivery = qdr_link_deliver(rlink, msg, ingress_iter, pn_delivery_settled(pnd), link_exclusions);
+    }
+
+    if (delivery) {
+        //
+        // Settle the proton delivery only if all the data has arrived
+        //
+        if (pn_delivery_settled(pnd)) {
+            if (receive_complete) {
+                pn_delivery_settle(pnd);
+                return;
+            }
+        }
+
+        // If this delivery is unsettled or if this is a settled multi-frame large message, set the context
+        pn_delivery_set_context(pnd, delivery);
+        qdr_delivery_set_context(delivery, pnd);
+        qdr_delivery_incref(delivery);
+    } else {
+        //
+        // If there is no delivery, the message is now and will always be unroutable because there is no address.
+        //
+        qd_message_set_discard(msg, true);
         pn_link_flow(pn_link, 1);
         pn_delivery_update(pnd, PN_REJECTED);
         pn_delivery_settle(pnd);
@@ -447,6 +464,11 @@ static void AMQP_disposition_handler(void* context, qd_link_t *link, pn_delivery
     if (!delivery)
         return;
 
+    bool receive_complete = qdr_delivery_receive_complete(delivery);
+
+    if (!receive_complete)
+        return;
+
     pn_disposition_t *disp   = pn_delivery_remote(pnd);
     pn_condition_t *cond     = pn_disposition_condition(disp);
     qdr_error_t    *error    = qdr_error_from_pn(cond);
@@ -459,6 +481,7 @@ static void AMQP_disposition_handler(void* context, qd_link_t *link, pn_delivery
     if (pn_delivery_settled(pnd)) {
         pn_delivery_set_context(pnd, 0);
         qdr_delivery_set_context(delivery, 0);
+        qdr_delivery_set_cleared_proton_ref(delivery, true);
 
         //
         // Don't decref the delivery here.  Rather, we will _give_ the reference to the core.
@@ -479,8 +502,9 @@ static void AMQP_disposition_handler(void* context, qd_link_t *link, pn_delivery
     //
     // If settled, close out the delivery
     //
-    if (pn_delivery_settled(pnd))
+    if (pn_delivery_settled(pnd)) {
         pn_delivery_settle(pnd);
+    }
 }
 
 
@@ -988,20 +1012,20 @@ static int CORE_link_push(void *context, qdr_link_t *link, int limit)
     qd_link_t   *qlink  = (qd_link_t*) qdr_link_get_context(link);
     if (!qlink)
         return 0;
-    
+
     pn_link_t *plink = qd_link_pn(qlink);
 
     if (plink) {
         int link_credit = pn_link_credit(plink);
         if (link_credit > limit)
             link_credit = limit;
-        qdr_link_process_deliveries(router->router_core, link, link_credit);
-        return link_credit;
-    }
 
+        if (link_credit > 0)
+            // We will not bother calling qdr_link_process_deliveries if we have no credit.
+            return qdr_link_process_deliveries(router->router_core, link, link_credit);
+    }
     return 0;
 }
-
 
 static void CORE_link_deliver(void *context, qdr_link_t *link, qdr_delivery_t *dlv, bool settled)
 {
@@ -1014,37 +1038,61 @@ static void CORE_link_deliver(void *context, qdr_link_t *link, qdr_delivery_t *d
     if (!plink)
         return;
 
-    const char *tag;
-    int         tag_length;
-
-    qdr_delivery_tag(dlv, &tag, &tag_length);
-
-    pn_delivery(plink, pn_dtag(tag, tag_length));
-    pn_delivery_t *pdlv = pn_link_current(plink);
-
-    // handle any delivery-state on the transfer e.g. transactional-state
-    qdr_delivery_write_extension_state(dlv, pdlv, true);
     //
     // If the remote send settle mode is set to 'settled' then settle the delivery on behalf of the receiver.
     //
     bool remote_snd_settled = qd_link_remote_snd_settle_mode(qlink) == PN_SND_SETTLED;
+    pn_delivery_t *pdlv = 0;
 
-    if (!settled && !remote_snd_settled) {
-        pn_delivery_set_context(pdlv, dlv);
-        qdr_delivery_set_context(dlv, pdlv);
-        qdr_delivery_incref(dlv);
+    if (!qdr_delivery_tag_sent(dlv)) {
+        const char *tag;
+        int         tag_length;
+
+        qdr_delivery_tag(dlv, &tag, &tag_length);
+
+        // Create a new proton delivery on link 'plink'
+        pn_delivery(plink, pn_dtag(tag, tag_length));
+
+        pdlv = pn_link_current(plink);
+
+        // handle any delivery-state on the transfer e.g. transactional-state
+        qdr_delivery_write_extension_state(dlv, pdlv, true);
+
+        //
+        // If the remote send settle mode is set to 'settled', we should settle the delivery on behalf of the receiver.
+        //
+        if (!settled && !remote_snd_settled) {
+            if (qdr_delivery_get_context(dlv) == 0)  {
+                pn_delivery_set_context(pdlv, dlv);
+                qdr_delivery_set_context(dlv, pdlv);
+                qdr_delivery_incref(dlv);
+            }
+        }
+
+        qdr_delivery_set_tag_sent(dlv, true);
+    }
+
+    if (!pdlv) {
+        pdlv = pn_link_current(plink);
     }
 
     qd_message_send(qdr_delivery_message(dlv), qlink, qdr_link_strip_annotations_out(link));
 
-    if (!settled && remote_snd_settled)
-        // Tell the core that the delivery has been accepted and settled, since we are settling on behalf of the receiver
-        qdr_delivery_update_disposition(router->router_core, dlv, PN_ACCEPTED, true, 0, 0, false);
+    bool send_complete = qdr_delivery_send_complete(dlv);
 
-    if (settled || remote_snd_settled)
-        pn_delivery_settle(pdlv);
+    if (send_complete) {
+        if (!settled && remote_snd_settled) {
+            // Tell the core that the delivery has been accepted and settled, since we are settling on behalf of the receiver
+            qdr_delivery_update_disposition(router->router_core, dlv, PN_ACCEPTED, true, 0, 0, false);
+        }
 
-    pn_link_advance(plink);
+        pn_link_advance(plink);
+
+        if (settled || remote_snd_settled) {
+            if (pdlv)
+                pn_delivery_settle(pdlv);
+        }
+    }
 }
 
 
@@ -1089,6 +1137,7 @@ static void CORE_delivery_update(void *context, qdr_delivery_t *dlv, uint64_t di
         qdr_delivery_set_context(dlv, 0);
         pn_delivery_set_context(pnd, 0);
         pn_delivery_settle(pnd);
+        qdr_delivery_set_cleared_proton_ref(dlv, true);
         qdr_delivery_decref(router->router_core, dlv);
     }
 }


### PR DESCRIPTION
1. Added new core API function qdr_deliver_continue() that will continue
delivering a large message
2. Modified qdr_link_process_deliveries() to not remove deliveries from
the undelivered list until they are fully delivered
3. Modified qd_message_receive() to recieve partial messages.
4. Modified qd_message_send() to be able to handle streaming send. This
function can now be called multiple times for the same message. It keeps
internal pointers to the point upto which the message has been sent and
is able to continue where it left off. Message content buffers are freed
as soon as the message has been sent to all recipients.
5. Added peer linkage for large settled deliveries and added a settled
list to handle with abrupt connection terminations when large messages
are being transmitted.
6. Added unit tests to test large messages.