### PR TITLE
NO JIRA - Update links to qdrouterd.conf man page

### DIFF
--- a/doc/new-book/configuration-connections.adoc
+++ b/doc/new-book/configuration-connections.adoc
@@ -44,7 +44,7 @@ listener {
 `host`:: Either an IP address (IPv4 or IPv6) or hostname on which the router should listen for incoming connections.
 `port`:: The port number or symbolic service name on which the router should listen for incoming connections.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_listener[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_listener[listener] in the `qdrouterd.conf` man page.
 --
 
 . If necessary, xref:securing-incoming-connections[secure the connection].
@@ -80,7 +80,7 @@ connector {
 `host`:: Either an IP address (IPv4 or IPv6) or hostname on which the router should connect.
 `port`:: The port number or symbolic service name on which the router should connect.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_connector[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_connector[connector] in the `qdrouterd.conf` man page.
 --
 
 . If necessary, xref:securing-outgoing-connections[secure the connection].

--- a/doc/new-book/configuration-security.adoc
+++ b/doc/new-book/configuration-security.adoc
@@ -116,7 +116,7 @@ For example:
 password: routerKeyPassword
 ----
 
-For information about additional `sslProfile` attributes, see link:{qdrouterdConfManPageUrl}#_sslprofile[the `qdrouterd.conf` man page].
+For information about additional `sslProfile` attributes, see link:{qdrouterdConfManPageUrl}#_sslprofile[sslProfile] in the `qdrouterd.conf` man page.
 --
 
 [id='setting-up-sasl-for-authentication-and-payload-encryption']

--- a/doc/new-book/logging.adoc
+++ b/doc/new-book/logging.adoc
@@ -291,7 +291,7 @@ To specify multiple levels, use a comma-separated list. You can also use `+` to 
 //end::logging-levels[]
 `includeTimestamp`:: Set this to `yes` to include the timestamp in all logs.
 
-For information about additional log attributes, see link:{qdrouterdConfManPageUrl}#_log[the `qdrouterd.conf` man page].
+For information about additional log attributes, see link:{qdrouterdConfManPageUrl}#_log[log] in the `qdrouterd.conf` man page.
 --
 
 . Add an additional `log` section for each logging module that should not follow the default logging configuration:
@@ -312,7 +312,7 @@ log {
 +
 include::logging.adoc[tags=logging-levels]
 
-For information about additional log attributes, see link:{qdrouterdConfManPageUrl}#_log[the `qdrouterd.conf` man page].
+For information about additional log attributes, see link:{qdrouterdConfManPageUrl}#_log[log] in the `qdrouterd.conf` man page.
 --
 
 == Viewing Log Entries

--- a/doc/new-book/managing-using-qdmanage.adoc
+++ b/doc/new-book/managing-using-qdmanage.adoc
@@ -85,7 +85,7 @@ You can use `qdmanage` to view, create, update, and delete listeners and connect
 
 Listeners define how clients can connect to a router. The following table lists the `qdmanage` commands you can use to perform common operations on listeners.
 
-For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_listener[the `qdrouterd.conf` man page].
+For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_listener[listener] in the `qdrouterd.conf` man page.
 
 //tag::qdmanage-connection-options-note[]
 [NOTE]
@@ -188,7 +188,7 @@ qdmanage delete --name=_LISTENER_NAME_
 
 Connectors define how the router can connect to other endpoints in your messaging network, such as brokers and other routers. The following table lists the `qdmanage` commands you can use to perform common operations on connectors.
 
-For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_connector[the `qdrouterd.conf` man page].
+For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_connector[connector] in the `qdrouterd.conf` man page.
 
 // Note about qdmanage connection options.
 include::managing-using-qdmanage.adoc[tags=qdmanage-connection-options-note]
@@ -297,7 +297,7 @@ qdmanage delete --name=_CONNECTOR_NAME_
 
 {RouterName} supports SSL/TLS for certificate-level encryption and mutual authentication. The following table lists the common `qdmanage` commands you can use to secure incoming and outgoing connections for a router in your router network.
 
-For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_sslprofile[the `qdrouterd.conf` man page].
+For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_sslprofile[sslProfile] and link:{qdrouterdConfManPageUrl}#_listener[listener] in the `qdrouterd.conf` man page.
 
 // Note about qdmanage connection options.
 include::managing-using-qdmanage.adoc[tags=qdmanage-connection-options-note]
@@ -375,7 +375,7 @@ qdmanage delete --name=_SSL_PROFILE_NAME_
 
 {RouterName} supports SASL for authentication and payload encryption. The following table lists the common `qdmanage` commands you can use to secure incoming and outgoing connections for a router in your router network.
 
-For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_router[the `qdrouterd.conf` man page].
+For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_router[router] and link:{qdrouterdConfManPageUrl}#_listener[listener] in the `qdrouterd.conf` man page.
 
 // Note about qdmanage connection options.
 include::managing-using-qdmanage.adoc[tags=qdmanage-connection-options-note]
@@ -574,7 +574,7 @@ qdmanage delete --name=_AUTOLINK_NAME_
 
 A link route is a chain of links between a sender and receiver that provides a private messaging path. The following table lists the common `qdmanage` commands you can use to view, create, update, and delete link routes.
 
-For more information about the attributes you can use with these commands, see the link:{qdrouterdConfManPageUrl}#_linkroute[the `qdrouterd.conf` man page].
+For more information about the attributes you can use with these commands, see the link:{qdrouterdConfManPageUrl}#_linkroute[linkRoute] in the `qdrouterd.conf` man page.
 
 // Note about qdmanage connection options.
 include::managing-using-qdmanage.adoc[tags=qdmanage-connection-options-note]
@@ -632,7 +632,7 @@ qdmanage delete --name=_OUTGOING_LINK_ROUTE_NAME_
 
 {RouterName} logs are broken into different categories called logging modules. Each module provides important information about a particular aspect of a router. The following table lists the common `qdmanage` commands you can use to view and change the configuration of a logging module.
 
-For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_log[the `qdrouterd.conf` man page].
+For more information about the attributes you can use with these commands, see link:{qdrouterdConfManPageUrl}#_log[log] in the `qdrouterd.conf` man page.
 
 // Note about qdmanage connection options.
 include::managing-using-qdmanage.adoc[tags=qdmanage-connection-options-note]

--- a/doc/new-book/routing.adoc
+++ b/doc/new-book/routing.adoc
@@ -248,7 +248,7 @@ You can convert a `prefix` value to a `pattern` by appending `/\#` to it. For ex
 +
 For more information about message distribution patterns, see xref:routing-patterns-overview[Routing Patterns].
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_address[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_address[address] in the `qdrouterd.conf` man page.
 --
 
 . Add the same `address` section to any other routers that need to use the address.
@@ -346,7 +346,7 @@ connector {
 `port`:: The port number or symbolic service name on which the router should connect to the broker.
 `role`:: Specify `route-container` to indicate that this connection is for an external container (broker).
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_connector[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_connector[connector] in the `qdrouterd.conf` man page.
 --
 
 . If you want to send messages to the broker queue, create an outgoing autolink to the broker queue:
@@ -367,7 +367,7 @@ autoLink {
 `connection` | `containerID`:: How the router should connect to the broker. You can specify either an outgoing connection (`connection`) or the container ID of the broker (`containerID`).
 `direction`:: Set this attribute to `out` to specify that this autolink can send messages from the router to the broker.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_autolink[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_autolink[autoLink] in the `qdrouterd.conf` man page.
 --
 
 . If you want to receive messages from the broker queue, create an incoming autolink from the broker queue:
@@ -388,7 +388,7 @@ autoLink {
 `connection` | `containerID`:: How the router should connect to the broker. You can specify either an outgoing connection (`connection`) or the container ID of the broker (`containerID`).
 `direction`:: Set this attribute to `in` to specify that this autolink can receive messages from the broker to the router.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_autolink[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_autolink[autoLink] in the `qdrouterd.conf` man page.
 --
 
 === Example: Routing Messages Through Broker Queues
@@ -572,7 +572,7 @@ connector {
 `port`:: The port number or symbolic service name on which the router should connect to the broker.
 `role`:: Specify `route-container` to indicate that this connection is for an external container (broker).
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_connector[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_connector[connector] in the `qdrouterd.conf` man page.
 --
 
 . If you want clients to send messages on this link route, create an incoming link route:
@@ -600,7 +600,7 @@ If multiple brokers are connected to the router through this connection, request
 
 `direction`:: Set this attribute to `in` to specify that clients can send messages into the router network on this link route.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_linkroute[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_linkroute[linkRoute] in the `qdrouterd.conf` man page.
 --
 
 . If you want clients to receive messages on this link route, create an outgoing link route:
@@ -627,7 +627,7 @@ include::routing.adoc[tags=pattern-matching]
 If multiple brokers are connected to the router through this connection, requests for addresses matching the link route's prefix or pattern are balanced across the brokers. Alternatively, if you want to specify a particular broker, use `containerID` and add the broker's container ID.
 `direction`:: Set this attribute to `out` to specify that this link route is for receivers.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_linkroute[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_linkroute[linkRoute] in the `qdrouterd.conf` man page.
 --
 
 === Example: Using a Link Route to Provide Client Isolation

--- a/doc/new-book/understand-router-configuration.adoc
+++ b/doc/new-book/understand-router-configuration.adoc
@@ -178,7 +178,7 @@ router {
 * `interior` - Use this mode if the router is part of a router network and needs to collaborate with other routers.
 `id`:: The unique identifier for the router. This ID will also be the container name at the AMQP protocol level.
 
-For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_router[the `qdrouterd.conf` man page].
+For information about additional attributes, see link:{qdrouterdConfManPageUrl}#_router[router] in the `qdrouterd.conf` man page.
 --
 
 . If necessary for your environment, secure the router.


### PR DESCRIPTION
In the Dispatch Router doc, even though each link to the qdrouterd.conf man page targets the correct section of the man page, the link text does not include the name of the section to which the link points. This PR adds the name of the section to the link text.