### PR TITLE
DISPATCH 894 - Made the following changes to make the system tests wo…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ addons:
     # documentation
     - asciidoc
     - dblatex
+    # unit test requirement
+    - python-unittest2
 
 install:
 - PREFIX=$PWD/install

--- a/README
+++ b/README
@@ -19,6 +19,7 @@ packages installed:
 - cyrus-sasl-plain
 - cyrus-sasl-devel
 - asciidoc (for building docs)
+- python-unittest2 (python2-unittest2 on Fedora) (we use unittest2 for running python tests)
 
 Dispatch will not build on Windows.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,9 +66,9 @@ add_test(unit_tests_size_1     ${TEST_WRAP} -x unit_tests_size 1)
 add_test(unit_tests            ${TEST_WRAP} -x unit_tests ${CMAKE_CURRENT_SOURCE_DIR}/threads4.conf)
 
 # Unit test python modules
-add_test(router_engine_test    ${TEST_WRAP} -m unittest -v router_engine_test)
-add_test(management_test       ${TEST_WRAP} -m unittest -v management)
-add_test(router_policy_test    ${TEST_WRAP} -m unittest -v router_policy_test)
+add_test(router_engine_test    ${TEST_WRAP} -x unit2 -v router_engine_test)
+add_test(management_test       ${TEST_WRAP} -x unit2 -v management)
+add_test(router_policy_test    ${TEST_WRAP} -x unit2 -v router_policy_test)
 
 if(USE_LIBWEBSOCKETS)
   set(SYSTEM_TESTS_HTTP system_tests_http)
@@ -105,7 +105,7 @@ foreach(py_test_module
     ${SYSTEM_TESTS_HTTP}
     )
 
-  add_test(${py_test_module} ${TEST_WRAP} -m unittest -v ${py_test_module})
+  add_test(${py_test_module} ${TEST_WRAP} -x unit2 -v ${py_test_module})
   list(APPEND SYSTEM_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${py_test_module}.py)
 endforeach()
 

--- a/tests/router_engine_test.py
+++ b/tests/router_engine_test.py
@@ -19,7 +19,7 @@
 
 import os
 import sys
-import unittest
+import unittest2 as unittest
 import mock                     # Mock definitions for tests.
 
 sys.path.append(os.path.join(os.environ["SOURCE_DIR"], "python"))

--- a/tests/router_policy_test.py
+++ b/tests/router_policy_test.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-import unittest
+import unittest2 as unittest
 
 from qpid_dispatch_internal.policy.policy_util import HostAddr, is_ipv6_enabled
 from qpid_dispatch_internal.policy.policy_util import HostStruct
@@ -315,6 +315,7 @@ class PolicyAppConnectionMgrTests(TestCase):
         self.assertTrue(stats.connections_active == 10000)
         self.assertTrue(stats.connections_approved == 10000)
         self.assertTrue(stats.connections_denied == 1)
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/run_system_tests.py
+++ b/tests/run_system_tests.py
@@ -28,7 +28,7 @@ the standard system places. Use run.py or config.sh to run against dispatch buil
 import os
 import sys
 from fnmatch import fnmatch
-import unittest
+import unittest2 as unittest
 import system_test
 
 # Collect all system_tests_*.py scripts in the same directory as this script.

--- a/tests/system_tests_auth_service_plugin.py
+++ b/tests/system_tests_auth_service_plugin.py
@@ -17,12 +17,14 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, Popen, STDOUT
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+import os
+from subprocess import PIPE, Popen
+from system_test import TestCase, Qdrouterd, main_module
 from proton import SASL
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
+
 
 class AuthServicePluginTest(TestCase):
     @classmethod
