### PR TITLE
DISPATCH-926: Fix offered capability encoding

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -429,6 +429,8 @@ static void decorate_connection(qd_server_t *qd_server, pn_connection_t *conn, c
     //
     // Offer ANONYMOUS_RELAY capability
     //
+    pn_data_put_array(pn_connection_offered_capabilities(conn), false, PN_SYMBOL);
+    pn_data_enter(pn_connection_offered_capabilities(conn));
     pn_data_put_symbol(pn_connection_offered_capabilities(conn), pn_bytes(clen, (char*) QD_CAPABILITY_ANONYMOUS_RELAY));
 
     //


### PR DESCRIPTION
This code fix encoding of offered capability (symbol -> symbol[]), as OASIS AMQP1.0 spec.
http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-open