### PR TITLE
DISPATCH-960 - Resolving service port when using http listener

### DIFF
--- a/src/amqp.c
+++ b/src/amqp.c
@@ -21,6 +21,9 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <netdb.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 const char * const QD_MA_PREFIX  = "x-opt-qd.";
 const char * const QD_MA_INGRESS = "x-opt-qd.ingress";
@@ -90,11 +93,29 @@ const char * const QD_AMQP_COND_CONNECTION_FORCED = "amqp:connection:forced";
 const char * const QD_AMQP_PORT_STR = "5672";
 const char * const QD_AMQPS_PORT_STR = "5671";
 
+const char * const QD_AMQP_DFLT_PROTO = "tcp";
+
 int qd_port_int(const char* port_str) {
-    if (!strcmp(port_str, QD_AMQP_PORT_STR)) return QD_AMQP_PORT_INT;
-    if (!strcmp(port_str, QD_AMQPS_PORT_STR)) return QD_AMQPS_PORT_INT;
     errno = 0;
     unsigned long n = strtoul(port_str, NULL, 10);
     if (errno || n > 0xFFFF) return -1;
+
+    // Port is not an integer (port = 'amqp' or 'amqps')
+    if ( !n && strlen(port_str) > 0 ) {
+        // Resolve service port
+        struct servent serv_info;
+        struct servent *serv_info_res;
+        int buf_len = 4096;
+        char *buf = calloc(buf_len, sizeof(char));
+
+        // Service port is resolved
+        if ( !getservbyname_r(port_str, QD_AMQP_DFLT_PROTO, &serv_info, buf, buf_len, &serv_info_res) ) {
+            n = ntohs(serv_info.s_port);
+        } else {
+            n = -1;
+        }
+        free(buf);
+    }
+
     return n;
 }


### PR DESCRIPTION
As suggested by @ted-ross, I am re-submitting this PR again now using getservbyname_r which is multi-thread safe.

If you find any other possible issue, please let me know. 