### PR TITLE
DISPATCH-845 - Added connection-scoped link-route destinations.

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -144,6 +144,7 @@ extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_NETHOST_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_PORT_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_SCHEME_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_HOSTNAME_KEY;
+extern const char * const QD_CONNECTION_PROPERTY_LINK_ROUTE_PATTERNS;
 /// @}
 
 /** @name AMQP error codes. */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -47,6 +47,7 @@ const char * const QD_CONNECTION_PROPERTY_FAILOVER_NETHOST_KEY  = "network-host"
 const char * const QD_CONNECTION_PROPERTY_FAILOVER_PORT_KEY     = "port";
 const char * const QD_CONNECTION_PROPERTY_FAILOVER_SCHEME_KEY   = "scheme";
 const char * const QD_CONNECTION_PROPERTY_FAILOVER_HOSTNAME_KEY = "hostname";
+const char * const QD_CONNECTION_PROPERTY_LINK_ROUTE_PATTERNS   = "qd.link-route-patterns";
 
 const qd_amqp_error_t QD_AMQP_OK = { 200, "OK" };
 const qd_amqp_error_t QD_AMQP_CREATED = { 201, "Created" };

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -1181,14 +1181,11 @@ static void qdr_connection_opened_CT(qdr_core_t *core, qdr_action_t *action, boo
         DEQ_ITEM_INIT(conn);
         DEQ_INSERT_TAIL(core->open_connections, conn);
 
-        if (conn->role == QDR_ROLE_NORMAL) {
-            //
-            // No action needed for NORMAL connections
-            //
-            qdr_field_free(action->args.connection.connection_label);
-            qdr_field_free(action->args.connection.container_id);
-            return;
-        }
+        //
+        // Notify the router-control module of the new connection.  There may be
+        // important side-effects in the router core that result.
+        //
+        qdr_route_connection_opened_CT(core, conn, action->args.connection.container_id, action->args.connection.connection_label);
 
         if (conn->role == QDR_ROLE_INTER_ROUTER) {
             //
@@ -1215,22 +1212,6 @@ static void qdr_connection_opened_CT(qdr_core_t *core, qdr_action_t *action, boo
                 (void) qdr_create_link_CT(core, conn, QD_LINK_ROUTER,  QD_INCOMING, qdr_terminus_router_data(), qdr_terminus_router_data());
                 (void) qdr_create_link_CT(core, conn, QD_LINK_ROUTER,  QD_OUTGOING, qdr_terminus_router_data(), qdr_terminus_router_data());
             }
-        }
-
-        if (conn->role == QDR_ROLE_ROUTE_CONTAINER) {
-            //
-            // Notify the route-control module that a route-container connection has opened.
-            // There may be routes that need to be activated due to the opening of this connection.
-            //
-
-            //
-            // If there's a connection label, use it as the identifier.  Otherwise, use the remote
-            // container id.
-            //
-            qdr_field_t *cid = action->args.connection.connection_label ?
-                action->args.connection.connection_label : action->args.connection.container_id;
-            if (cid)
-                qdr_route_connection_opened_CT(core, conn, action->args.connection.container_id, action->args.connection.connection_label);
         }
     }
 

--- a/src/router_core/route_control.c
+++ b/src/router_core/route_control.c
@@ -266,6 +266,115 @@ static void qdr_auto_link_deactivate_CT(qdr_core_t *core, qdr_auto_link_t *al, q
 }
 
 
