### PR TITLE
DISPATCH-940 - Allow configuration file to be used from relative path…

### DIFF
--- a/router/src/main.c
+++ b/router/src/main.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 #include <getopt.h>
 #include <errno.h>
 #include "config.h"
@@ -186,9 +187,8 @@ static void daemon_process(const char *config_path, const char *python_pkgdir,
                 char *cur_path = NULL;
                 int path_size = 256;
                 int getcwd_error = 0;
-
-                cur_path = (char *) malloc(path_size * sizeof(char));
-                memset(cur_path, 0, path_size * sizeof(char));
+                cur_path = (char *) calloc(path_size, sizeof(char));
+                cur_path = (char *) calloc(path_size, sizeof(char));
 
                 while ( getcwd(cur_path, path_size) == NULL ) {
                     free(cur_path);
@@ -199,15 +199,17 @@ static void daemon_process(const char *config_path, const char *python_pkgdir,
                     }
                     // If current path does not fit, allocate more memory
                     path_size += 256;
-                    cur_path = (char *) malloc(path_size * sizeof(char));
-                    memset(cur_path, 0, path_size * sizeof(char));
+                    cur_path = (char *) calloc(path_size, sizeof(char));
                 }
 
                 // Populating fully qualified config file name
                 if (!getcwd_error) {
-                    config_path_full = malloc((path_size + strlen(config_path) + 1) * sizeof(char));
-                    memset(config_path_full, 0, (path_size + strlen(config_path) + 1) * sizeof(char));
-                    sprintf(config_path_full, "%s%s%s", cur_path, !strcmp("/", cur_path)? "":"/", config_path);
+                    int cpf_len = path_size + strlen(config_path) + 1;
+                    config_path_full = calloc(cpf_len, sizeof(char));
+                    snprintf(config_path_full, cpf_len, "%s%s%s",
+                             cur_path,
+                             !strcmp("/", cur_path)? "":"/",
+                             config_path);
                 }
 
                 // Releasing temporary path variable

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ foreach(py_test_module
     system_tests_topology
     system_tests_topology_disposition
     system_tests_topology_addition
+    system_tests_cmdline_parsing
     ${SYSTEM_TESTS_HTTP}
     )
 

--- a/tests/system_tests_cmdline_parsing.py
+++ b/tests/system_tests_cmdline_parsing.py
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest2 as unittest
+import os
+import signal
+from system_test import TestCase, Qdrouterd, main_module, Process
+from subprocess import PIPE, STDOUT
+
+
+class CommandLineTest(TestCase):
+    """System tests for command line arguments parsing"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Uses a default config for testing"""
+
+        super(CommandLineTest, cls).setUpClass()
+        cls.name = "test-router"
+        cls.config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'test-router'}),
+            ('listener', {'port': cls.tester.get_port()})
+        ])
+
+    def run_qdrouterd_as_daemon(self, config_file_name="test-router", pid_file_name=os.getcwd()+'/test.pid'):
+
+        p = self.popen(
+            ['qdrouterd', '-d', '-c',
+             self.config.write(config_file_name), '-P', pid_file_name],
+            stdout=PIPE, stderr=STDOUT, expect=Process.EXIT_OK)
+        out = p.communicate()[0]
+
+        try:
+            p.teardown()
+            # kill qdrouterd running as a daemon
+            with open(pid_file_name, 'r') as pidfile:
+                for line in pidfile:
+                    os.kill(int(line), signal.SIGTERM)
+            pidfile.close()
+        except Exception, e:
+            raise Exception("%s\n%s" % (e, out))
+
+        pass
+
+    def test_01_qdrouterd_daemon_config_relative_path(self):
+        """
+        Starts qdrouterd as daemon, enforcing a config file name with
+        relative path.
+        """
+
+        try:
+            self.run_qdrouterd_as_daemon()
+        except Exception, e:
+            self.fail(e)
+
+    def test_02_qdrouterd_daemon_config_full_path(self):
+        """
+        Starts qdrouterd as daemon, enforcing a config file name with
+        full path.
+        """
+
+        try:
+            self.run_qdrouterd_as_daemon(os.getcwd() + "/test-router.conf".format(os.getpid()))
+        except Exception, e:
+            self.fail(e)
+
+
+if __name__ == '__main__':
+    unittest.main(main_module())


### PR DESCRIPTION
DISPATCH-940 - Allow configuration file to be used from relative path when running as a daemon.