### PR TITLE
Dispatch memory fixes

### DIFF
--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -514,7 +514,7 @@ static void* http_thread_run(void* v) {
     return NULL;
 }
 
-void qd_http_server_free(qd_http_server_t *hs) {
+void qd_http_server_stop(qd_http_server_t *hs) {
     if (!hs) return;
     if (hs->thread) {
         /* Thread safe, stop via work queue then clean up */
@@ -524,6 +524,11 @@ void qd_http_server_free(qd_http_server_t *hs) {
         sys_thread_free(hs->thread);
         hs->thread = NULL;
     }
+}
+
+void qd_http_server_free(qd_http_server_t *hs) {
+    if (!hs) return;
+    qd_http_server_stop(hs);
     work_queue_destroy(&hs->work);
     if (hs->context) lws_context_destroy(hs->context);
     free(hs);

--- a/src/http.h
+++ b/src/http.h
@@ -31,7 +31,10 @@ struct qd_log_source_t;
 /* Create a HTTP server */
 qd_http_server_t *qd_http_server(struct qd_server_t *server, struct qd_log_source_t *log);
 
-/* Free the HTTP server */
+/* Stop the HTTP server threads */
+void qd_http_server_stop(qd_http_server_t*);
+
+/* Free the HTTP server (stops threads if still running) */
 void qd_http_server_free(qd_http_server_t*);
 
 /* Listening for HTTP, thread safe. */

--- a/src/server.c
+++ b/src/server.c
@@ -1154,7 +1154,8 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
 void qd_server_free(qd_server_t *qd_server)
 {
     if (!qd_server) return;
-    qd_http_server_free(qd_server->http); /* Shut down in reverse order of start-up */
+    qd_http_server_free(qd_server->http);
+    pn_proactor_free(qd_server->proactor);
     qd_connection_t *ctx = DEQ_HEAD(qd_server->conn_list);
     while (ctx) {
         DEQ_REMOVE_HEAD(qd_server->conn_list);
@@ -1166,7 +1167,6 @@ void qd_server_free(qd_server_t *qd_server)
         ctx = DEQ_HEAD(qd_server->conn_list);
     }
     qd_timer_finalize();
-    pn_proactor_free(qd_server->proactor);
     sys_mutex_free(qd_server->lock);
     sys_cond_free(qd_server->cond);
     Py_XDECREF((PyObject *)qd_server->py_displayname_obj);

--- a/src/server.c
+++ b/src/server.c
@@ -1154,6 +1154,7 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
 void qd_server_free(qd_server_t *qd_server)
 {
     if (!qd_server) return;
+    qd_http_server_free(qd_server->http); /* Shut down in reverse order of start-up */
     qd_connection_t *ctx = DEQ_HEAD(qd_server->conn_list);
     while (ctx) {
         DEQ_REMOVE_HEAD(qd_server->conn_list);
@@ -1201,7 +1202,7 @@ void qd_server_run(qd_dispatch_t *qd)
         sys_thread_free(threads[i]);
     }
     free(threads);
-    qd_http_server_free(qd_server->http);
+    qd_http_server_stop(qd_server->http); /* Stop HTTP threads immediately */
 
     qd_log(qd_server->log_source, QD_LOG_NOTICE, "Shut Down");
 }

--- a/tests/compose_test.c
+++ b/tests/compose_test.c
@@ -155,7 +155,7 @@ static char *test_compose_insert_empty_string(void *context)
         if (empty_string[idx] != right[idx])
             return "Pattern Mismatch";
     }
-
+    qd_compose_free(field);
     return 0;
 }
 
@@ -173,7 +173,7 @@ static char *test_compose_insert_empty_symbol(void *context)
         if (empty_string[idx] != right[idx])
             return "Pattern Mismatch";
     }
-
+    qd_compose_free(field);
     return 0;
 }
 
@@ -191,7 +191,7 @@ static char *test_compose_insert_empty_binary(void *context)
         if (empty_string[idx] != right[idx])
             return "Pattern Mismatch";
     }
-
+    qd_compose_free(field);
     return 0;
 }
 

--- a/tests/proton_utils_tests.c
+++ b/tests/proton_utils_tests.c
@@ -69,18 +69,22 @@ static char *test_data_as_string(void *context)
         pn_data_t *data = pn_data(0);
         pn_data_decode(data, vector->encoded, vector->size);
         char *result = qdpn_data_as_string(data);
+        pn_data_free(data);
 
         if (result || vector->expected) {
             if ((result == 0 || vector->expected == 0) && result != vector->expected) {
                 snprintf(error, MAX_ERROR, "Expected '%s', got '%s'", vector->expected, result);
+                free(result);
                 return error;
             }
 
             if (strcmp(result, vector->expected)) {
                 snprintf(error, MAX_ERROR, "Expected '%s', got '%s'", vector->expected, result);
+                free(result);
                 return error;
             }
         }
+        free(result);
         vector++;
     }
 


### PR DESCRIPTION
These are fixes for valgrind errors in the unit tests that I saw when running tests on master. There are more to fix, in the system tests.

Requesting review as I have been away from dispatch for a while, don't want to cause a regression. ctest with my changes is no worse than without - the policy and user_id_proxy system tests are failing with timeouts for me on master with/without these changes.