### PR TITLE
DISPATCH-818 - Added connection info list to the connector which stor…

### DIFF
--- a/include/qpid/dispatch/failoverlist.h
+++ b/include/qpid/dispatch/failoverlist.h
@@ -1,5 +1,6 @@
 #ifndef __failoverlist_h__
 #define __failoverlist_h__ 1
+#include <qpid/dispatch/ctools.h>
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -23,6 +24,17 @@
  * qd_failover_list_t - This type stores one failover list.
  */
 typedef struct qd_failover_list_t qd_failover_list_t;
+
+typedef struct qd_failover_item_t {
+    DEQ_LINKS(struct qd_failover_item_t);
+    char *scheme;
+    char *host;
+    char *port;
+    char *hostname;
+    char *host_port;
+} qd_failover_item_t;
+
+DEQ_DECLARE(qd_failover_item_t, qd_failover_item_list_t);
 
 /**
  * qd_failover_list

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -895,7 +895,13 @@
                     "default": "none",
                     "description": "A comma separated list that indicates which components of the message should be logged (no spaces allowed between list components). Defaults to 'none' (log nothing). If you want all properties and application properties of the message logged use 'all'. Specific components of the message can be logged by indicating the components via a comma separated list. The components are message-id, user-id, to, subject, reply-to, correlation-id, content-type, content-encoding, absolute-expiry-time, creation-time, group-id, group-sequence, reply-to-group-id, app-properties. The application-data part of the bare message will not be logged. This log message is written to the MESSAGE logging module. In the 'log' entity, set 'module' property to MESSAGE or DEFAULT and 'enable' to trace+ to see this log message",
                     "create": true
-                }
+                },
+                "failoverList": {
+                    "type": "string",
+                    "description": "A read-only, comma-separated list of failover urls. ",
+                    "create": false
+                    
+                }            
             }
         },
 

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -633,7 +633,46 @@ qd_error_t qd_entity_refresh_listener(qd_entity_t* entity, void *impl)
 
 qd_error_t qd_entity_refresh_connector(qd_entity_t* entity, void *impl)
 {
-    return QD_ERROR_NONE;
+    qd_connector_t *ct = (qd_connector_t*) impl;
+
+    if (DEQ_SIZE(ct->conn_info_list) > 1) {
+        qd_failover_item_list_t   conn_info_list = ct->conn_info_list;
+
+        qd_failover_item_t *item = DEQ_HEAD(conn_info_list);
+
+        //
+        // As you can see we are skipping the head of the list. The
+        // first item in the list is always the original connection information
+        // and we dont want to display that information as part of the failover list.
+        //
+        char failover_info[250];
+        memset(failover_info, 0, sizeof(failover_info));
+
+        item = DEQ_NEXT(item);
+
+        while(item) {
+            if (item->scheme) {
+                strcat(failover_info, item->scheme);
+                strcat(failover_info, "://");
+            }
+            if (item->host_port) {
+                strcat(failover_info, item->host_port);
+            }
+            item = DEQ_NEXT(item);
+            if (item) {
+                strcat(failover_info, ", ");
+            }
+        }
+
+        if (qd_entity_set_string(entity, "failoverList", failover_info) == 0)
+            return QD_ERROR_NONE;
+    }
+    else {
+        if (qd_entity_clear(entity, "failoverList") == 0)
+            return QD_ERROR_NONE;
+    }
+
+    return qd_error_code();
 }
 
 
@@ -645,6 +684,24 @@ qd_connector_t *qd_dispatch_configure_connector(qd_dispatch_t *qd, qd_entity_t *
         DEQ_ITEM_INIT(ct);
         DEQ_INSERT_TAIL(cm->connectors, ct);
         log_config(cm->log_source, &ct->config, "Connector");
+
+        //
+        // Add the first item to the ct->conn_info_list
+        // The initial connection information and any backup connection information is stored in the conn_info_list
+        //
+        qd_failover_item_t *item = NEW(qd_failover_item_t);
+        ZERO(item);
+        item->scheme   = 0;
+        item->host     = strdup(ct->config.host);
+        item->port     = strdup(ct->config.port);
+        item->hostname = 0;
+
+        int hplen = strlen(item->host) + strlen(item->port) + 2;
+        item->host_port = malloc(hplen);
+        snprintf(item->host_port, hplen, "%s:%s", item->host , item->port);
+
+        DEQ_INSERT_TAIL(ct->conn_info_list, item);
+
         return ct;
     }
     qd_log(cm->log_source, QD_LOG_ERROR, "Unable to create connector: %s", qd_error_message());

--- a/src/failoverlist.c
+++ b/src/failoverlist.c
@@ -23,16 +23,6 @@
 #include <ctype.h>
 #include <string.h>
 
-typedef struct qd_failover_item_t {
-    DEQ_LINKS(struct qd_failover_item_t);
-    const char *scheme;
-    const char *host;
-    const char *port;
-    const char *hostname;
-} qd_failover_item_t;
-
-DEQ_DECLARE(qd_failover_item_t, qd_failover_item_list_t);
-
 struct qd_failover_list_t {
     qd_failover_item_list_t  item_list;
     char                    *text;

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -119,6 +119,10 @@ struct qd_connector_t {
     sys_mutex_t              *lock;
     cxtr_state_t              state;
     qd_connection_t          *ctx;
+
+    /* This conn_list contains all the connection information needed to make a connection. It also includes failover connection information */
+    qd_failover_item_list_t   conn_info_list;
+    int                       conn_index; // Which connection in the connection list to connect to next.
     DEQ_LINKS(qd_connector_t);
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ foreach(py_test_module
     system_tests_drain
     system_tests_management
     system_tests_one_router
+    system_tests_handle_failover
     system_tests_default_distribution
     system_tests_policy
     system_tests_protocol_family

--- a/tests/system_tests_handle_failover.py
+++ b/tests/system_tests_handle_failover.py
@@ -1,0 +1,140 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import json, re
+from time import sleep
+import system_test
+from system_test import TestCase, Qdrouterd, Process, TIMEOUT
+from subprocess import PIPE, STDOUT
+
+class FailoverTest(TestCase):
+    inter_router_port = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(FailoverTest, cls).setUpClass()
+
+        def router(name, config):
+            config = Qdrouterd.Config(config)
+
+            cls.routers.append(cls.tester.qdrouterd(name, config, wait=True))
+
+        cls.routers = []
+
+        inter_router_port = cls.tester.get_port()
+        cls.inter_router_port_1 = cls.tester.get_port()
+        cls.backup_port = cls.tester.get_port()
+        cls.failover_list = 'amqp://third-host:5671, ' + 'amqp://localhost:' + str(cls.backup_port)
+
+        #
+        # Router A tries to connect to Router B via its connectorToB. Router B responds with an open frame which will
+        # have the failover-server-list as one of its connection properties like the following -
+        # [0x13024d0]:0 <- @open(16) [container-id="Router.A", max-frame-size=16384, channel-max=32767,
+        # idle-time-out=8000, offered-capabilities=:"ANONYMOUS-RELAY",
+        # properties={:product="qpid-dispatch-router", :version="1.0.0",
+        #  :"failover-server-list"=[{:"network-host"="some-host", :port="35000"},
+        #  {:"network-host"="localhost", :port="25000"}]}]
+        #
+        # The suite of tests determine if the router receiving this open frame stores it properly and if the
+        # original connection goes down, check that the router is trying to make connections to the failover urls.
+        #
+        router('QDR.B', [
+                        ('router', {'mode': 'interior', 'id': 'QDR.B'}),
+                        ('listener', {'role': 'inter-router', 'port': inter_router_port,
+                                      'failoverList': cls.failover_list}),
+                        ('listener', {'role': 'normal', 'port': cls.tester.get_port()}),
+                        ]
+              )
+        router('QDR.A',
+                    [
+                        ('router', {'mode': 'interior', 'id': 'QDR.A'}),
+                        ('listener', {'role': 'normal', 'port': cls.tester.get_port()}),
+                        ('connector', {'name': 'connectorToB', 'role': 'inter-router',
+                                       'port': inter_router_port, 'verifyHostName': 'no'}),
+                    ]
+               )
+
+        router('QDR.C', [
+                            ('router', {'mode': 'interior', 'id': 'QDR.C'}),
+                            ('listener', {'role': 'inter-router', 'port': cls.backup_port}),
+                            ('listener', {'role': 'normal', 'port': cls.tester.get_port()}),
+                        ]
+              )
+
+        cls.routers[1].wait_router_connected('QDR.B')
+
+    def address(self):
+        return self.routers[1].addresses[0]
+
+    def run_qdmanage(self, cmd, input=None, expect=Process.EXIT_OK, address=None):
+        p = self.popen(
+            ['qdmanage'] + cmd.split(' ') + ['--bus', address or self.address(), '--indent=-1', '--timeout', str(TIMEOUT)],
+            stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=expect)
+        out = p.communicate(input)[0]
+        try:
+            p.teardown()
+        except Exception, e:
+            raise Exception("%s\n%s" % (e, out))
+        return out
+
+    def run_qdstat(self, args, regexp=None, address=None):
+        p = self.popen(
+            ['qdstat', '--bus', str(address or self.router.addresses[0]), '--timeout', str(system_test.TIMEOUT) ] + args,
+            name='qdstat-'+self.id(), stdout=PIPE, expect=None)
+
+        out = p.communicate()[0]
+        assert p.returncode == 0, \
+            "qdstat exit status %s, output:\n%s" % (p.returncode, out)
+        if regexp: assert re.search(regexp, out, re.I), "Can't find '%s' in '%s'" % (regexp, out)
+        return out
+
+    def test_connector_has_failover_list(self):
+        """
+        Makes a qdmanage connector query and checks if Router A is storing the failover information received from
+        Router B.
+        :return:
+        """
+        long_type = 'org.apache.qpid.dispatch.connector'
+        query_command = 'QUERY --type=' + long_type
+        output = json.loads(self.run_qdmanage(query_command))
+        self.assertIn(FailoverTest.failover_list, output[0]['failoverList'])
+
+    def test_remove_router_B(self):
+        # First make sure there are no inter-router connections on router C
+        outs = self.run_qdstat(['--connections'], address=self.routers[2].addresses[1])
+        self.assertNotIn('inter-router', outs)
+
+        # Kill the router B
+        FailoverTest.routers[0].teardown()
+
+        # Make sure that the router B is gone
+        # You need to sleep 5 seconds for the router to cycle thru the failover urls and make a successful connection
+        # to Router C
+        sleep(4)
+
+        long_type = 'org.apache.qpid.dispatch.connector'
+        query_command = 'QUERY --type=' + long_type
+        output = json.loads(self.run_qdmanage(query_command, address=self.routers[1].addresses[0]))
+        # The failoverList must now be gone since the backup router does not send a failoverList in its
+        # connection properties.
+        self.assertIsNone(output[0].get('failoverList'))
+
+        # Since router B has been killed, router A should now try to connect to a listener on router C.
+        # Use qdstat to connect to router C and determine that there is an inter-router connection with router A.
+        self.run_qdstat(['--connections'], regexp=r'QDR.A.*inter-router.*', address=self.routers[2].addresses[1])


### PR DESCRIPTION
…es the initial connection information and the backup connection information

1. If the primary connection goes down, the primary and the backup connections will be tried in quick succession
2. If the new backup connection does not provide failover-server-list, the list on the server is cleaned up to contain only the one pertinent connection info.
3. The connection info list always has at least one element in it which represents the initial successful connection information