### PR TITLE
DISPATCH-921 Run npm install after stand-alone console install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ option(QD_MEMORY_STATS "Track memory pool usage statistics" ON)
 
 file(STRINGS "${CMAKE_SOURCE_DIR}/VERSION.txt" QPID_DISPATCH_VERSION)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 include(CheckLibraryExists)
 include(CheckSymbolExists)
 include(CheckFunctionExists)

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -25,11 +25,24 @@ set(CONSOLE_BASE_SOURCE_DIR "${CMAKE_SOURCE_DIR}/console/stand-alone/")
 option(CONSOLE_INSTALL "Install stand-alone console" ON)
 if(CONSOLE_INSTALL)
 
-	# Static console files
-	install(
-	  DIRECTORY ${CONSOLE_BASE_SOURCE_DIR}
+  # Static console files
+  install(
+    DIRECTORY ${CONSOLE_BASE_SOURCE_DIR}
           DESTINATION ${CONSOLE_STAND_ALONE_INSTALL_DIR}
     )
+
+  # run npm install for console if npm is installed
+  find_program(PROG_NPM npm)
+  if (PROG_NPM STREQUAL "PROG_NPM-NOTFOUND")
+    message(WARNING "Program npm not found. You must manually install console dependencies.")
+  else ()
+    message(STATUS "Program npm found. Console dependencies will be installed.")
+    install(
+      CODE "MESSAGE(\"Installing console dependencies with npm.\")")
+    install(
+      CODE "execute_process(COMMAND npm install
+            WORKING_DIRECTORY ${CONSOLE_STAND_ALONE_INSTALL_DIR})")
+  endif()
 
 endif(CONSOLE_INSTALL)
 
@@ -38,20 +51,20 @@ endif(CONSOLE_INSTALL)
 ##
 find_program (MAVEN_EXE mvn DOC "Location of the maven program")
 if (MAVEN_EXE)
-	# the directory where the .war file will be built
-	set(HAWTIO_BUILD_DIR "${CMAKE_BINARY_DIR}/hawtio")
+  # the directory where the .war file will be built
+  set(HAWTIO_BUILD_DIR "${CMAKE_BINARY_DIR}/hawtio")
 
-	# create the console .war file
-	add_custom_target(hawtio
-	    COMMAND ${MAVEN_EXE} -DbuildDirectory=${HAWTIO_BUILD_DIR} package
-	    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/console/hawtio
-	)
+  # create the console .war file
+  add_custom_target(hawtio
+      COMMAND ${MAVEN_EXE} -DbuildDirectory=${HAWTIO_BUILD_DIR} package
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/console/hawtio
+  )
 
-	# install the built war file into the console dir
-	install(
-	    # We don't know in advance what the name of the final .war will be because
-		# the war file name depends on the version in the pom.xml. The version will change each release
-	    CODE "file( GLOB builtwar \"${HAWTIO_BUILD_DIR}/dispatch-hawtio-console*.war\" )"
-	    CODE "file( INSTALL \${builtwar} DESTINATION \"${CONSOLE_INSTALL_DIR}/hawtio\" )"
-	)
+  # install the built war file into the console dir
+  install(
+    # We don't know in advance what the name of the final .war will be because
+    # the war file name depends on the version in the pom.xml. The version will change each release
+      CODE "file( GLOB builtwar \"${HAWTIO_BUILD_DIR}/dispatch-hawtio-console*.war\" )"
+      CODE "file( INSTALL \${builtwar} DESTINATION \"${CONSOLE_INSTALL_DIR}/hawtio\" )"
+  )
 endif(MAVEN_EXE)


### PR DESCRIPTION
Checks to make sure npm is installed and runs npm install after console file have been copied.