### PR TITLE
DISPATCH-879 - Document how routers use alternate failover URLs

### DIFF
--- a/doc/new-book/configuration-connections.adoc
+++ b/doc/new-book/configuration-connections.adoc
@@ -56,7 +56,10 @@ If you have set up SSL/TLS or SASL in your environment, you can configure the ro
 [[adding_outgoing_connections]]
 == Adding Outgoing Connections
 
-Configuring outgoing connections involves setting the host and port on which the router should connect to other routers and brokers.
+Configuring outgoing connections involves setting the host and port on which the router connects to other routers and brokers.
+
+// Adding this here for now; in the future it might be better to have separate procedures for creating inter-router and route-container connections.
+When a router connects to a broker, the broker may provide backup connection data that the router can use if the primary connection fails. If the primary connection fails, the router attempts to reconnect by using a combination of the primary and -- if provided -- backup connections. For more information about viewing the backup connection data provided by the broker, see xref:managing_connectors[].
 
 .Procedure
 

--- a/doc/new-book/configuration-connections.adoc
+++ b/doc/new-book/configuration-connections.adoc
@@ -59,7 +59,7 @@ If you have set up SSL/TLS or SASL in your environment, you can configure the ro
 Configuring outgoing connections involves setting the host and port on which the router connects to other routers and brokers.
 
 // Adding this here for now; in the future it might be better to have separate procedures for creating inter-router and route-container connections.
-When a router connects to a broker, the broker may provide backup connection data that the router can use if the primary connection fails. If the primary connection fails, the router attempts to reconnect by using a combination of the primary and -- if provided -- backup connections in round-robin fashion until the connection is successful. For more information about viewing the backup connection data provided by the broker, see xref:managing_connectors[].
+When a router connects to a broker, the broker might provide backup connection data that the router can use if the primary connection fails. If the primary connection fails, the router attempts to reconnect by using a combination of the primary and -- if provided -- backup connections in round-robin fashion until the connection is successful. For more information about viewing the backup connection data provided by the broker, see xref:managing_connectors[].
 
 .Procedure
 

--- a/doc/new-book/configuration-connections.adoc
+++ b/doc/new-book/configuration-connections.adoc
@@ -59,7 +59,7 @@ If you have set up SSL/TLS or SASL in your environment, you can configure the ro
 Configuring outgoing connections involves setting the host and port on which the router connects to other routers and brokers.
 
 // Adding this here for now; in the future it might be better to have separate procedures for creating inter-router and route-container connections.
-When a router connects to a broker, the broker may provide backup connection data that the router can use if the primary connection fails. If the primary connection fails, the router attempts to reconnect by using a combination of the primary and -- if provided -- backup connections. For more information about viewing the backup connection data provided by the broker, see xref:managing_connectors[].
+When a router connects to a broker, the broker may provide backup connection data that the router can use if the primary connection fails. If the primary connection fails, the router attempts to reconnect by using a combination of the primary and -- if provided -- backup connections in round-robin fashion until the connection is successful. For more information about viewing the backup connection data provided by the broker, see xref:managing_connectors[].
 
 .Procedure
 

--- a/doc/new-book/managing-using-qdmanage.adoc
+++ b/doc/new-book/managing-using-qdmanage.adoc
@@ -183,6 +183,7 @@ qdmanage delete --name=_LISTENER_NAME_
 
 |===
 
+[[managing_connectors]]
 === Managing Connectors
 
 Connectors define how the router can connect to other endpoints in your messaging network, such as brokers and other routers. The following table lists the `qdmanage` commands you can use to perform common operations on connectors.
@@ -208,6 +209,13 @@ a|
 [options="nowrap"]
 ----
 qdmanage query role port --type=connector
+----
+
+|If the router is connected to a broker, view the alternate URLs on which the router can connect to the broker if the primary connection fails
+a|
+[options="nowrap",subs="+quotes"]
+----
+qdmanage query failoverList --name=_CONNECTOR_NAME_
 ----
 
 |View the attributes configured for a connector

--- a/doc/new-book/managing-using-qdmanage.adoc
+++ b/doc/new-book/managing-using-qdmanage.adoc
@@ -215,7 +215,7 @@ qdmanage query role port --type=connector
 a|
 [options="nowrap",subs="+quotes"]
 ----
-qdmanage query failoverList --name=_CONNECTOR_NAME_
+qdmanage query failoverList --type=connector --name=CONNECTOR_NAME
 ----
 
 |View the attributes configured for a connector


### PR DESCRIPTION
@ganeshmurthy, can you please review for technical accuracy?

In the part where we talk about outgoing connections, I described a bit about how routers use the failover list. Also, in the part about managing outgoing connections, I added a command that can be used to view the failover list.