### PR TITLE
DISPATCH-825: Fix interlocking between message send and receive

### DIFF
--- a/src/message_private.h
+++ b/src/message_private.h
@@ -68,6 +68,7 @@ typedef struct {
     sys_mutex_t         *lock;
     sys_atomic_t         ref_count;                       // The number of messages referencing this
     qd_buffer_list_t     buffers;                         // The buffer chain containing the message
+    qd_buffer_t         *pending;                         // Buffer owned by and filled by qd_message_receive
     qd_field_location_t  section_message_header;          // The message header list
     qd_field_location_t  section_delivery_annotation;     // The delivery annotation map
     qd_field_location_t  section_message_annotation;      // The message annotation map


### PR DESCRIPTION
Don't allow a buffer on the message buffer chain that might be removed.
Use a content-based pending buffer instead.
Don't release message lock between adding final buffer and setting
receive_complete flag.