+static void qdr_router_add_link_route_pattern_CT(qdr_core_t *core, qdr_connection_t *conn, const char *pattern, qd_direction_t dir)
+{
+    if (*pattern == '\0')
+        return;
+
+    char          *addr_hash = qdr_link_route_pattern_to_address(pattern, dir);
+    qd_iterator_t *iter      = qd_iterator_string(addr_hash + 1, ITER_VIEW_ADDRESS_HASH);
+    qdr_address_t *addr      = 0;
+
+    qd_iterator_annotate_prefix(iter, addr_hash[0]);
+    if (conn->tenant_space)
+        qd_iterator_annotate_space(iter, conn->tenant_space, conn->tenant_space_len);
+
+    qd_hash_retrieve(core->addr_hash, iter, (void*) &addr);
+    if (!addr) {
+        addr = qdr_address_CT(core, QD_TREATMENT_LINK_BALANCED);
+        DEQ_INSERT_TAIL(core->addrs, addr);
+        qd_hash_insert(core->addr_hash, iter, addr, &addr->hash_handle);
+        qdr_link_route_map_pattern_CT(core, iter, addr);
+    }
+
+    qdr_add_address_ref(&conn->addr_refs, addr);
+    qdr_add_connection_ref(&addr->conns, conn);
+    if (DEQ_SIZE(addr->conns) == 1) {
+        char *hash_key = (char*) qd_iterator_copy(iter);
+        qdr_post_mobile_added_CT(core, hash_key);
+        free(hash_key);
+    }
+
+    free(addr_hash);
+}
+
+
+static void qdr_route_use_connection_properties_CT(qdr_core_t *core, qdr_connection_t *conn)
+{
+    pn_data_t *p = conn->connection_info->connection_properties;
+
+    //
+    // If there are no connection properties, we have nothing to do.
+    //
+    if (!p)
+        return;
+
+    pn_data_rewind(p);
+    pn_data_next(p);
+
+    //
+    // If the connection properties are not a map, there's no point in continuing.
+    //
+    if (pn_data_type(p) != PN_MAP)
+        return;
+
+    pn_data_enter(p);
+    pn_data_next(p);
+
+    //
+    // Work across the map looking for keys that are relevant for route modification.
+    //
+    while (pn_data_type(p) == PN_SYMBOL) {
+        pn_bytes_t key = pn_data_get_symbol(p);
+        if (strcmp(key.start, QD_CONNECTION_PROPERTY_LINK_ROUTE_PATTERNS) == 0) {
+            //
+            // The connected container wants to receive link-routed attaches.
+            //
+            pn_data_next(p);
+            if (pn_data_type(p) == PN_LIST) {
+                pn_data_enter(p);
+                pn_data_next(p);
+                while (pn_data_type(p) == PN_STRING) {
+                    pn_bytes_t pattern = pn_data_get_string(p);
+                    pn_data_next(p);
+                    if (pn_data_type(p) == PN_SYMBOL) {
+                        pn_bytes_t dir = pn_data_get_symbol(p);
+                        pn_data_next(p);
+                        if (strcmp(dir.start, "in") == 0 || strcmp(dir.start, "inout") == 0)
+                            qdr_router_add_link_route_pattern_CT(core, conn, pattern.start, QD_INCOMING);
+                        if (strcmp(dir.start, "out") == 0 || strcmp(dir.start, "inout") == 0)
+                            qdr_router_add_link_route_pattern_CT(core, conn, pattern.start, QD_OUTGOING);
+                    } else
+                        break;
+                }
+                pn_data_exit(p);
+            }
+        } else
+            pn_data_next(p);
+        pn_data_next(p);
+    }
+
+    pn_data_exit(p);
+    pn_data_rewind(p);
+}
+
+
+static void qdr_route_cleanup_connection_CT(qdr_core_t *core, qdr_connection_t *conn)
+{
+    qdr_address_ref_t *ref = DEQ_HEAD(conn->addr_refs);
+
+    while (ref) {
+        qdr_address_t *addr = ref->addr;
+        if (DEQ_SIZE(addr->conns) == 1)
+            qdr_post_mobile_removed_CT(core, (const char*) qd_hash_key_by_handle(addr->hash_handle));
+        qdr_del_connection_ref(&addr->conns, conn);
+        qdr_del_address_ref(&conn->addr_refs, addr);
+        qdr_check_addr_CT(core, addr, false);
+        ref = DEQ_HEAD(conn->addr_refs);
+    }
+}
+
+
 qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
                                               qd_iterator_t          *name,
                                               qd_parsed_field_t      *prefix_field,
@@ -321,7 +430,6 @@ qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
             qd_hash_insert(core->addr_hash, a_iter, lr->addr, &lr->addr->hash_handle);
             qdr_link_route_map_pattern_CT(core, a_iter, lr->addr);
         }
-
         qd_iterator_free(a_iter);
         free(addr_hash);
     }
