### PR TITLE
Enhanced link-statistics

### DIFF
--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -561,13 +561,14 @@ void qdr_link_delete(qdr_link_t *link);
  * @param link_exclusion If present, this is a bitmask of inter-router links that should not be used
  *                       to send this message.  This bitmask is created by the trace_mask module and
  *                       it built on the trace header from a received message.
+ * @param ingress_index The bitmask index of the router that this delivery entered the network through.
  * @return Pointer to the qdr_delivery that will track the lifecycle of this delivery on this link.
  */
 qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterator_t *ingress,
-                                 bool settled, qd_bitmask_t *link_exclusion);
+                                 bool settled, qd_bitmask_t *link_exclusion, int ingress_index);
 qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
                                     qd_iterator_t *ingress, qd_iterator_t *addr,
-                                    bool settled, qd_bitmask_t *link_exclusion);
+                                    bool settled, qd_bitmask_t *link_exclusion, int ingress_index);
 qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *msg, bool settled,
                                                 const uint8_t *tag, int tag_length,
                                                 uint64_t disposition, pn_data_t* disposition_state);

--- a/include/qpid/dispatch/trace_mask.h
+++ b/include/qpid/dispatch/trace_mask.h
@@ -89,9 +89,10 @@ void qd_tracemask_remove_link(qd_tracemask_t *tm, int router_maskbit);
  *
  * @param tm Tracemask created by qd_tracemask()
  * @param tracelist The parsed field from a message's trace header
+ * @param ingress_index (out) The mask-bit for the first router in the trace list (the ingress router)
  * @return A new bit mask with a set-bit for each neighbor router in the list.  This must be freed
  *         by the caller when the caller is done with it.
  */
-qd_bitmask_t *qd_tracemask_create(qd_tracemask_t *tm, qd_parsed_field_t *tracelist);
+qd_bitmask_t *qd_tracemask_create(qd_tracemask_t *tm, qd_parsed_field_t *tracelist, int *ingress_index);
 
 #endif

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1325,6 +1325,10 @@
                 "lastTopoChange": {
                      "description": "Timestamp showing the most recent change to this node's neighborhood.",
                      "type": "integer"
+                },
+                "index": {
+                    "description": "Index number for this router node used in statistics histograms.  This index is specific to this router.",
+                    "type": "integer"
                 }
 
             }

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1207,6 +1207,10 @@
                     "type": "integer",
                     "graph": true,
                     "description": "The total number of modified deliveries."
+                },
+                "ingressHistogram": {
+                    "type": "list",
+                    "description": "For outgoing links on normal connections.  This is a histogram with a value per interior router node.  The value is a count of settled deliveries on this link that ingressed the network at the specific interior router."
                 }
             }
         },

