### PR TITLE
DISPATCH-803 - The following changes were made to support forbidden d…

### DIFF
--- a/include/qpid/dispatch/router.h
+++ b/include/qpid/dispatch/router.h
@@ -43,7 +43,7 @@ typedef enum {
     QD_TREATMENT_ANYCAST_CLOSEST  = 2,
     QD_TREATMENT_ANYCAST_BALANCED = 3,
     QD_TREATMENT_LINK_BALANCED    = 4,
-    QD_TREATMENT_LINK_FORBIDDEN   = 5
+    QD_TREATMENT_FORBIDDEN        = 5
 } qd_address_treatment_t;
 
 #include <qpid/dispatch/router_core.h>

--- a/include/qpid/dispatch/router.h
+++ b/include/qpid/dispatch/router.h
@@ -42,7 +42,8 @@ typedef enum {
     QD_TREATMENT_MULTICAST_ONCE   = 1,
     QD_TREATMENT_ANYCAST_CLOSEST  = 2,
     QD_TREATMENT_ANYCAST_BALANCED = 3,
-    QD_TREATMENT_LINK_BALANCED    = 4
+    QD_TREATMENT_LINK_BALANCED    = 4,
+    QD_TREATMENT_LINK_FORBIDDEN   = 5
 } qd_address_treatment_t;
 
 #include <qpid/dispatch/router_core.h>

--- a/include/qpid/dispatch/router.h
+++ b/include/qpid/dispatch/router.h
@@ -43,7 +43,7 @@ typedef enum {
     QD_TREATMENT_ANYCAST_CLOSEST  = 2,
     QD_TREATMENT_ANYCAST_BALANCED = 3,
     QD_TREATMENT_LINK_BALANCED    = 4,
-    QD_TREATMENT_FORBIDDEN        = 5
+    QD_TREATMENT_UNAVAILABLE      = 5
 } qd_address_treatment_t;
 
 #include <qpid/dispatch/router_core.h>

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -504,6 +504,13 @@
                     "deprecated": true,
                     "description": "(DEPRECATED) This value is no longer used in the router.",
                     "create": true
+                },
+                "defaultDistribution": {
+                    "type": ["multicast", "closest", "balanced", "forbidden"],
+                    "description": "Default forwarding treatment for any address without a specified treatment. multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; linkBalanced - for link-routing, link attaches balanced across destinations; forbidden - this address is forbidden, link attaches to an address of forbidden distribution will be rejected.",
+                    "create": true,
+                    "required": false,
+                    "default": "balanced"
                 }
             }
         },
