### PR TITLE
DISPATCH-856 Add hostName to router entity

### DIFF
--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -397,6 +397,10 @@
                     "type": "string",
                     "description": "Software Version"
                 },
+                "hostName": {
+                    "type": "string",
+                    "description": "hostName of machine on which router is running"
+                },
                 "helloInterval": {
                     "type": "integer",
                     "default": 1,

--- a/python/qpid_dispatch_internal/management/agent.py
+++ b/python/qpid_dispatch_internal/management/agent.py
@@ -63,6 +63,7 @@ data that may be updated in other threads.
 """
 
 import traceback, json, pstats
+import socket
 from itertools import ifilter, chain
 from traceback import format_exc
 from threading import Lock
@@ -241,6 +242,10 @@ class RouterEntity(EntityAdapter):
         return self.attributes.get('id')
 
     def create(self):
+        try:
+            self.attributes[u"hostName"] = socket.gethostbyaddr(socket.gethostname())[0]
+        except:
+            self.attributes[u"hostName"] = ''
         self._qd.qd_dispatch_configure_router(self._dispatch, self)
 
     def __str__(self):


### PR DESCRIPTION
The router.hostName will be used by the console to visually group routers that are deployed on the same machine.