@@ -485,15 +593,26 @@ void qdr_route_connection_opened_CT(qdr_core_t       *core,
                                     qdr_field_t      *container_field,
                                     qdr_field_t      *connection_field)
 {
+    //
+    // If this is a normal or route-container connection, check the connection
+    // properties to see if there are any routing directives in there that need
+    // to be honored.
+    //
+    if (conn->role == QDR_ROLE_ROUTE_CONTAINER ||
+        conn->role == QDR_ROLE_NORMAL)
+        qdr_route_use_connection_properties_CT(core, conn);
+
+    //
+    // The rest of this function is for router-container connections only.
+    //
     if (conn->role != QDR_ROLE_ROUTE_CONTAINER)
         return;
 
     qdr_conn_identifier_t *cid = qdr_route_declare_id_CT(core,
-            container_field?container_field->iterator:0, connection_field?connection_field->iterator:0);
-
+                                                         container_field  ? container_field->iterator  : 0,
+                                                         connection_field ? connection_field->iterator : 0);
     qdr_add_connection_ref(&cid->connection_refs, conn);
-
-    conn->conn_id        = cid;
+    conn->conn_id = cid;
 
     //
     // Activate all link-routes associated with this remote container.
@@ -517,6 +636,14 @@ void qdr_route_connection_opened_CT(qdr_core_t       *core,
 
 void qdr_route_connection_closed_CT(qdr_core_t *core, qdr_connection_t *conn)
 {
+    //
+    // If this is a normal or route-container connection, undo any routing entries
+    // that are associated with the connection.
+    //
+    if (conn->role == QDR_ROLE_ROUTE_CONTAINER ||
+        conn->role == QDR_ROLE_NORMAL)
+        qdr_route_cleanup_connection_CT(core, conn);
+
     if (conn->role != QDR_ROLE_ROUTE_CONTAINER)
         return;
 
@@ -599,3 +726,5 @@ void qdr_link_route_unmap_pattern_CT(qdr_core_t *core, qd_iterator_t *address)
     qd_iterator_free(iter);
     free(pattern);
 }
+
+

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -33,6 +33,7 @@ ALLOC_DEFINE(qdr_link_ref_t);
 ALLOC_DEFINE(qdr_general_work_t);
 ALLOC_DEFINE(qdr_link_work_t);
 ALLOC_DEFINE(qdr_connection_ref_t);
+ALLOC_DEFINE(qdr_address_ref_t);
 ALLOC_DEFINE(qdr_connection_info_t);
 
 static void qdr_general_handler(void *context);
@@ -415,6 +416,29 @@ void qdr_del_connection_ref(qdr_connection_ref_list_t *ref_list, qdr_connection_
         if (ref->conn == conn) {
             DEQ_REMOVE(*ref_list, ref);
             free_qdr_connection_ref_t(ref);
+            break;
+        }
+        ref = DEQ_NEXT(ref);
+    }
+}
+
+
+void qdr_add_address_ref(qdr_address_ref_list_t *ref_list, qdr_address_t *addr)
+{
+    qdr_address_ref_t *ref = new_qdr_address_ref_t();
+    DEQ_ITEM_INIT(ref);
+    ref->addr = addr;
+    DEQ_INSERT_TAIL(*ref_list, ref);
+}
+
+
+void qdr_del_address_ref(qdr_address_ref_list_t *ref_list, qdr_address_t *addr)
+{
+    qdr_address_ref_t *ref = DEQ_HEAD(*ref_list);
+    while (ref) {
+        if (ref->addr == addr) {
+            DEQ_REMOVE(*ref_list, ref);
+            free_qdr_address_ref_t(ref);
             break;
         }
         ref = DEQ_NEXT(ref);

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -36,6 +36,7 @@ typedef struct qdr_link_route_t      qdr_link_route_t;
 typedef struct qdr_auto_link_t       qdr_auto_link_t;
 typedef struct qdr_conn_identifier_t qdr_conn_identifier_t;
 typedef struct qdr_connection_ref_t  qdr_connection_ref_t;
+typedef struct qdr_address_ref_t     qdr_address_ref_t;
 
 qdr_forwarder_t *qdr_forwarder_CT(qdr_core_t *core, qd_address_treatment_t treatment);
 int qdr_forward_message_CT(qdr_core_t *core, qdr_address_t *addr, qd_message_t *msg, qdr_delivery_t *in_delivery,
@@ -474,6 +475,17 @@ struct qdr_address_t {
 ALLOC_DECLARE(qdr_address_t);
 DEQ_DECLARE(qdr_address_t, qdr_address_list_t);
 
+struct qdr_address_ref_t {
+    DEQ_LINKS(qdr_address_ref_t);
+    qdr_address_t *addr;
+};
+
+ALLOC_DECLARE(qdr_address_ref_t);
+DEQ_DECLARE(qdr_address_ref_t, qdr_address_ref_list_t);
+
+void qdr_add_address_ref(qdr_address_ref_list_t *ref_list, qdr_address_t *addr);
+void qdr_del_address_ref(qdr_address_ref_list_t *ref_list, qdr_address_t *addr);
+
 qdr_address_t *qdr_address_CT(qdr_core_t *core, qd_address_treatment_t treatment);
 qdr_address_t *qdr_add_local_address_CT(qdr_core_t *core, char aclass, const char *addr, qd_address_treatment_t treatment);
 void qdr_core_remove_address(qdr_core_t *core, qdr_address_t *addr);
@@ -538,6 +550,7 @@ struct qdr_connection_t {
     sys_mutex_t                *work_lock;
     qdr_link_ref_list_t         links;
     qdr_link_ref_list_t         links_with_work;
+    qdr_address_ref_list_t      addr_refs;
     char                       *tenant_space;
     int                         tenant_space_len;
     qdr_connection_info_t      *connection_info;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ foreach(py_test_module
     system_tests_failover_list
     system_tests_denied_unsettled_multicast
     system_tests_auth_service_plugin
+    system_tests_dynamic_link_routes
     ${SYSTEM_TESTS_HTTP}
     )
 

--- a/tests/system_tests_dynamic_link_routes.py
+++ b/tests/system_tests_dynamic_link_routes.py
@@ -1,0 +1,349 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest, os, json
+from subprocess import PIPE, STDOUT
+from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout, symbol
+from system_test import TestCase, Qdrouterd, main_module, DIR, Process
+from proton.handlers import MessagingHandler
+from proton.reactor import Container, DynamicNodeProperties
+
+# PROTON-828:
+try:
+    from proton import MODIFIED
+except ImportError:
+    from proton import PN_STATUS_MODIFIED as MODIFIED
+
+
+class RouterTest(TestCase):
+
+    inter_router_port = None
+
+    @classmethod
+    def setUpClass(cls):
+        """Start a router"""
+        super(RouterTest, cls).setUpClass()
+
+        def router(name, connection):
+
+            config = [
+                ('router', {'mode': 'interior', 'id': name}),
+                ('listener', {'port': cls.tester.get_port(), 'stripAnnotations': 'no'}),
+                ('listener', {'port': cls.tester.get_port(), 'stripAnnotations': 'no', 'multiTenant': 'yes'}),
+                ('listener', {'port': cls.tester.get_port(), 'stripAnnotations': 'no', 'role': 'route-container'}),
+                ('address', {'prefix': 'closest', 'distribution': 'closest'}),
+                ('address', {'prefix': 'spread', 'distribution': 'balanced'}),
+                ('address', {'prefix': 'multicast', 'distribution': 'multicast'}),
+                connection
+            ]
+
+            config = Qdrouterd.Config(config)
+
+            cls.routers.append(cls.tester.qdrouterd(name, config, wait=True))
+
+        cls.routers = []
+
+        inter_router_port = cls.tester.get_port()
+
+        router('A', ('listener', {'role': 'inter-router', 'port': inter_router_port}))
+        router('B', ('connector', {'name': 'connectorToA', 'role': 'inter-router', 'port': inter_router_port, 'verifyHostName': 'no'}))
+
+        cls.routers[0].wait_router_connected('B')
+        cls.routers[1].wait_router_connected('A')
+
+
+    def test_01_single_incoming_prefix(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.prefix.#', symbol('in')]},
+                                    [u'ClinkRoute.prefix'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_02_single_outgoing_prefix(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.prefix.#', symbol('out')]},
+                                    [u'DlinkRoute.prefix'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_03_single_inout_prefix(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.prefix.#', symbol('inout')]},
+                                    [u'ClinkRoute.prefix', u'DlinkRoute.prefix'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_04_single_incoming_pattern(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.*.pattern.#', symbol('in')]},
+                                    [u'ElinkRoute.*.pattern.#'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_05_single_outgoing_pattern(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.*.pattern.#', symbol('out')]},
+                                    [u'FlinkRoute.*.pattern.#'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_06_single_inout_pattern(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.*.pattern.#', symbol('inout')]},
+                                    [u'ElinkRoute.*.pattern.#', u'FlinkRoute.*.pattern.#'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_07_pattern_in_flat_noise(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('earlier-property'):u'value',
+                                     symbol('qd.link-route-patterns'):[u'linkRoute.*.pattern.#', symbol('inout')],
+                                     symbol('later-property'):u'value'},
+                                    [u'ElinkRoute.*.pattern.#', u'FlinkRoute.*.pattern.#'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_08_pattern_in_deep_noise(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('earlier-property'):{symbol('first-sub'):u'value',
+                                                                 symbol('second-sub'):45},
+                                     symbol('qd.link-route-patterns'):[u'linkRoute.*.pattern.#', symbol('inout')],
+                                     symbol('later-property'):[u'one', u'two', u'three']},
+                                    [u'ElinkRoute.*.pattern.#', u'FlinkRoute.*.pattern.#'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_09_prefix_on_route_container(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[2],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.prefix.#', symbol('in')]},
+                                    [u'ClinkRoute.prefix'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_10_multiple_patterns(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[0],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.prefix.#', symbol('in'),
+                                                                       u'some.*.pattern.#.end', symbol('out'),
+                                                                       u'another.pattern.*.x', symbol('inout')]},
+                                    [u'ClinkRoute.prefix', u'Fsome.*.pattern.#.end',
+                                     u'Eanother.pattern.*.x', u'Fanother.pattern.*.x'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_11_prefix_with_multi_tenancy(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[1],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.prefix.#', symbol('inout')]},
+                                    [u'C0.0.0.0/linkRoute.prefix', u'D0.0.0.0/linkRoute.prefix'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+    def test_12_pattern_with_multi_tenancy(self):
+        test = DynamicLinkRouteTest(self.routers[0].addresses[1],
+                                    self.routers[0].addresses[0],
+                                    self.routers[1].addresses[0],
+                                    {symbol('qd.link-route-patterns'):[u'linkRoute.#.prefix.#', symbol('inout')]},
+                                    [u'E0.0.0.0/linkRoute.#.prefix.#', u'F0.0.0.0/linkRoute.#.prefix.#'])
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+class Entity(object):
+    def __init__(self, status_code, status_description, attrs):
+        self.status_code        = status_code
+        self.status_description = status_description
+        self.attrs              = attrs
+
+    def __getattr__(self, key):
+        return self.attrs[key]
+
+
+class RouterProxy(object):
+    def __init__(self, reply_addr):
+        self.reply_addr = reply_addr
+
+    def response(self, msg):
+        ap = msg.properties
+        return Entity(ap['statusCode'], ap['statusDescription'], msg.body)
+
+    def read_address(self, name):
+        ap = {'operation': 'READ', 'type': 'org.apache.qpid.dispatch.router.address', 'name': name}
+        return Message(properties=ap, reply_to=self.reply_addr)
+
+    def query_addresses(self):
+        ap = {'operation': 'QUERY', 'type': 'org.apache.qpid.dispatch.router.address'}
+        return Message(properties=ap, reply_to=self.reply_addr)
+
+
+class Timeout(object):
+    def __init__(self, parent):
+        self.parent = parent
+
+    def on_timer_task(self, event):
+        self.parent.timeout()
+
+
+class PollTimeout(object):
+    def __init__(self, parent):
+        self.parent = parent
+
+    def on_timer_task(self, event):
+        self.parent.poll_timeout()
+
+
+class DynamicLinkRouteTest(MessagingHandler):
+    def __init__(self, local_host, local_mgmt_host, remote_mgmt_host, properties, expected_addresses):
+        super(DynamicLinkRouteTest, self).__init__()
+        self.local_host       = local_host
+        self.local_mgmt_host  = local_mgmt_host
+        self.remote_mgmt_host = remote_mgmt_host
+        self.properties       = properties
+        self.expected_local   = expected_addresses
+        self.expected_remote  = expected_addresses[:]  # Make a copy
+        self.removed_local    = expected_addresses[:]  # Make a copy
+        self.removed_remote   = expected_addresses[:]  # Make a copy
+
+        self.local_conn       = None
+        self.local_mgmt_conn  = None
+        self.remote_mgmt_conn = None
+        self.error            = None
+        self.proxy            = None
+        self.timer            = None
+        self.poll_timer       = None
+
+    def timeout(self):
+        self.error = "Timeout Expired - local: %r  remote: %r  rlocal: %r  rremote: %r" %\
+                     (self.expected_local, self.expected_remote, self.removed_local, self.removed_remote)
+        if len(self.expected_local) + len(self.expected_remote) > 0:
+            self.local_conn.close()
+        self.local_mgmt_conn.close()
+        self.remote_mgmt_conn.close()
+        if self.poll_timer:
+            self.poll_timer.cancel()
+
+    def poll_timeout(self):
+        self.poll_timer = None
+        self.send_management_request()
+
+    def send_management_request(self):
+        if len(self.expected_local) > 0:
+            message = self.proxy.read_address(self.expected_local[0])
+            self.local_sender.send(message)
+            return
+        
+        if len(self.expected_remote) > 0:
+            message = self.proxy.read_address(self.expected_remote[0])
+            self.remote_sender.send(message)
+            return
+
+        if len(self.removed_local) > 0:
+            message = self.proxy.read_address(self.removed_local[0])
+            self.local_sender.send(message)
+            return
+        
+        if len(self.removed_remote) > 0:
+            message = self.proxy.read_address(self.removed_remote[0])
+            self.remote_sender.send(message)
+            return
+
+        self.local_mgmt_conn.close()
+        self.remote_mgmt_conn.close()
+        self.timer.cancel()
+
+    def on_start(self, event):
+        self.timer            = event.reactor.schedule(15.0, Timeout(self))
+        self.local_conn       = event.container.connect(self.local_host, properties=self.properties)
+        self.local_mgmt_conn  = event.container.connect(self.local_mgmt_host)
+        self.remote_mgmt_conn = event.container.connect(self.remote_mgmt_host)
+        self.reply_receiver   = event.container.create_receiver(self.local_mgmt_conn, dynamic=True)
+
+    def on_link_opened(self, event):
+        if event.receiver == self.reply_receiver:
+            self.proxy         = RouterProxy(self.reply_receiver.remote_source.address)
+            self.local_sender  = event.container.create_sender(self.local_mgmt_conn,  "$management")
+            self.remote_sender = event.container.create_sender(self.remote_mgmt_conn, "$management")
+            self.send_management_request()
+
+    def on_message(self, event):
+        if event.receiver == self.reply_receiver:
+            response = self.proxy.response(event.message)
+            if len(self.expected_local) > 0:
+                if response.status_code == 200:
+                    if response.name == self.expected_local[0] and response.containerCount == 1 and response.remoteCount == 0:
+                        self.expected_local.pop(0)
+                        self.send_management_request()
+                        return
+            elif len(self.expected_remote) > 0:
+                if response.status_code == 200:
+                    if response.name == self.expected_remote[0] and response.containerCount == 0 and response.remoteCount == 1:
+                        self.expected_remote.pop(0)
+                        self.send_management_request()
+                        if len(self.expected_remote) == 0:
+                            self.local_conn.close()
+                        return
+            elif len(self.removed_local) > 0:
+                if response.status_code == 404:
+                    self.removed_local.pop(0)
+                    self.send_management_request()
+                    return
+            elif len(self.removed_remote) > 0:
+                if response.status_code == 404:
+                    self.removed_remote.pop(0)
+                    self.send_management_request()
+                    return
+            self.poll_timer = event.reactor.schedule(0.1, PollTimeout(self))
+
+    def run(self):
+        Container(self).run()
+
+
+if __name__ == '__main__':
+    unittest.main(main_module())


### PR DESCRIPTION
Link route destinations can be dynamically created for a connection based on a connection property in the OPEN frame.  The lifecycle of the link-route addresses tracks the connection.