@@ -956,7 +963,7 @@
                     "required": true
                 },
                 "distribution": {
-                    "type": ["multicast", "closest", "balanced"],
+                    "type": ["multicast", "closest", "balanced", "forbidden"],
                     "description": "Treatment of traffic associated with the address",
                     "create": true,
                     "required": false,
@@ -1172,8 +1179,8 @@
             "extends": "operationalEntity",
             "attributes": {
                 "distribution": {
-                    "type": ["flood", "multicast", "closest", "balanced", "linkBalanced"],
-                    "description": "Forwarding treatment for the address: flood - messages delivered to all subscribers along all available paths (this will cause duplicate deliveries if there are redundant paths); multi - one copy of each message delivered to all subscribers; anyClosest - messages delivered to only the closest subscriber; anyBalanced - messages delivered to one subscriber with load balanced across subscribers; linkBalanced - for link-routing, link attaches balanced across destinations."
+                    "type": ["flood", "multicast", "closest", "balanced", "linkBalanced", "forbidden"],
+                    "description": "Forwarding treatment for the address: flood - messages delivered to all subscribers along all available paths (this will cause duplicate deliveries if there are redundant paths); multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; linkBalanced - for link-routing, link attaches balanced across destinations; forbidden - this address is forbidden, link attaches to an address of forbidden distribution will be rejected."
                 },
                 "inProcess": {
                     "type": "integer",

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -506,8 +506,8 @@
                     "create": true
                 },
                 "defaultDistribution": {
-                    "type": ["multicast", "closest", "balanced", "forbidden"],
-                    "description": "Default forwarding treatment for any address without a specified treatment. multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; forbidden - this address is forbidden, link attaches to an address of forbidden distribution will be rejected.",
+                    "type": ["multicast", "closest", "balanced", "unavailable"],
+                    "description": "Default forwarding treatment for any address without a specified treatment. multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; unavailable - this address is unavailable, link attaches to an address of unavilable distribution will be rejected.",
                     "create": true,
                     "required": false,
                     "default": "balanced"
@@ -963,7 +963,7 @@
                     "required": true
                 },
                 "distribution": {
-                    "type": ["multicast", "closest", "balanced", "forbidden"],
+                    "type": ["multicast", "closest", "balanced", "unavailable"],
                     "description": "Treatment of traffic associated with the address",
                     "create": true,
                     "required": false,
@@ -1179,8 +1179,8 @@
             "extends": "operationalEntity",
             "attributes": {
                 "distribution": {
-                    "type": ["flood", "multicast", "closest", "balanced", "linkBalanced", "forbidden"],
-                    "description": "Forwarding treatment for the address: flood - messages delivered to all subscribers along all available paths (this will cause duplicate deliveries if there are redundant paths); multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; linkBalanced - for link-routing, link attaches balanced across destinations; forbidden - this address is forbidden, link attaches to an address of forbidden distribution will be rejected."
+                    "type": ["flood", "multicast", "closest", "balanced", "linkBalanced", "unavailable"],
+                    "description": "Forwarding treatment for the address: flood - messages delivered to all subscribers along all available paths (this will cause duplicate deliveries if there are redundant paths); multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; linkBalanced - for link-routing, link attaches balanced across destinations; unavailable - this address is unavailable, link attaches to an address of unavailable distribution will be rejected."
                 },
                 "inProcess": {
                     "type": "integer",

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -507,7 +507,7 @@
                 },
                 "defaultDistribution": {
                     "type": ["multicast", "closest", "balanced", "forbidden"],
-                    "description": "Default forwarding treatment for any address without a specified treatment. multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; linkBalanced - for link-routing, link attaches balanced across destinations; forbidden - this address is forbidden, link attaches to an address of forbidden distribution will be rejected.",
+                    "description": "Default forwarding treatment for any address without a specified treatment. multicast - one copy of each message delivered to all subscribers; closest - messages delivered to only the closest subscriber; balanced - messages delivered to one subscriber with load balanced across subscribers; forbidden - this address is forbidden, link attaches to an address of forbidden distribution will be rejected.",
                     "create": true,
                     "required": false,
                     "default": "balanced"

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -50,7 +50,10 @@ qd_router_t    *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *
 void            qd_router_setup_late(qd_dispatch_t *qd);
 void            qd_router_free(qd_router_t *router);
 void            qd_error_initialize();
-
+const char     *CLOSEST_DISTRIBUTION   = "closest";
+const char     *MULTICAST_DISTRIBUTION = "multicast";
+const char     *BALANCED_DISTRIBUTION  = "balanced";
+const char     *FORBIDDEN_DISTRIBUTION = "forbidden";
 qd_dispatch_t *qd_dispatch(const char *python_pkgdir)
 {
     qd_dispatch_t *qd = NEW(qd_dispatch_t);
@@ -76,6 +79,7 @@ qd_dispatch_t *qd_dispatch(const char *python_pkgdir)
     qd_dispatch_set_router_area(qd, strdup("0"));
     qd_dispatch_set_router_id(qd, strdup("0"));
     qd->router_mode = QD_ROUTER_MODE_ENDPOINT;
+    qd->treatment   = QD_TREATMENT_LINK_BALANCED;
 
     qd_python_initialize(qd, python_pkgdir);
     if (qd_error_code()) { qd_dispatch_free(qd); return 0; }
@@ -163,10 +167,27 @@ qd_error_t qd_dispatch_configure_container(qd_dispatch_t *qd, qd_entity_t *entit
     return QD_ERROR_NONE;
 }
 
+void qd_dispatch_set_router_default_distribution(qd_dispatch_t *qd, char *distribution)
+{
+    if (distribution) {
+        if (strcmp(distribution, MULTICAST_DISTRIBUTION) == 0)
+            qd->treatment = QD_TREATMENT_MULTICAST_ONCE;
+        else if (strcmp(distribution, CLOSEST_DISTRIBUTION) == 0)
+            qd->treatment = QD_TREATMENT_ANYCAST_CLOSEST;
+        else if (strcmp(distribution, BALANCED_DISTRIBUTION) == 0)
+            qd->treatment = QD_TREATMENT_ANYCAST_BALANCED;
+        else if (strcmp(distribution, FORBIDDEN_DISTRIBUTION) == 0)
+            qd->treatment = QD_TREATMENT_LINK_FORBIDDEN;
+    }
+    else
+        // The default for the router defaultDistribution field is QD_TREATMENT_ANYCAST_BALANCED
+        qd->treatment = QD_TREATMENT_ANYCAST_BALANCED;
+}
 
 qd_error_t qd_dispatch_configure_router(qd_dispatch_t *qd, qd_entity_t *entity)
 {
     qd_dispatch_set_router_id(qd, qd_entity_opt_string(entity, "routerId", 0)); QD_ERROR_RET();
+    qd_dispatch_set_router_default_distribution(qd, qd_entity_opt_string(entity, "defaultDistribution", 0)); QD_ERROR_RET();
     if (! qd->router_id) {
         qd_dispatch_set_router_id(qd, qd_entity_opt_string(entity, "id", 0)); QD_ERROR_RET();
     }

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -79,7 +79,7 @@ qd_dispatch_t *qd_dispatch(const char *python_pkgdir)
     qd_dispatch_set_router_area(qd, strdup("0"));
     qd_dispatch_set_router_id(qd, strdup("0"));
     qd->router_mode = QD_ROUTER_MODE_ENDPOINT;
-    qd->treatment   = QD_TREATMENT_LINK_BALANCED;
+    qd->default_treatment   = QD_TREATMENT_LINK_BALANCED;
 
     qd_python_initialize(qd, python_pkgdir);
     if (qd_error_code()) { qd_dispatch_free(qd); return 0; }
@@ -171,17 +171,17 @@ void qd_dispatch_set_router_default_distribution(qd_dispatch_t *qd, char *distri
 {
     if (distribution) {
         if (strcmp(distribution, MULTICAST_DISTRIBUTION) == 0)
-            qd->treatment = QD_TREATMENT_MULTICAST_ONCE;
+            qd->default_treatment = QD_TREATMENT_MULTICAST_ONCE;
         else if (strcmp(distribution, CLOSEST_DISTRIBUTION) == 0)
-            qd->treatment = QD_TREATMENT_ANYCAST_CLOSEST;
+            qd->default_treatment = QD_TREATMENT_ANYCAST_CLOSEST;
         else if (strcmp(distribution, BALANCED_DISTRIBUTION) == 0)
-            qd->treatment = QD_TREATMENT_ANYCAST_BALANCED;
+            qd->default_treatment = QD_TREATMENT_ANYCAST_BALANCED;
         else if (strcmp(distribution, FORBIDDEN_DISTRIBUTION) == 0)
-            qd->treatment = QD_TREATMENT_LINK_FORBIDDEN;
+            qd->default_treatment = QD_TREATMENT_FORBIDDEN;
     }
     else
         // The default for the router defaultDistribution field is QD_TREATMENT_ANYCAST_BALANCED
-        qd->treatment = QD_TREATMENT_ANYCAST_BALANCED;
+        qd->default_treatment = QD_TREATMENT_ANYCAST_BALANCED;
 }
 
 qd_error_t qd_dispatch_configure_router(qd_dispatch_t *qd, qd_entity_t *entity)

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -53,7 +53,7 @@ void            qd_error_initialize();
 const char     *CLOSEST_DISTRIBUTION   = "closest";
 const char     *MULTICAST_DISTRIBUTION = "multicast";
 const char     *BALANCED_DISTRIBUTION  = "balanced";
-const char     *FORBIDDEN_DISTRIBUTION = "forbidden";
+const char     *UNAVAILABLE_DISTRIBUTION = "unavailable";
 qd_dispatch_t *qd_dispatch(const char *python_pkgdir)
 {
     qd_dispatch_t *qd = NEW(qd_dispatch_t);
@@ -176,8 +176,8 @@ void qd_dispatch_set_router_default_distribution(qd_dispatch_t *qd, char *distri
             qd->default_treatment = QD_TREATMENT_ANYCAST_CLOSEST;
         else if (strcmp(distribution, BALANCED_DISTRIBUTION) == 0)
             qd->default_treatment = QD_TREATMENT_ANYCAST_BALANCED;
-        else if (strcmp(distribution, FORBIDDEN_DISTRIBUTION) == 0)
-            qd->default_treatment = QD_TREATMENT_FORBIDDEN;
+        else if (strcmp(distribution, UNAVAILABLE_DISTRIBUTION) == 0)
+            qd->default_treatment = QD_TREATMENT_UNAVAILABLE;
     }
     else
         // The default for the router defaultDistribution field is QD_TREATMENT_ANYCAST_BALANCED

--- a/src/dispatch_private.h
+++ b/src/dispatch_private.h
@@ -52,6 +52,7 @@ struct qd_dispatch_t {
     qd_connection_manager_t *connection_manager;
     qd_policy_t             *policy;
     void                    *dl_handle;
+    qd_address_treatment_t   treatment;
 
     int    thread_count;
     char  *sasl_config_path;

--- a/src/dispatch_private.h
+++ b/src/dispatch_private.h
@@ -52,7 +52,7 @@ struct qd_dispatch_t {
     qd_connection_manager_t *connection_manager;
     qd_policy_t             *policy;
     void                    *dl_handle;
-    qd_address_treatment_t   treatment;
+    qd_address_treatment_t   default_treatment;
 
     int    thread_count;
     char  *sasl_config_path;

--- a/src/router_core/agent_address.c
+++ b/src/router_core/agent_address.c
@@ -85,7 +85,7 @@ static void qdr_insert_address_columns_CT(qdr_core_t          *core,
             case QD_TREATMENT_ANYCAST_CLOSEST:  qd_compose_insert_string(body, "closest");      break;
             case QD_TREATMENT_ANYCAST_BALANCED: qd_compose_insert_string(body, "balanced");     break;
             case QD_TREATMENT_LINK_BALANCED:    qd_compose_insert_string(body, "linkBalanced"); break;
-            case QD_TREATMENT_FORBIDDEN:        qd_compose_insert_string(body, "forbidden");    break;
+            case QD_TREATMENT_UNAVAILABLE:      qd_compose_insert_string(body, "unavailable");  break;
         }
         break;
     }

--- a/src/router_core/agent_address.c
+++ b/src/router_core/agent_address.c
@@ -85,7 +85,7 @@ static void qdr_insert_address_columns_CT(qdr_core_t          *core,
             case QD_TREATMENT_ANYCAST_CLOSEST:  qd_compose_insert_string(body, "closest");      break;
             case QD_TREATMENT_ANYCAST_BALANCED: qd_compose_insert_string(body, "balanced");     break;
             case QD_TREATMENT_LINK_BALANCED:    qd_compose_insert_string(body, "linkBalanced"); break;
-            case QD_TREATMENT_LINK_FORBIDDEN:   qd_compose_insert_string(body, "forbidden");    break;
+            case QD_TREATMENT_FORBIDDEN:        qd_compose_insert_string(body, "forbidden");    break;
         }
         break;
     }

--- a/src/router_core/agent_address.c
+++ b/src/router_core/agent_address.c
@@ -80,11 +80,12 @@ static void qdr_insert_address_columns_CT(qdr_core_t          *core,
 
     case QDR_ADDRESS_DISTRIBUTION: {
         switch (addr->treatment) {
-        case QD_TREATMENT_MULTICAST_FLOOD:  qd_compose_insert_string(body, "flood");        break;
-        case QD_TREATMENT_MULTICAST_ONCE:   qd_compose_insert_string(body, "multicast");    break;
-        case QD_TREATMENT_ANYCAST_CLOSEST:  qd_compose_insert_string(body, "closest");      break;
-        case QD_TREATMENT_ANYCAST_BALANCED: qd_compose_insert_string(body, "balanced");     break;
-        case QD_TREATMENT_LINK_BALANCED:    qd_compose_insert_string(body, "linkBalanced"); break;
+            case QD_TREATMENT_MULTICAST_FLOOD:  qd_compose_insert_string(body, "flood");        break;
+            case QD_TREATMENT_MULTICAST_ONCE:   qd_compose_insert_string(body, "multicast");    break;
+            case QD_TREATMENT_ANYCAST_CLOSEST:  qd_compose_insert_string(body, "closest");      break;
+            case QD_TREATMENT_ANYCAST_BALANCED: qd_compose_insert_string(body, "balanced");     break;
+            case QD_TREATMENT_LINK_BALANCED:    qd_compose_insert_string(body, "linkBalanced"); break;
+            case QD_TREATMENT_LINK_FORBIDDEN:   qd_compose_insert_string(body, "forbidden");    break;
         }
         break;
     }

--- a/src/router_core/agent_config_address.c
+++ b/src/router_core/agent_config_address.c
@@ -212,7 +212,7 @@ static qd_address_treatment_t qdra_address_treatment_CT(qd_parsed_field_t *field
         if (qd_iterator_equal(iter, (unsigned char*) "multicast"))    return QD_TREATMENT_MULTICAST_ONCE;
         if (qd_iterator_equal(iter, (unsigned char*) "closest"))      return QD_TREATMENT_ANYCAST_CLOSEST;
         if (qd_iterator_equal(iter, (unsigned char*) "balanced"))     return QD_TREATMENT_ANYCAST_BALANCED;
-        if (qd_iterator_equal(iter, (unsigned char*) "forbidden"))    return QD_TREATMENT_LINK_FORBIDDEN;
+        if (qd_iterator_equal(iter, (unsigned char*) "forbidden"))    return QD_TREATMENT_FORBIDDEN;
     }
     return QD_TREATMENT_ANYCAST_BALANCED;
 }

--- a/src/router_core/agent_config_address.c
+++ b/src/router_core/agent_config_address.c
@@ -212,7 +212,7 @@ static qd_address_treatment_t qdra_address_treatment_CT(qd_parsed_field_t *field
         if (qd_iterator_equal(iter, (unsigned char*) "multicast"))    return QD_TREATMENT_MULTICAST_ONCE;
         if (qd_iterator_equal(iter, (unsigned char*) "closest"))      return QD_TREATMENT_ANYCAST_CLOSEST;
         if (qd_iterator_equal(iter, (unsigned char*) "balanced"))     return QD_TREATMENT_ANYCAST_BALANCED;
-        if (qd_iterator_equal(iter, (unsigned char*) "forbidden"))    return QD_TREATMENT_FORBIDDEN;
+        if (qd_iterator_equal(iter, (unsigned char*) "unavailable"))  return QD_TREATMENT_UNAVAILABLE;
     }
     return QD_TREATMENT_ANYCAST_BALANCED;
 }

--- a/src/router_core/agent_config_address.c
+++ b/src/router_core/agent_config_address.c
@@ -212,6 +212,7 @@ static qd_address_treatment_t qdra_address_treatment_CT(qd_parsed_field_t *field
         if (qd_iterator_equal(iter, (unsigned char*) "multicast"))    return QD_TREATMENT_MULTICAST_ONCE;
         if (qd_iterator_equal(iter, (unsigned char*) "closest"))      return QD_TREATMENT_ANYCAST_CLOSEST;
         if (qd_iterator_equal(iter, (unsigned char*) "balanced"))     return QD_TREATMENT_ANYCAST_BALANCED;
+        if (qd_iterator_equal(iter, (unsigned char*) "forbidden"))    return QD_TREATMENT_LINK_FORBIDDEN;
     }
     return QD_TREATMENT_ANYCAST_BALANCED;
 }

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -978,7 +978,7 @@ static qdr_address_t *qdr_lookup_terminus_address_CT(qdr_core_t       *core,
                                                      bool              create_if_not_found,
                                                      bool              accept_dynamic,
                                                      bool             *link_route,
-                                                     bool             *forbidden)
+                                                     bool             *unavailable)
 {
     qdr_address_t *addr = 0;
 
@@ -986,7 +986,7 @@ static qdr_address_t *qdr_lookup_terminus_address_CT(qdr_core_t       *core,
     // Unless expressly stated, link routing is not indicated for this terminus.
     //
     *link_route = false;
-    *forbidden = false;
+    *unavailable = false;
 
     if (qdr_terminus_is_dynamic(terminus)) {
         //
@@ -1089,8 +1089,8 @@ static qdr_address_t *qdr_lookup_terminus_address_CT(qdr_core_t       *core,
     int addr_phase;
     qd_address_treatment_t treat = qdr_treatment_for_address_CT(core, conn, iter, &in_phase, &out_phase);
 
-    if (treat == QD_TREATMENT_FORBIDDEN) {
-        *forbidden = true;
+    if (treat == QD_TREATMENT_UNAVAILABLE) {
+        *unavailable = true;
         return 0;
     }
 
@@ -1311,10 +1311,10 @@ static void qdr_link_inbound_first_attach_CT(qdr_core_t *core, qdr_action_t *act
                 // This link has a target address
                 //
                 bool  link_route;
-                bool  forbidden;
-                qdr_address_t *addr = qdr_lookup_terminus_address_CT(core, dir, conn, target, true, true, &link_route, &forbidden);
-                if (forbidden) {
-                    qdr_link_outbound_detach_CT(core, link, qdr_error(QD_AMQP_COND_NOT_ALLOWED, "Connectivity to the node is forbidden"), 0, true);
+                bool  unavailable;
+                qdr_address_t *addr = qdr_lookup_terminus_address_CT(core, dir, conn, target, true, true, &link_route, &unavailable);
+                if (unavailable) {
+                    qdr_link_outbound_detach_CT(core, link, qdr_error(QD_AMQP_COND_NOT_FOUND, "Node not found"), 0, true);
                     qdr_terminus_free(source);
                     qdr_terminus_free(target);
                 }
@@ -1374,10 +1374,10 @@ static void qdr_link_inbound_first_attach_CT(qdr_core_t *core, qdr_action_t *act
         switch (link->link_type) {
         case QD_LINK_ENDPOINT: {
             bool  link_route;
-            bool  forbidden;
-            qdr_address_t *addr = qdr_lookup_terminus_address_CT(core, dir, conn, source, true, true, &link_route, &forbidden);
-            if (forbidden) {
-                qdr_link_outbound_detach_CT(core, link, qdr_error(QD_AMQP_COND_NOT_ALLOWED, "Connectivity to the node is forbidden"), 0, true);
+            bool  unavailable;
+            qdr_address_t *addr = qdr_lookup_terminus_address_CT(core, dir, conn, source, true, true, &link_route, &unavailable);
+            if (unavailable) {
+                qdr_link_outbound_detach_CT(core, link, qdr_error(QD_AMQP_COND_NOT_FOUND, "Node not found"), 0, true);
                 qdr_terminus_free(source);
                 qdr_terminus_free(target);
             }

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -875,7 +875,7 @@ qd_address_treatment_t qdr_treatment_for_address_CT(qdr_core_t *core, qdr_connec
     if (out_phase) *out_phase = addr ? addr->out_phase : 0;
 
 
-    return addr ? addr->treatment : core->qd->treatment;
+    return addr ? addr->treatment : core->qd->default_treatment;
 }
 
 
@@ -886,7 +886,7 @@ qd_address_treatment_t qdr_treatment_for_address_hash_CT(qdr_core_t *core, qd_it
     char *copy    = storage;
     bool  on_heap = false;
     int   length  = qd_iterator_length(iter);
-    qd_address_treatment_t trt = core->qd->treatment;
+    qd_address_treatment_t trt = core->qd->default_treatment;
 
     if (length > HASH_STORAGE_SIZE) {
         copy    = (char*) malloc(length + 1);
@@ -1089,7 +1089,7 @@ static qdr_address_t *qdr_lookup_terminus_address_CT(qdr_core_t       *core,
     int addr_phase;
     qd_address_treatment_t treat = qdr_treatment_for_address_CT(core, conn, iter, &in_phase, &out_phase);
 
-    if (treat == QD_TREATMENT_LINK_FORBIDDEN) {
+    if (treat == QD_TREATMENT_FORBIDDEN) {
         *forbidden = true;
         return 0;
     }
@@ -1314,7 +1314,7 @@ static void qdr_link_inbound_first_attach_CT(qdr_core_t *core, qdr_action_t *act
                 bool  forbidden;
                 qdr_address_t *addr = qdr_lookup_terminus_address_CT(core, dir, conn, target, true, true, &link_route, &forbidden);
                 if (forbidden) {
-                    qdr_link_outbound_detach_CT(core, link, 0, QDR_CONDITION_FORBIDDEN, true);
+                    qdr_link_outbound_detach_CT(core, link, qdr_error(QD_AMQP_COND_NOT_ALLOWED, "Connectivity to the node is forbidden"), 0, true);
                     qdr_terminus_free(source);
                     qdr_terminus_free(target);
                 }
@@ -1377,7 +1377,7 @@ static void qdr_link_inbound_first_attach_CT(qdr_core_t *core, qdr_action_t *act
             bool  forbidden;
             qdr_address_t *addr = qdr_lookup_terminus_address_CT(core, dir, conn, source, true, true, &link_route, &forbidden);
             if (forbidden) {
-                qdr_link_outbound_detach_CT(core, link, 0, QDR_CONDITION_FORBIDDEN, true);
+                qdr_link_outbound_detach_CT(core, link, qdr_error(QD_AMQP_COND_NOT_ALLOWED, "Connectivity to the node is forbidden"), 0, true);
                 qdr_terminus_free(source);
                 qdr_terminus_free(target);
             }

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -274,7 +274,7 @@ void qdr_action_enqueue(qdr_core_t *core, qdr_action_t *action)
 
 qdr_address_t *qdr_address_CT(qdr_core_t *core, qd_address_treatment_t treatment)
 {
-    if (treatment == QD_TREATMENT_LINK_FORBIDDEN)
+    if (treatment == QD_TREATMENT_FORBIDDEN)
         return 0;
     qdr_address_t *addr = new_qdr_address_t();
     ZERO(addr);

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -274,7 +274,7 @@ void qdr_action_enqueue(qdr_core_t *core, qdr_action_t *action)
 
 qdr_address_t *qdr_address_CT(qdr_core_t *core, qd_address_treatment_t treatment)
 {
-    if (treatment == QD_TREATMENT_FORBIDDEN)
+    if (treatment == QD_TREATMENT_UNAVAILABLE)
         return 0;
     qdr_address_t *addr = new_qdr_address_t();
     ZERO(addr);

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -274,6 +274,8 @@ void qdr_action_enqueue(qdr_core_t *core, qdr_action_t *action)
 
 qdr_address_t *qdr_address_CT(qdr_core_t *core, qd_address_treatment_t treatment)
 {
+    if (treatment == QD_TREATMENT_LINK_FORBIDDEN)
+        return 0;
     qdr_address_t *addr = new_qdr_address_t();
     ZERO(addr);
     addr->treatment = treatment;
@@ -295,10 +297,12 @@ qdr_address_t *qdr_add_local_address_CT(qdr_core_t *core, char aclass, const cha
     qd_hash_retrieve(core->addr_hash, iter, (void**) &addr);
     if (!addr) {
         addr = qdr_address_CT(core, treatment);
-        qd_hash_insert(core->addr_hash, iter, addr, &addr->hash_handle);
-        DEQ_INSERT_TAIL(core->addrs, addr);
-        addr->block_deletion = true;
-        addr->local = (aclass == 'L');
+        if (addr) {
+            qd_hash_insert(core->addr_hash, iter, addr, &addr->hash_handle);
+            DEQ_INSERT_TAIL(core->addrs, addr);
+            addr->block_deletion = true;
+            addr->local = (aclass == 'L');
+        }
     }
     qd_iterator_free(iter);
     return addr;

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -637,16 +637,16 @@ static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery
     //
     // There is no address that we can send this delivery to, which means the addr was not found in our hastable. This
     // can be because there were no receivers or because the address was not defined in the config file.
-    // If the treatment for such addresses is set to be forbidden, we send back a rejected disposition and detach the link
+    // If the treatment for such addresses is set to be unavailable, we send back a rejected disposition and detach the link
     //
-    else if (core->qd->default_treatment == QD_TREATMENT_FORBIDDEN) {
+    else if (core->qd->default_treatment == QD_TREATMENT_UNAVAILABLE) {
         dlv->disposition = PN_REJECTED;
-        dlv->error = qdr_error(QD_AMQP_COND_NOT_ALLOWED, "Sending deliveries to this address is forbidden");
+        dlv->error = qdr_error(QD_AMQP_COND_NOT_FOUND, "Deliveries cannot be sent to an unavailable address");
         qdr_delivery_push_CT(core, dlv);
         //
         // We will not detach this link because this could be anonymous sender. We don't know
         // which address the sender will be sending to next
-        // If this was not an anonymous sender, the initial attach would have been rejected if the target address was forbidden.
+        // If this was not an anonymous sender, the initial attach would have been rejected if the target address was unavailable.
         //
         return;
     }

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -639,9 +639,9 @@ static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery
     // can be because there were no receivers or because the address was not defined in the config file.
     // If the treatment for such addresses is set to be forbidden, we send back a rejected disposition and detach the link
     //
-    else if (core->qd->treatment == QD_TREATMENT_LINK_FORBIDDEN) {
+    else if (core->qd->default_treatment == QD_TREATMENT_FORBIDDEN) {
         dlv->disposition = PN_REJECTED;
-        dlv->error = qdr_error("qd:forbidden", "Sending deliveries to this address is forbidden");
+        dlv->error = qdr_error(QD_AMQP_COND_NOT_ALLOWED, "Sending deliveries to this address is forbidden");
         qdr_delivery_push_CT(core, dlv);
         //
         // We will not detach this link because this could be anonymous sender. We don't know

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ foreach(py_test_module
     system_tests_drain
     system_tests_management
     system_tests_one_router
+    system_tests_default_distribution
     system_tests_policy
     system_tests_protocol_family
     system_tests_protocol_settings

--- a/tests/system_tests_default_distribution.py
+++ b/tests/system_tests_default_distribution.py
@@ -133,7 +133,7 @@ class ForbiddenAnonymousSender(MessagingHandler):
         self.timer = None
         self.link_name = "anon_link"
         self.error_description = "Sending deliveries to this address is forbidden"
-        self.error_name = u'qd:forbidden'
+        self.error_name = u'amqp:not-allowed'
         self.num_sent = 0
 
     def on_start(self, event):

--- a/tests/system_tests_default_distribution.py
+++ b/tests/system_tests_default_distribution.py
@@ -1,0 +1,162 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from system_test import TestCase, Qdrouterd, TIMEOUT
+from proton.handlers import MessagingHandler
+from proton.reactor import Container
+from proton import Message
+
+class DefaultDistributionTest(TestCase):
+    """System tests for testing the defaultDistribution attribute of the router entity"""
+    @classmethod
+    def setUpClass(cls):
+        super(DefaultDistributionTest, cls).setUpClass()
+        name = "test-router"
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR', "defaultDistribution": 'forbidden'}),
+
+            ('listener', {'port': cls.tester.get_port()}),
+
+            ('address', {'prefix': 'closest', 'distribution': 'closest'}),
+            ('address', {'prefix': 'spread', 'distribution': 'balanced'}),
+            ('address', {'prefix': 'multicast', 'distribution': 'multicast'})
+        ])
+        cls.router = cls.tester.qdrouterd(name, config)
+        cls.router.wait_ready()
+        cls.address = cls.router.addresses[0]
+
+    def test_create_forbidden_sender(self):
+        test = ForbiddenSender(self.address)
+        test.run()
+        self.assertTrue(test.passed)
+
+    def test_create_forbidden_receiver(self):
+        test = ForbiddenReceiver(self.address)
+        test.run()
+        self.assertTrue(test.passed)
+
+    def test_anonymous_sender(self):
+        test = ForbiddenAnonymousSender(self.address)
+        test.run()
+        self.assertTrue(test.received_error)
+class Timeout(object):
+    def __init__(self, parent):
+        self.parent = parent
+
+    def on_timer_task(self, event):
+        self.parent.timeout()
+
+class ForbiddenBase(MessagingHandler):
+    def __init__(self, address):
+        super(ForbiddenBase, self).__init__()
+        self.address = address
+        self.dest = "ForbiddenBase"
+        self.conn = None
+        self.sender = None
+        self.receiver = None
+        self.link_error = False
+        self.link_closed = False
+        self.passed = False
+        self.timer = None
+        self.link_name = "base_link"
+
+    def check_if_done(self):
+        if self.link_error and self.link_closed:
+            self.passed = True
+            self.conn.close()
+            self.timer.cancel()
+
+    def on_link_error(self, event):
+        link = event.link
+        if event.link.name == self.link_name and link.remote_condition.description \
+                == "Connectivity to the node is forbidden":
+            self.link_error = True
+        self.check_if_done()
+
+    def on_link_remote_close(self, event):
+        if event.link.name == self.link_name:
+            self.link_closed = True
+            self.check_if_done()
+
+    def run(self):
+        Container(self).run()
+
+class ForbiddenSender(ForbiddenBase):
+    def __init__(self, address):
+        super(ForbiddenSender, self).__init__(address)
+
+    def on_start(self, event):
+        self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
+        self.conn = event.container.connect(self.address)
+        # Creating a sender to an address with forbidden distribution
+        # The router will not allow this link to be established. It will close the link with an error of
+        # "Connectivity to the node is forbidden"
+        self.sender = event.container.create_sender(self.conn, self.dest, name=self.link_name)
+
+class ForbiddenReceiver(ForbiddenBase):
+    def __init__(self, address):
+        super(ForbiddenReceiver, self).__init__(address)
+
+    def on_start(self, event):
+        self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
+        self.conn = event.container.connect(self.address)
+        # Creating a receiver to an address with forbidden distribution
+        # The router will not allow this link to be established. It will close the link with an error of
+        # "Connectivity to the node is forbidden"
+        self.receiver = event.container.create_receiver(self.conn, self.dest, name=self.link_name)
+
+class ForbiddenAnonymousSender(MessagingHandler):
+    def __init__(self, address):
+        super(ForbiddenAnonymousSender, self).__init__()
+        self.address = address
+        self.dest = "ForbiddenBase"
+        self.conn = None
+        self.sender = None
+        self.receiver = None
+        self.received_error = False
+        self.timer = None
+        self.link_name = "anon_link"
+        self.error_description = "Sending deliveries to this address is forbidden"
+        self.error_name = u'qd:forbidden'
+        self.num_sent = 0
+
+    def on_start(self, event):
+        self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
+        self.conn = event.container.connect(self.address)
+        # Creating an anonymous sender
+        self.sender = event.container.create_sender(self.conn, name=self.link_name)
+
+    def on_sendable(self, event):
+        if self.num_sent < 1:
+            msg = Message(id=1, body='Hello World')
+            # this is a forbidden address
+            msg.address = "SomeForbiddenAddress"
+            event.sender.send(msg)
+            self.num_sent += 1
+
+    def on_rejected(self, event):
+        if event.link.name == self.link_name and event.delivery.remote.condition.name == self.error_name \
+                and self.error_description == event.delivery.remote.condition.description:
+            self.received_error = True
+            self.conn.close()
+            self.timer.cancel()
+
+    def run(self):
+        Container(self).run()
+

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -53,7 +53,7 @@ class RouterTest(TestCase):
             ('address', {'prefix': 'closest', 'distribution': 'closest'}),
             ('address', {'prefix': 'spread', 'distribution': 'balanced'}),
             ('address', {'prefix': 'multicast', 'distribution': 'multicast'}),
-            ('address', {'prefix': 'forbidden', 'distribution': 'forbidden'})
+            ('address', {'prefix': 'unavailable', 'distribution': 'unavailable'})
         ])
         cls.router = cls.tester.qdrouterd(name, config)
         cls.router.wait_ready()
@@ -1125,13 +1125,13 @@ class RouterTest(TestCase):
         test.run()
         self.assertEqual(None, test.error)
 
-    def test_27_create_forbidden_sender(self):
-        test = ForbiddenSender(self.address)
+    def test_27_create_unavailable_sender(self):
+        test = UnavailableSender(self.address)
         test.run()
         self.assertTrue(test.passed)
 
-    def test_28_create_forbidden_receiver(self):
-        test = ForbiddenReceiver(self.address)
+    def test_28_create_unavailable_receiver(self):
+        test = UnavailableReceiver(self.address)
         test.run()
         self.assertTrue(test.passed)
 
@@ -1245,11 +1245,11 @@ class ExcessDeliveriesReleasedTest(MessagingHandler):
     def run(self):
         Container(self).run()
 
-class ForbiddenBase(MessagingHandler):
+class UnavailableBase(MessagingHandler):
     def __init__(self, address):
-        super(ForbiddenBase, self).__init__()
+        super(UnavailableBase, self).__init__()
         self.address = address
-        self.dest = "forbidden"
+        self.dest = "unavailable"
         self.conn = None
         self.sender = None
         self.receiver = None
@@ -1268,7 +1268,7 @@ class ForbiddenBase(MessagingHandler):
     def on_link_error(self, event):
         link = event.link
         if event.link.name == self.link_name and link.remote_condition.description \
-                == "Connectivity to the node is forbidden":
+                == "Node not found":
             self.link_error = True
         self.check_if_done()
 
@@ -1280,28 +1280,28 @@ class ForbiddenBase(MessagingHandler):
     def run(self):
         Container(self).run()
 
-class ForbiddenSender(ForbiddenBase):
+class UnavailableSender(UnavailableBase):
     def __init__(self, address):
-        super(ForbiddenSender, self).__init__(address)
+        super(UnavailableSender, self).__init__(address)
 
     def on_start(self, event):
         self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
         self.conn = event.container.connect(self.address)
-        # Creating a sender to an address with forbidden distribution
+        # Creating a sender to an address with unavailable distribution
         # The router will not allow this link to be established. It will close the link with an error of
-        # "Connectivity to the node is forbidden"
+        # "Node not found"
         self.sender = event.container.create_sender(self.conn, self.dest, name=self.link_name)
 
-class ForbiddenReceiver(ForbiddenBase):
+class UnavailableReceiver(UnavailableBase):
     def __init__(self, address):
-        super(ForbiddenReceiver, self).__init__(address)
+        super(UnavailableReceiver, self).__init__(address)
 
     def on_start(self, event):
         self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
         self.conn = event.container.connect(self.address)
-        # Creating a receiver to an address with forbidden distribution
+        # Creating a receiver to an address with unavailable distribution
         # The router will not allow this link to be established. It will close the link with an error of
-        # "Connectivity to the node is forbidden"
+        # "Node not found"
         self.receiver = event.container.create_receiver(self.conn, self.dest, name=self.link_name)
 
 class MulticastUnsettledTest(MessagingHandler):

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -53,6 +53,7 @@ class RouterTest(TestCase):
             ('address', {'prefix': 'closest', 'distribution': 'closest'}),
             ('address', {'prefix': 'spread', 'distribution': 'balanced'}),
             ('address', {'prefix': 'multicast', 'distribution': 'multicast'}),
+            ('address', {'prefix': 'forbidden', 'distribution': 'forbidden'})
         ])
         cls.router = cls.tester.qdrouterd(name, config)
         cls.router.wait_ready()
@@ -1124,6 +1125,16 @@ class RouterTest(TestCase):
         test.run()
         self.assertEqual(None, test.error)
 
+    def test_27_create_forbidden_sender(self):
+        test = ForbiddenSender(self.address)
+        test.run()
+        self.assertTrue(test.passed)
+
+    def test_28_create_forbidden_receiver(self):
+        test = ForbiddenReceiver(self.address)
+        test.run()
+        self.assertTrue(test.passed)
+
     def test_reject_disposition(self):
         test = RejectDispositionTest(self.address)
         test.run()
@@ -1234,6 +1245,64 @@ class ExcessDeliveriesReleasedTest(MessagingHandler):
     def run(self):
         Container(self).run()
 
+class ForbiddenBase(MessagingHandler):
+    def __init__(self, address):
+        super(ForbiddenBase, self).__init__()
+        self.address = address
+        self.dest = "forbidden"
+        self.conn = None
+        self.sender = None
+        self.receiver = None
+        self.link_error = False
+        self.link_closed = False
+        self.passed = False
+        self.timer = None
+        self.link_name = "test_link"
+
+    def check_if_done(self):
+        if self.link_error and self.link_closed:
+            self.passed = True
+            self.conn.close()
+            self.timer.cancel()
+
+    def on_link_error(self, event):
+        link = event.link
+        if event.link.name == self.link_name and link.remote_condition.description \
+                == "Connectivity to the node is forbidden":
+            self.link_error = True
+        self.check_if_done()
+
+    def on_link_remote_close(self, event):
+        if event.link.name == self.link_name:
+            self.link_closed = True
+            self.check_if_done()
+
+    def run(self):
+        Container(self).run()
+
+class ForbiddenSender(ForbiddenBase):
+    def __init__(self, address):
+        super(ForbiddenSender, self).__init__(address)
+
+    def on_start(self, event):
+        self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
+        self.conn = event.container.connect(self.address)
+        # Creating a sender to an address with forbidden distribution
+        # The router will not allow this link to be established. It will close the link with an error of
+        # "Connectivity to the node is forbidden"
+        self.sender = event.container.create_sender(self.conn, self.dest, name=self.link_name)
+
+class ForbiddenReceiver(ForbiddenBase):
+    def __init__(self, address):
+        super(ForbiddenReceiver, self).__init__(address)
+
+    def on_start(self, event):
+        self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
+        self.conn = event.container.connect(self.address)
+        # Creating a receiver to an address with forbidden distribution
+        # The router will not allow this link to be established. It will close the link with an error of
+        # "Connectivity to the node is forbidden"
+        self.receiver = event.container.create_receiver(self.conn, self.dest, name=self.link_name)
 
 class MulticastUnsettledTest(MessagingHandler):
     def __init__(self, address):


### PR DESCRIPTION
…istribution

1. Added a new attribute to the router entity called called defaultDistribution which defaults to balanced
but can be set to forbidden
2. Attaches to forbidden addresses are rejected and the link is detached
3. Anonymous senders sending to forbidden addresses will be sent back a disposition of PN_REJECTED but link will not be closed
4. Added system test system_tests_default_distribution.py to test the above cases