--- a/python/qpid_dispatch_internal/router/node.py
+++ b/python/qpid_dispatch_internal/router/node.py
@@ -55,6 +55,7 @@ class NodeTracker(object):
         """Refresh management attributes"""
         attributes.update({
             "id": self.my_id,
+            "index": 0,
             "protocolVersion": ProtocolVersion,
             "instance": self.container.instance, # Boot number, integer
             "linkState": [ls for ls in self.link_state.peers], # List of neighbour nodes
@@ -411,6 +412,7 @@ class RouterNode(object):
         """Refresh management attributes"""
         attributes.update({
             "id": self.id,
+            "index": self.maskbit,
             "protocolVersion": self.version,
             "instance": self.instance, # Boot number, integer
             "linkState": [ls for ls in self.link_state.peers], # List of neighbour nodes

--- a/src/router_core/agent_link.c
+++ b/src/router_core/agent_link.c
@@ -42,6 +42,7 @@
 #define QDR_LINK_REJECTED_COUNT           18
 #define QDR_LINK_RELEASED_COUNT           19
 #define QDR_LINK_MODIFIED_COUNT           20
+#define QDR_LINK_INGRESS_HISTOGRAM        21
 
 const char *qdr_link_columns[] =
     {"name",
@@ -65,6 +66,7 @@ const char *qdr_link_columns[] =
      "rejectedCount",
      "releasedCount",
      "modifiedCount",
+     "ingressHistogram",
      0};
 
 static const char *qd_link_type_name(qd_link_type_t lt)
@@ -206,6 +208,16 @@ static void qdr_agent_write_column_CT(qd_composed_field_t *body, int col, qdr_li
 
     case QDR_LINK_MODIFIED_COUNT:
         qd_compose_insert_ulong(body, link->modified_deliveries);
+        break;
+
+    case QDR_LINK_INGRESS_HISTOGRAM:
+        if (link->ingress_histogram) {
+            qd_compose_start_list(body);
+            for (int i = 0; i < qd_bitmask_width(); i++)
+                qd_compose_insert_ulong(body, link->ingress_histogram[i]);
+            qd_compose_end_list(body);
+        } else
+            qd_compose_insert_null(body);
         break;
 
     default:

--- a/src/router_core/agent_link.h
+++ b/src/router_core/agent_link.h
@@ -29,7 +29,7 @@ void qdra_link_update_CT(qdr_core_t          *core,
                          qdr_query_t         *query,
                          qd_parsed_field_t   *in_body);
 
-#define QDR_LINK_COLUMN_COUNT  21
+#define QDR_LINK_COLUMN_COUNT  22
 
 const char *qdr_link_columns[QDR_LINK_COLUMN_COUNT + 1];
 

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -113,6 +113,8 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *in
     out_dlv->tag_length = 8;
     out_dlv->error      = 0;
 
+    out_dlv->ingress_index = in_dlv ? in_dlv->ingress_index : -1;
+
     //
     // Add one to the message fanout. This will later be used in the qd_message_send function that sends out messages.
     //

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -346,6 +346,7 @@ struct qdr_delivery_t {
     qd_bitmask_t           *link_exclusion;
     qdr_address_t          *tracking_addr;
     int                     tracking_addr_bit;
+    int                     ingress_index;
     qdr_link_work_t        *link_work;         ///< Delivery work item for this delivery
     qdr_subscription_list_t subscriptions;
     qdr_delivery_ref_list_t peers;             /// Use this list if there if the delivery has more than one peer.
@@ -401,13 +402,14 @@ struct qdr_link_t {
     bool                     drain_mode;
     bool                     stalled_outbound;  ///< Indicates that this link is stalled on outbound buffer backpressure
 
-    uint64_t total_deliveries;
-    uint64_t presettled_deliveries;
-    uint64_t dropped_presettled_deliveries;
-    uint64_t accepted_deliveries;
-    uint64_t rejected_deliveries;
-    uint64_t released_deliveries;
-    uint64_t modified_deliveries;
+    uint64_t  total_deliveries;
+    uint64_t  presettled_deliveries;
+    uint64_t  dropped_presettled_deliveries;
+    uint64_t  accepted_deliveries;
+    uint64_t  rejected_deliveries;
+    uint64_t  released_deliveries;
+    uint64_t  modified_deliveries;
+    uint64_t *ingress_histogram;
 };
 
 ALLOC_DECLARE(qdr_link_t);

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -42,7 +42,7 @@ void qdr_delivery_copy_extension_state(qdr_delivery_t *src, qdr_delivery_t *dest
 //==================================================================================
 
 qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterator_t *ingress,
-                                 bool settled, qd_bitmask_t *link_exclusion)
+                                 bool settled, qd_bitmask_t *link_exclusion, int ingress_index)
 {
     qdr_action_t   *action = qdr_action(qdr_link_deliver_CT, "link_deliver");
     qdr_delivery_t *dlv    = new_qdr_delivery_t();
@@ -55,6 +55,7 @@ qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterato
     dlv->settled        = settled;
     dlv->presettled     = settled;
     dlv->link_exclusion = link_exclusion;
+    dlv->ingress_index  = ingress_index;
     dlv->error          = 0;
 
     qdr_delivery_incref(dlv, "qdr_link_deliver - newly created delivery, add to action list");
@@ -68,7 +69,7 @@ qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterato
 
 qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
                                     qd_iterator_t *ingress, qd_iterator_t *addr,
-                                    bool settled, qd_bitmask_t *link_exclusion)
+                                    bool settled, qd_bitmask_t *link_exclusion, int ingress_index)
 {
     qdr_action_t   *action = qdr_action(qdr_link_deliver_CT, "link_deliver");
     qdr_delivery_t *dlv    = new_qdr_delivery_t();
@@ -81,6 +82,7 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
     dlv->settled        = settled;
     dlv->presettled     = settled;
     dlv->link_exclusion = link_exclusion;
+    dlv->ingress_index  = ingress_index;
     dlv->error          = 0;
 
     qdr_delivery_incref(dlv, "qdr_link_deliver_to - newly created delivery, add to action list");
@@ -530,6 +532,9 @@ static void qdr_delete_delivery_internal_CT(qdr_core_t *core, qdr_delivery_t *de
             link->released_deliveries++;
         else if (delivery->disposition == PN_MODIFIED)
             link->modified_deliveries++;
+
+        if (qd_bitmask_valid_bit_value(delivery->ingress_index) && link->ingress_histogram)
+            link->ingress_histogram[delivery->ingress_index]++;
     }
 
     //

--- a/tests/parse_test.c
+++ b/tests/parse_test.c
@@ -302,9 +302,15 @@ static char *test_tracemask(void *context)
     qd_parsed_field_t *pf   = qd_parse(iter);
     qd_iterator_free(iter);
 
-    bm = qd_tracemask_create(tm, pf);
+    int ingress = -1;
+
+    bm = qd_tracemask_create(tm, pf, &ingress);
     if (qd_bitmask_cardinality(bm) != 3) {
         sprintf(error, "Expected cardinality of 3, got %d", qd_bitmask_cardinality(bm));
+        return error;
+    }
+    if (ingress != 0) {
+        sprintf(error, "(A) Expected ingress index of 0, got %d", ingress);
         return error;
     }
     int total = 0;
@@ -321,10 +327,15 @@ static char *test_tracemask(void *context)
     qd_tracemask_del_router(tm, 3);
     qd_tracemask_remove_link(tm, 0);
 
-    bm = qd_tracemask_create(tm, pf);
+    ingress = -1;
+    bm = qd_tracemask_create(tm, pf, &ingress);
     qd_parse_free(pf);
     if (qd_bitmask_cardinality(bm) != 1) {
         sprintf(error, "Expected cardinality of 1, got %d", qd_bitmask_cardinality(bm));
+        return error;
+    }
+    if (ingress != 0) {
+        sprintf(error, "(B) Expected ingress index of 0, got %d", ingress);
         return error;
     }
 


### PR DESCRIPTION
This pull request contains a code change that adds the following contents to the management entities in the router:
- An index number has been added to the router.node entity to facilitate mapping histogram slots to router identities.
- A new attribute in the 'link' entity called 'ingressHistogram'.  This attribute is valid only for outgoing links on normal connections.  It contains an array of numbers that indicate the number of deliveries that arrived on each ingress router in the network.