### PR TITLE
DISPATCH-813: change lifecycle of link route to remove reference count

### DIFF
--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -338,6 +338,12 @@ void qdr_core_remove_address(qdr_core_t *core, qdr_address_t *addr)
     // Remove the address from the list, hash index, and parse tree
     DEQ_REMOVE(core->addrs, addr);
     if (addr->hash_handle) {
+        const char *a_str = (const char *)qd_hash_key_by_handle(addr->hash_handle);
+        if (QDR_IS_LINK_ROUTE(a_str[0])) {
+            qd_iterator_t *iter = qd_iterator_string(a_str, ITER_VIEW_ALL);
+            qdr_link_route_unmap_pattern_CT(core, iter);
+            qd_iterator_free(iter);
+        }
         qd_hash_remove_by_handle(core->addr_hash, addr->hash_handle);
         qd_hash_handle_free(addr->hash_handle);
     }

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -445,7 +445,6 @@ struct qdr_address_t {
     qd_address_treatment_t     treatment;
     qdr_forwarder_t           *forwarder;
     int                        ref_count;     ///< Number of link-routes + auto-links referencing this address
-    int                        map_count;     ///< parse tree map/unmap operations for link route patterns
     bool                       block_deletion;
     bool                       local;
     uint32_t                   tracked_deliveries;


### PR DESCRIPTION
Remove the ref counting when adding/removing link route patterns and
instead simply add the pattern when the address is first added to the
hash table, and remove it when the address is removed.

Technique proposed by Ted Ross.