@@ -134,6 +136,7 @@ class SimpleConnect(MessagingHandler):
 
     def run(self):
         Container(self).run()
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_autolinks.py
+++ b/tests/system_tests_autolinks.py
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-import unittest
-from proton import Message, Delivery, PENDING, ACCEPTED, REJECTED
+import unittest2 as unittest
+from proton import Message
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
-from proton.reactor import Container, AtMostOnce, AtLeastOnce
+from proton.reactor import Container
 
 CONNECTION_PROPERTIES = {u'connection': u'properties', u'int_property': 6451}
 

--- a/tests/system_tests_broker.py
+++ b/tests/system_tests_broker.py
@@ -21,9 +21,11 @@
 System tests involving one or more brokers and dispatch routers integrated
 with waypoints.
 """
-import unittest, system_test
+import unittest2 as unittest
+import system_test
 from system_test import Qdrouterd, message, MISSING_REQUIREMENTS
 from itertools import cycle
+
 
 class DistributedQueueTest(system_test.TestCase): # pylint: disable=too-many-public-methods
     """System tests involving routers and qpidd brokers"""
@@ -100,6 +102,7 @@ class DistributedQueueTest(system_test.TestCase): # pylint: disable=too-many-pub
             for r in routers: r.wait_ready()
             addrs = [r.addresses[0]+"/"+self.testq for r in routers]
             self.verify_equal_spread(addrs, addrs)
+
 
 if __name__ == '__main__':
     unittest.main(system_test.main_module())

--- a/tests/system_tests_default_distribution.py
+++ b/tests/system_tests_default_distribution.py
@@ -17,13 +17,14 @@
 # under the License.
 #
 
+import unittest2 as unittest
 import re
-import system_test
 from subprocess import PIPE
-from system_test import TestCase, Qdrouterd, TIMEOUT
+from system_test import TestCase, Qdrouterd, TIMEOUT, main_module
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from proton import Message
+
 
 class DefaultDistributionTest(TestCase):
     """System tests for testing the defaultDistribution attribute of the router entity"""
@@ -46,7 +47,7 @@ class DefaultDistributionTest(TestCase):
 
     def run_qdstat(self, args, regexp=None, address=None):
         p = self.popen(
-            ['qdstat', '--bus', str(address or self.address), '--timeout', str(system_test.TIMEOUT) ] + args,
+            ['qdstat', '--bus', str(address or self.address), '--timeout', str(TIMEOUT) ] + args,
             name='qdstat-'+self.id(), stdout=PIPE, expect=None)
 
         out = p.communicate()[0]
@@ -184,3 +185,6 @@ class UnavailableAnonymousSender(MessagingHandler):
     def run(self):
         Container(self).run()
 
+
+if __name__ == '__main__':
+    unittest.main(main_module())

--- a/tests/system_tests_delivery_abort.py
+++ b/tests/system_tests_delivery_abort.py
@@ -17,12 +17,11 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, STDOUT
-from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+from proton import Message, Timeout
+from system_test import TestCase, Qdrouterd, main_module
 from proton.handlers import MessagingHandler
-from proton.reactor import Container, DynamicNodeProperties
+from proton.reactor import Container
 
 # PROTON-828:
 try:

--- a/tests/system_tests_denied_unsettled_multicast.py
+++ b/tests/system_tests_denied_unsettled_multicast.py
@@ -17,12 +17,11 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, STDOUT
-from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+from proton import Message, Timeout
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
-from proton.reactor import Container, DynamicNodeProperties
+from proton.reactor import Container
 
 # PROTON-828:
 try:

--- a/tests/system_tests_distribution.py
+++ b/tests/system_tests_distribution.py
@@ -17,19 +17,11 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess      import PIPE, STDOUT
-from proton          import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test     import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+from proton          import Message, Timeout
+from system_test     import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
-from proton.reactor  import Container, AtMostOnce, AtLeastOnce, DynamicNodeProperties, LinkOption, ApplicationEvent, EventInjector
-from proton.utils    import BlockingConnection
-from qpid_dispatch.management.client import Node
-
-import time
-import datetime
-
-
+from proton.reactor  import Container, LinkOption, ApplicationEvent, EventInjector
 
 # PROTON-828:
 try:
@@ -4199,9 +4191,6 @@ class ParallelWaypointTest ( MessagingHandler ):
         container = Container(self)
         container.container_id = self.container_id
         container.run()
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/system_tests_drain.py
+++ b/tests/system_tests_drain.py
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-import unittest
-
+import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, main_module
 from system_tests_drain_support import DrainMessagesHandler, DrainOneMessageHandler
 from system_tests_drain_support import DrainNoMessagesHandler, DrainNoMoreMessagesHandler
+
 
 class DrainSupportTest(TestCase):
 
@@ -61,6 +61,7 @@ class DrainSupportTest(TestCase):
         drain_support = DrainNoMoreMessagesHandler(self.address)
         drain_support.run()
         self.assertEqual(drain_support.error, None)
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_drain_support.py
+++ b/tests/system_tests_drain_support.py
@@ -17,10 +17,11 @@
 # under the License.
 #
 
+import unittest2 as unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from proton import Message, Endpoint
-from system_test import TIMEOUT
+from system_test import main_module, TIMEOUT
 
 class Timeout(object):
     def __init__(self, parent):
@@ -205,3 +206,6 @@ class DrainNoMoreMessagesHandler(MessagingHandler):
     def run(self):
         Container(self).run()
 
+
+if __name__ == '__main__':
+    unittest.main(main_module())

--- a/tests/system_tests_dynamic_terminus.py
+++ b/tests/system_tests_dynamic_terminus.py
@@ -17,12 +17,11 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, STDOUT
-from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+from proton import Message, Timeout
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
-from proton.reactor import Container, DynamicNodeProperties, LinkOption
+from proton.reactor import Container, LinkOption
 
 # PROTON-828:
 try:

--- a/tests/system_tests_failover_list.py
+++ b/tests/system_tests_failover_list.py
@@ -17,12 +17,11 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, STDOUT
-from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+from proton import Timeout
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
-from proton.reactor import Container, DynamicNodeProperties
+from proton.reactor import Container
 
 # PROTON-828:
 try:
@@ -32,8 +31,6 @@ except ImportError:
 
 
 class RouterTest(TestCase):
-
-    inter_router_port = None
 
     @classmethod
     def setUpClass(cls):
@@ -55,11 +52,8 @@ class RouterTest(TestCase):
 
         cls.routers = []
 
-        inter_router_port = cls.tester.get_port()
-
         router('A')
         cls.routers[0].wait_ready()
-
 
     def test_01_no_failover_list(self):
         test = FailoverTest(self.routers[0].addresses[0], 0)
@@ -129,7 +123,6 @@ class FailoverTest(MessagingHandler):
 
         self.timer.cancel()
         self.conn.close()
-
 
     def run(self):
         Container(self).run()

--- a/tests/system_tests_http.py
+++ b/tests/system_tests_http.py
@@ -17,9 +17,11 @@
 # under the License.
 #
 
-import unittest, os, json, threading, sys, ssl, urllib2
+import unittest2 as unittest
+import os, threading, sys, urllib2
 import ssl
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+from system_test import TestCase, Qdrouterd, main_module, DIR
+
 
 class RouterTestHttp(TestCase):
 
@@ -131,6 +133,7 @@ class RouterTestHttp(TestCase):
         self.assertRaises(urllib2.URLError, self.assert_get, "https://localhost:%s" % r.ports[2])
         # Provide client cert
         self.assert_get_cert("https://localhost:%d" % r.ports[2])
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -17,17 +17,16 @@
 # under the License.
 #
 
-import unittest
+import unittest2 as unittest
 from time import sleep, time
 from subprocess import PIPE, STDOUT
 
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, Process
 
-from proton import Message, Endpoint
+from proton import Message
 from proton.handlers import MessagingHandler
 from proton.reactor import AtMostOnce, Container, DynamicNodeProperties, LinkOption
-from proton.utils import BlockingConnection, LinkDetached
-
+from proton.utils import BlockingConnection
 from system_tests_drain_support import DrainMessagesHandler, DrainOneMessageHandler, DrainNoMessagesHandler, DrainNoMoreMessagesHandler
 
 from qpid_dispatch.management.client import Node

--- a/tests/system_tests_log_message_components.py
+++ b/tests/system_tests_log_message_components.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import unittest2 as unittest
 import json
 from proton import Message, symbol
 from system_test import TestCase, Qdrouterd, Process, TIMEOUT
@@ -203,3 +204,7 @@ class LogMessageTest(MessagingHandler):
 
     def run(self):
         Container(self).run()
+
+
+if __name__ == '__main__':
+    unittest.main(main_module())

--- a/tests/system_tests_management.py
+++ b/tests/system_tests_management.py
@@ -1,25 +1,26 @@
-##
-## Licensed to the Apache Software Foundation (ASF) under one
-## or more contributor license agreements.  See the NOTICE file
-## distributed with this work for additional information
-## regarding copyright ownership.  The ASF licenses this file
-## to you under the Apache License, Version 2.0 (the
-## "License"); you may not use this file except in compliance
-## with the License.  You may obtain a copy of the License at
-##
-##   http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing,
-## software distributed under the License is distributed on an
-## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-## KIND, either express or implied.  See the License for the
-## specific language governing permissions and limitations
-## under the License
-##
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
 
 """System tests for management of qdrouter"""
 
-import unittest, system_test, re, os, json, sys
+import unittest2 as unittest
+import system_test, re, os, json, sys
 from qpid_dispatch.management.client import Node, ManagementError, Url, BadRequestStatus, NotImplementedStatus, NotFoundStatus
 from qpid_dispatch_internal.management.qdrouter import QdSchema
 from qpid_dispatch_internal.compat import dictify
@@ -463,6 +464,7 @@ class ManagementTest(system_test.TestCase):
         self.assertEquals(schema, dictify(json.loads(got)))
         got = self.node.call(self.node.request(operation="GET-SCHEMA", identity="self")).body
         self.assertEquals(schema, got)
+
 
 if __name__ == '__main__':
     unittest.main(system_test.main_module())

--- a/tests/system_tests_multi_tenancy.py
+++ b/tests/system_tests_multi_tenancy.py
@@ -17,10 +17,9 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, STDOUT
-from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+from proton import Message, Timeout
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, DynamicNodeProperties
 

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-import unittest
+import unittest2 as unittest
 from proton import Condition, Message, Delivery, PENDING, ACCEPTED, REJECTED, Url, symbol
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler, TransactionHandler
@@ -1896,6 +1896,7 @@ class RejectDispositionTest(MessagingHandler):
 
     def run(self):
         Container(self).run()
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_policy.py
+++ b/tests/system_tests_policy.py
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-import unittest, json
-import os
+import unittest as unittest
+import os, json
 from system_test import TestCase, Qdrouterd, main_module, Process, TIMEOUT, DIR
 from subprocess import PIPE, STDOUT
 from proton import ConnectionException
@@ -300,6 +300,7 @@ class SenderReceiverLimits(TestCase):
         self.assertRaises(LinkDetached, bs1.create_sender, "****NO****")
 
         bs1.close()
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_protocol_family.py
+++ b/tests/system_tests_protocol_family.py
@@ -17,8 +17,7 @@
 # under the License.
 #
 
-import unittest
-from time import sleep
+import unittest2 as unittest
 from proton import Message
 from system_test import TestCase, Qdrouterd, main_module
 from qpid_dispatch_internal.policy.policy_util import is_ipv6_enabled
@@ -138,6 +137,7 @@ class ProtocolFamilyTest(TestCase):
 
         M1.stop()
         M2.stop()
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_protocol_settings.py
+++ b/tests/system_tests_protocol_settings.py
@@ -17,14 +17,18 @@
 # under the License.
 #
 
-import unittest
-from proton import Message, Delivery, PENDING, ACCEPTED, REJECTED
+import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, main_module
-from proton.handlers import MessagingHandler
-from proton.reactor import Container, AtMostOnce, AtLeastOnce
-from proton.utils import BlockingConnection, SyncRequestResponse
-from qpid_dispatch.management.client import Node
-from proton import ConnectionException
+from proton.utils import BlockingConnection
+import subprocess
+X86_64_ARCH = "x86_64"
+skip_test = True
+
+# Dont skip tests on 64 bit architectures.
+p = subprocess.Popen("uname -m", shell=True, stdout=subprocess.PIPE)
+if X86_64_ARCH in p.communicate()[0]:
+    skip_test = False
+
 
 class MaxFrameMaxSessionFramesTest(TestCase):
     """System tests setting proton negotiated size max-frame-size and incoming-window"""
@@ -223,6 +227,8 @@ class MaxSessionFramesDefaultTest(TestCase):
 
     def test_max_session_frames_default(self):
         # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        if skip_test:
+            return self.skipTest("Test skipped on non-64 bit architectures")
         bc = BlockingConnection(self.router.addresses[0])
         bc.create_receiver("xxx")
         bc.close()
@@ -259,6 +265,8 @@ class MaxFrameMaxSessionFramesZeroTest(TestCase):
 
     def test_max_frame_max_session_zero(self):
         # Set up a connection to get the Open and a receiver to get a Begin frame in the log
+        if skip_test:
+            return self.skipTest("Test disabled on non-64 bit architectures")
         bc = BlockingConnection(self.router.addresses[0])
         bc.create_receiver("xxx")
         bc.close()
@@ -316,6 +324,8 @@ class ConnectorSettingsDefaultTest(TestCase):
         cls.routers[1].wait_router_connected('QDR.A')
 
     def test_connector_default(self):
+        if skip_test:
+            return self.skipTest("Test disabled on non-64 bit architectures")
         with  open('../setUpClass/A.log', 'r') as router_log:
             log_lines = router_log.read().split("\n")
             open_lines = [s for s in log_lines if "<- @open" in s]

--- a/tests/system_tests_qdmanage.py
+++ b/tests/system_tests_qdmanage.py
@@ -17,9 +17,9 @@
 # under the License
 #
 
-import json, unittest, os
+import json, unittest2 as unittest, os
 
-from system_test import TestCase, Process, Qdrouterd, main_module, TIMEOUT, DIR, wait_port
+from system_test import TestCase, Process, Qdrouterd, main_module, TIMEOUT, DIR
 from subprocess import PIPE, STDOUT
 from qpid_dispatch_internal.compat import dictify
 from qpid_dispatch_internal.management.qdrouter import QdSchema

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -23,6 +23,8 @@ import system_test
 import unittest
 from subprocess import PIPE
 from proton import Url, SSLDomain, SSLUnavailable, SASL
+from system_test import main_module
+
 
 class QdstatTest(system_test.TestCase):
     """Test qdstat tool output"""
@@ -358,4 +360,4 @@ except SSLUnavailable:
 
 
 if __name__ == '__main__':
-    unittest.main(system_test.main_module())
+    unittest.main(main_module())

--- a/tests/system_tests_sasl_plain.py
+++ b/tests/system_tests_sasl_plain.py
@@ -17,9 +17,9 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess import PIPE, Popen, STDOUT
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest, os
+from subprocess import PIPE, Popen
+from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT
 from qpid_dispatch.management.client import Node
 from proton import SASL
 
@@ -541,7 +541,8 @@ class RouterTestVerifyHostNameNo(RouterTestPlainSaslCommon):
         local_node.delete(type='connector', name='connectorToX')
         local_node.delete(type='sslProfile', name='client-ssl-profile')
         connections = local_node.query(type='org.apache.qpid.dispatch.connection').get_entities()
-        self.assertNotIn("QDR.X", [c.container for c in connections]) # Should not be present now
+        is_qdr_x = "QDR.X" in [c.container for c in connections]
+        self.assertFalse(is_qdr_x) # Should not be present now
 
         # re-create the ssl profile
         local_node.create({'type': 'sslProfile',

--- a/tests/system_tests_topology.py
+++ b/tests/system_tests_topology.py
@@ -17,28 +17,20 @@
 # under the License.
 #
 
-import unittest, os, json
-from subprocess      import PIPE, STDOUT
-from proton          import Message, PENDING, ACCEPTED, REJECTED, RELEASED, SSLDomain, SSLUnavailable, Timeout
-from system_test     import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+
+import unittest2 as unittest
+from proton          import Message, Timeout
+from system_test     import TestCase, Qdrouterd, main_module
 from proton.handlers import MessagingHandler
-from proton.reactor  import Container, AtMostOnce, AtLeastOnce, DynamicNodeProperties, LinkOption, ApplicationEvent, EventInjector
-from proton.utils    import BlockingConnection
-from qpid_dispatch.management.client import Node
+from proton.reactor  import Container
 
 import time
-import datetime
-import pdb
-
-
 
 # PROTON-828:
 try:
     from proton import MODIFIED
 except ImportError:
     from proton import PN_STATUS_MODIFIED as MODIFIED
-
-
 
 
 #------------------------------------------------
@@ -601,8 +593,6 @@ class TopologyFailover ( MessagingHandler ):
 
     def run(self):
         Container(self).run()
-
-
 
 
 if __name__ == '__main__':

--- a/tests/system_tests_two_routers.py
+++ b/tests/system_tests_two_routers.py
@@ -17,12 +17,12 @@
 # under the License.
 #
 
-import unittest, os, json, logging
-from subprocess import PIPE, STDOUT
-from proton import Message, PENDING, ACCEPTED, REJECTED, RELEASED, Timeout
-from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process
+import unittest2 as unittest
+import logging
+from proton import Message, PENDING, ACCEPTED, REJECTED, Timeout
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
-from proton.reactor import Container, AtMostOnce, AtLeastOnce
+from proton.reactor import Container
 
 # PROTON-828:
 try:
@@ -1314,6 +1314,7 @@ class AttachOnInterRouterTest(MessagingHandler):
             Container(self).run()
         finally:
             logging.disable(logging.NOTSET) # Restore to normal
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_user_id.py
+++ b/tests/system_tests_user_id.py
@@ -19,10 +19,10 @@
 
 
 import os
-import unittest
+import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, DIR, main_module
 from qpid_dispatch.management.client import Node
-from proton import SSLDomain, Message
+from proton import SSLDomain
 
 class QdSSLUseridTest(TestCase):
 
@@ -312,6 +312,7 @@ class QdSSLUseridTest(TestCase):
         self.assertEqual("user13", user_id)
 
         node.close()
+
 
 if __name__ == '__main__':
     unittest.main(main_module())

--- a/tests/system_tests_user_id_proxy.py
+++ b/tests/system_tests_user_id_proxy.py
@@ -19,12 +19,12 @@
 
 
 import os
-import unittest
+import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, DIR, main_module
-from qpid_dispatch.management.client import Node
 import proton
-from proton import SSLDomain, Message, ProtonException, Delivery
+from proton import SSLDomain, Delivery
 from proton.utils import BlockingConnection
+
 
 class QdSSLUseridTest(TestCase):
 


### PR DESCRIPTION
…rk on CentOS 6.

1. Modified system tests to use unittest2 instead of unittest test framework.
2. Modified tests/CMakeLists.txt to use the unit2 test runner.
3. Fixed some tests to use backwards compatible assert functions.
4. Remove unused imports in tests