### PR TITLE
Dispatch 990 Use patterns for policy vhost hostnames

### DIFF
--- a/doc/book/policy.adoc
+++ b/doc/book/policy.adoc
@@ -90,6 +90,64 @@ xref:example2[Example 2] illustrates how the default vhost feature can
 be used to apply a single vhost policy set of restrictions to any
 number of vhost connections.
 
+=== Vhost Patterns
+
+Policy vhost names may be interpreted as literal host names or 
+as host name patterns. Vhost name patterns are a convenience
+for letting a single policy rule cover a wide range of vhosts.
+
+Host name patterns consist of a series of host and domain name
+labels and one or more tokens all concatenated with periods or dots.
+A token can be one of the following:
+
+[options="header"]
+|====
+| Token character | Match rule
+| asterisk *      | matches a single hostname label
+| hash #          | matches zero or more hostname labels
+|====
+
+Some simple examples show how given policy name patterns match
+incoming connection vhost names.
+
+[options="header"]
+|====
+| Policy pattern         | Connection vhost           | Policy match
+| *.example.com          | example.com                | no
+| *.example.com          | www.example.com            | yes
+| *.example.com          | srv2.www.example.com       | no
+| #.example.com          | example.com                | yes
+| #.example.com          | www.example.com            | yes
+| #.example.com          | a.b.c.d.example.com        | yes
+| #.example.com          | bighost.com                | no
+| www.*.test.example.com | www.test.example.com       | no
+| www.*.test.example.com | www.a.test.example.com     | yes
+| www.*.test.example.com | www.a.b.c.test.example.com | no
+| www.#.test.example.com | www.test.example.com       | yes
+| www.#.test.example.com | www.a.test.example.com     | yes
+| www.#.test.example.com | www.a.b.c.test.example.com | yes
+|====
+
+Pattern matching applies the following precedence rules.
+
+[options="header"]
+|====
+| Policy pattern      | Precedence
+| exact match         | high
+| asterisk *          | medium
+| hash #              | low
+|====
+
+Policy vhost name patterns are optimised before they are used 
+in connection vhost name matching. As a result of this
+optimisation the names stored for pattern match lookups are
+not necessarily the same as the patterns specified in the 
+vhost policy hostname. The policy agent disallows vhost
+name patterns that reduce to the same pattern as an existing name 
+pattern. For instance, name pattern _pass:[#.#.#.#.com]_ is reduced to _pass:[#.com]_.
+Attempts to create a vhost name pattern whose optimised
+name conflicts with an existing optimised name will be denied.
+
 == Policy Schema
 
 Policy configuration is specified in two schema objects.
@@ -123,6 +181,7 @@ created as needed.
 | enableVhostPolicy   | false      | Enable vhost policy connection denial, and resource limit enforcement.
 | policyDir           | ""         | Absolute path to a directory that holds vhost definition .json files. All vhost definitions in all .json files in this directory are processed.
 | defaultVhost        | "$default" | Vhost rule set name to use for connections with a vhost that is otherwise not defined. Default vhost processing may be disabled either by erasing the definition of _defaultVhost_ or by not defining a _vhost_ object named _$default_.
+| enableVhostNamePatterns | false  | Enable vhost name patterns. When false vhost hostnames are treated as literal strings. When true vhost hostnames are treated as match patterns.
 |====
 
 === Vhost Policy

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1678,6 +1678,13 @@
                     "required": false,
                     "create": true
                 },
+                "useVhostNamePatterns": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use Vhost name patterns.",
+                    "required": false,
+                    "create": true
+                },
                 "policyDir": {
                     "type": "path",
                     "default": "",

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1678,10 +1678,10 @@
                     "required": false,
                     "create": true
                 },
-                "useVhostNamePatterns": {
+                "enableVhostNamePatterns": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Use Vhost name patterns.",
+                    "description": "Enable vhost name patterns. When false vhost hostnames are treated as literal strings. When true vhost hostnames are treated as match patterns.",
                     "required": false,
                     "create": true
                 },

--- a/python/qpid_dispatch_internal/dispatch.py
+++ b/python/qpid_dispatch_internal/dispatch.py
@@ -78,7 +78,7 @@ class QdDll(ctypes.PyDLL):
         self._prototype(self.qd_dispatch_policy_c_counts_alloc, c_long, [], check=False)
         self._prototype(self.qd_dispatch_policy_c_counts_free, None, [c_long], check=False)
         self._prototype(self.qd_dispatch_policy_c_counts_refresh, None, [c_long, py_object])
-        self._prototype(self.qd_dispatch_policy_host_pattern_add, None, [self.qd_dispatch_p, c_char_p])
+        self._prototype(self.qd_dispatch_policy_host_pattern_add, ctypes.c_bool, [self.qd_dispatch_p, c_char_p])
         self._prototype(self.qd_dispatch_policy_host_pattern_remove, None, [self.qd_dispatch_p, c_char_p])
         self._prototype(self.qd_dispatch_policy_host_pattern_lookup, c_char_p, [self.qd_dispatch_p, c_char_p])
         

--- a/python/qpid_dispatch_internal/dispatch.py
+++ b/python/qpid_dispatch_internal/dispatch.py
@@ -78,6 +78,10 @@ class QdDll(ctypes.PyDLL):
         self._prototype(self.qd_dispatch_policy_c_counts_alloc, c_long, [], check=False)
         self._prototype(self.qd_dispatch_policy_c_counts_free, None, [c_long], check=False)
         self._prototype(self.qd_dispatch_policy_c_counts_refresh, None, [c_long, py_object])
+        self._prototype(self.qd_dispatch_policy_host_pattern_add, None, [self.qd_dispatch_p, c_char_p])
+        self._prototype(self.qd_dispatch_policy_host_pattern_remove, None, [self.qd_dispatch_p, c_char_p])
+        self._prototype(self.qd_dispatch_policy_host_pattern_lookup, c_char_p, [self.qd_dispatch_p, c_char_p])
+        
 
         self._prototype(self.qd_dispatch_register_display_name_service, None, [self.qd_dispatch_p, py_object])
 

--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -178,7 +178,7 @@ def configure_dispatch(dispatch, lib_handle, filename):
     # Configure policy and policy manager before vhosts
     policyDir           = config.by_type('policy')[0]['policyDir']
     policyDefaultVhost  = config.by_type('policy')[0]['defaultVhost']
-    useHostnamePatterns = config.by_type('policy')[0]['useVhostNamePatterns']
+    useHostnamePatterns = config.by_type('policy')[0]['enableVhostNamePatterns']
     for a in config.by_type("policy"):
         configure(a)
     agent.policy.set_default_vhost(policyDefaultVhost)

--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -174,13 +174,21 @@ def configure_dispatch(dispatch, lib_handle, filename):
     from qpid_dispatch_internal.display_name.display_name import DisplayNameService
     displayname_service = DisplayNameService()
     qd.qd_dispatch_register_display_name_service(dispatch, displayname_service)
-    policyDir = config.by_type('policy')[0]['policyDir']
-    policyDefaultVhost = config.by_type('policy')[0]['defaultVhost']
+
+    # Configure policy and policy manager before vhosts
+    policyDir           = config.by_type('policy')[0]['policyDir']
+    policyDefaultVhost  = config.by_type('policy')[0]['defaultVhost']
+    useHostnamePatterns = config.by_type('policy')[0]['useVhostNamePatterns']
+    for a in config.by_type("policy"):
+        configure(a)
+    agent.policy.set_default_vhost(policyDefaultVhost)
+    agent.policy.set_use_hostname_patterns(useHostnamePatterns)
+
     # Remaining configuration
     for t in "sslProfile", "authServicePlugin", "listener", "connector", \
              "router.config.address", "router.config.linkRoute", "router.config.autoLink", \
              "router.config.exchange", "router.config.binding", \
-             "policy", "vhost":
+             "vhost":
         for a in config.by_type(t):
             configure(a)
             if t == "sslProfile":
@@ -201,6 +209,3 @@ def configure_dispatch(dispatch, lib_handle, filename):
                 pconfig = PolicyConfig(os.path.join(apath, i))
                 for a in pconfig.by_type("vhost"):
                     agent.configure(a)
-
-    # Set policy default application after all rulesets loaded
-    agent.policy.set_default_vhost(policyDefaultVhost)

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -703,9 +703,16 @@ class PolicyLocal(object):
         """
         try:
             vhost = vhost_in
+            if self.use_hostname_patterns:
+                agent = self._manager.get_agent()
+                vhost = agent.qd.qd_dispatch_policy_host_pattern_lookup(agent.dispatch, vhost)
             if vhost not in self.rulesetdb:
                 if self.default_vhost_enabled():
                     vhost = self._default_vhost
+            if vhost != vhost_in:
+                self._manager.log_debug(
+                    "AMQP Open lookup settings for user '%s', rhost '%s', vhost '%s': "
+                    "proceeds using vhost '%s' ruleset" % (user, rhost, vhost_in, vhost))
 
             if vhost not in self.rulesetdb:
                 self._manager.log_info(

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -539,6 +539,13 @@ class PolicyLocal(object):
             self.statsdb[name].update_ruleset(candidate)
             self._manager.log_info("Updated policy rules for vhost %s" % name)
         # TODO: ruleset lock
+        if self.use_hostname_patterns:
+            agent = self._manager.get_agent()
+            if name in self.rulesetdb:
+                # an update. remove existing hostname pattern
+                agent.qd.qd_dispatch_policy_host_pattern_remove(agent.dispatch, name)
+            # add new pattern
+            agent.qd.qd_dispatch_policy_host_pattern_add(agent.dispatch, name)
         self.rulesetdb[name] = {}
         self.rulesetdb[name].update(candidate)
 
@@ -550,6 +557,9 @@ class PolicyLocal(object):
         if name not in self.rulesetdb:
             raise PolicyError("Policy '%s' does not exist" % name)
         # TODO: ruleset lock
+        if self.use_hostname_patterns:
+            agent = self._manager.get_agent()
+            agent.qd.qd_dispatch_policy_host_pattern_remove(agent.dispatch, name)
         del self.rulesetdb[name]
 
     #

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -508,6 +508,11 @@ class PolicyLocal(object):
         #  open.hostname is not found in the rulesetdb
         self._default_vhost = ""
 
+        # _use_hostname_patterns
+        #  holds policy setting.
+        #  When true policy ruleset definitions are propagated to C code
+        self.use_hostname_patterns = False
+
     #
     # Service interfaces
     #

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -607,15 +607,24 @@ class PolicyLocal(object):
         """
         try:
             # choose rule set based on incoming vhost or default vhost
+            # or potential vhost found by pattern matching
             vhost = vhost_in
-            if vhost_in not in self.rulesetdb:
+            if self.use_hostname_patterns:
+                agent = self._manager.get_agent()
+                vhost = agent.qd.qd_dispatch_policy_host_pattern_lookup(agent.dispatch, vhost)
+            if vhost not in self.rulesetdb:
                 if self.default_vhost_enabled():
                     vhost = self._default_vhost
                 else:
                     self._manager.log_info(
                         "DENY AMQP Open for user '%s', rhost '%s', vhost '%s': "
-                        "No policy defined for vhost" % (user, rhost, vhost))
+                        "No policy defined for vhost" % (user, rhost, vhost_in))
                     return ""
+            if vhost != vhost_in:
+                self._manager.log_debug(
+                    "AMQP Open for user '%s', rhost '%s', vhost '%s': "
+                    "proceeds using vhost '%s' ruleset" % (user, rhost, vhost_in, vhost))
+
             ruleset = self.rulesetdb[vhost]
 
             # look up the stats

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -531,6 +531,11 @@ class PolicyLocal(object):
         if len(warnings) > 0:
             for warning in warnings:
                 self._manager.log_warning(warning)
+        # Reject if parse tree optimized name collision
+        if self.use_hostname_patterns:
+            agent = self._manager.get_agent()
+            if not agent.qd.qd_dispatch_policy_host_pattern_add(agent.dispatch, name):
+                raise PolicyError("Policy '%s' optimized pattern conflicts with existing pattern" % name)
         if name not in self.rulesetdb:
             if name not in self.statsdb:
                 self.statsdb[name] = AppStats(name, self._manager, candidate)
@@ -539,13 +544,6 @@ class PolicyLocal(object):
             self.statsdb[name].update_ruleset(candidate)
             self._manager.log_info("Updated policy rules for vhost %s" % name)
         # TODO: ruleset lock
-        if self.use_hostname_patterns:
-            agent = self._manager.get_agent()
-            if name in self.rulesetdb:
-                # an update. remove existing hostname pattern
-                agent.qd.qd_dispatch_policy_host_pattern_remove(agent.dispatch, name)
-            # add new pattern
-            agent.qd.qd_dispatch_policy_host_pattern_add(agent.dispatch, name)
         self.rulesetdb[name] = {}
         self.rulesetdb[name].update(candidate)
 

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -711,8 +711,8 @@ class PolicyLocal(object):
                     vhost = self._default_vhost
             if vhost != vhost_in:
                 self._manager.log_debug(
-                    "AMQP Open lookup settings for user '%s', rhost '%s', vhost '%s': "
-                    "proceeds using vhost '%s' ruleset" % (user, rhost, vhost_in, vhost))
+                    "AMQP Open lookup settings for vhost '%s': "
+                    "proceeds using vhost '%s' ruleset" % (vhost_in, vhost))
 
             if vhost not in self.rulesetdb:
                 self._manager.log_info(

--- a/python/qpid_dispatch_internal/policy/policy_manager.py
+++ b/python/qpid_dispatch_internal/policy/policy_manager.py
@@ -43,6 +43,7 @@ class PolicyManager(object):
         self._agent = agent
         self._policy_local = PolicyLocal(self)
         self.log_adapter = LogAdapter("POLICY")
+        self._use_hostname_patterns = False
 
     def log(self, level, text):
         info = traceback.extract_stack(limit=2)[0] # Caller frame info
@@ -69,6 +70,13 @@ class PolicyManager(object):
 
     def get_agent(self):
         return self._agent
+
+    def get_use_hostname_patterns(self):
+        return self._use_hostname_patterns
+
+    def set_use_hostname_patterns(self, v):
+        self._use_hostname_patterns = v
+        self._policy_local.use_hostname_patterns = v
 
     #
     # Management interface to create a ruleset

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -270,6 +270,21 @@ void qd_dispatch_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
     qd_policy_c_counts_refresh(ccounts, entity);
 }
 
+void qd_dispatch_policy_host_pattern_add(qd_dispatch_t *qd, char *hostPattern)
+{
+    qd_policy_host_pattern_add(qd->policy, hostPattern);
+}
+
+void qd_dispatch_policy_host_pattern_remove(qd_dispatch_t *qd, char *hostPattern)
+{
+    qd_policy_host_pattern_remove(qd->policy, hostPattern);
+}
+
+char * qd_dispatch_policy_host_pattern_lookup(qd_dispatch_t *qd, char *hostPattern)
+{
+    return qd_policy_host_pattern_lookup(qd->policy, hostPattern);
+}
+
 qd_error_t qd_dispatch_prepare(qd_dispatch_t *qd)
 {
     qd->server             = qd_server(qd, qd->thread_count, qd->router_id, qd->sasl_config_path, qd->sasl_config_name);

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -270,9 +270,9 @@ void qd_dispatch_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
     qd_policy_c_counts_refresh(ccounts, entity);
 }
 
-void qd_dispatch_policy_host_pattern_add(qd_dispatch_t *qd, char *hostPattern)
+bool qd_dispatch_policy_host_pattern_add(qd_dispatch_t *qd, char *hostPattern)
 {
-    qd_policy_host_pattern_add(qd->policy, hostPattern);
+    return qd_policy_host_pattern_add(qd->policy, hostPattern);
 }
 
 void qd_dispatch_policy_host_pattern_remove(qd_dispatch_t *qd, char *hostPattern)

--- a/src/policy.c
+++ b/src/policy.c
@@ -67,7 +67,7 @@ struct qd_policy_t {
     int                   max_connection_limit;
     char                 *policyDir;
     bool                  enableVhostPolicy;
-    bool                  useVhostNamePatterns;
+    bool                  enableVhostNamePatterns;
                           // live statistics
     int                   connections_processed;
     int                   connections_denied;
@@ -115,7 +115,7 @@ qd_error_t qd_entity_configure_policy(qd_policy_t *policy, qd_entity_t *entity)
     policy->policyDir =
         qd_entity_opt_string(entity, "policyDir", 0); CHECK();
     policy->enableVhostPolicy = qd_entity_opt_bool(entity, "enableVhostPolicy", false); CHECK();
-    policy->useVhostNamePatterns = qd_entity_opt_bool(entity, "useVhostNamePatterns", false); CHECK();
+    policy->enableVhostNamePatterns = qd_entity_opt_bool(entity, "enableVhostNamePatterns", false); CHECK();
     qd_log(policy->log_source, QD_LOG_INFO,
            "Policy configured maxConnections: %d, "
            "policyDir: '%s',"
@@ -124,7 +124,7 @@ qd_error_t qd_entity_configure_policy(qd_policy_t *policy, qd_entity_t *entity)
            policy->max_connection_limit,
            policy->policyDir,
            (policy->enableVhostPolicy ? "true" : "false"),
-           (policy->useVhostNamePatterns ? "true" : "false"));
+           (policy->enableVhostNamePatterns ? "true" : "false"));
     return QD_ERROR_NONE;
 
 error:

--- a/src/policy.c
+++ b/src/policy.c
@@ -834,10 +834,10 @@ bool qd_policy_approve_link_name(const char *username,
 
 
 // Add a hostname to the lookup parse_tree
-void qd_policy_host_pattern_add(qd_policy_t *policy, const char *hostPattern)
+void qd_policy_host_pattern_add(qd_policy_t *policy, char *hostPattern)
 {
     sys_mutex_lock(policy->tree_lock);
-    void *oldp = qd_parse_tree_add_pattern_str(policy->hostname_tree, hostPattern, (void*)hostPattern);
+    void *oldp = qd_parse_tree_add_pattern_str(policy->hostname_tree, hostPattern, hostPattern);
     sys_mutex_unlock(policy->tree_lock);
     if (oldp) {
         qd_log(policy->log_source, QD_LOG_INFO, "vhost hostname pattern '%s' replaced existing pattern", hostPattern);
@@ -846,7 +846,7 @@ void qd_policy_host_pattern_add(qd_policy_t *policy, const char *hostPattern)
 
 
 // Remove a hostname from the lookup parse_tree
-void qd_policy_host_pattern_remove(qd_policy_t *policy, const char *hostPattern)
+void qd_policy_host_pattern_remove(qd_policy_t *policy, char *hostPattern)
 {
     sys_mutex_lock(policy->tree_lock);
     void *oldp = qd_parse_tree_remove_pattern_str(policy->hostname_tree, hostPattern);
@@ -858,14 +858,16 @@ void qd_policy_host_pattern_remove(qd_policy_t *policy, const char *hostPattern)
 
 
 // Look up a hostname in the lookup parse_tree
-const char *qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPattern)
+char * qd_policy_host_pattern_lookup(qd_policy_t *policy, char *hostPattern)
 {
     void *payload = 0;
     sys_mutex_lock(policy->tree_lock);
     bool matched = qd_parse_tree_retrieve_match_str(policy->hostname_tree, hostPattern, &payload);
     sys_mutex_unlock(policy->tree_lock);
-    if (!matched) payload = 0;
+    if (!matched) {
+        payload = 0;
+    }
     qd_log(policy->log_source, QD_LOG_TRACE, "vhost hostname pattern '%s' lookup returned '%s'", 
            hostPattern, (payload ? (char *)payload : "null"));
-    return (const char *)payload;
+    return payload;
 }

--- a/src/policy.c
+++ b/src/policy.c
@@ -61,6 +61,7 @@ struct qd_policy_t {
     qd_dispatch_t        *qd;
     qd_log_source_t      *log_source;
     void                 *py_policy_manager;
+    sys_mutex_t          *tree_lock;
     qd_parse_tree_t      *hostname_tree;
                           // configured settings
     int                   max_connection_limit;
@@ -83,6 +84,7 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->qd                   = qd;
     policy->log_source           = qd_log_source("POLICY");
     policy->max_connection_limit = 65535;
+    policy->tree_lock            = sys_mutex();
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");

--- a/src/policy.c
+++ b/src/policy.c
@@ -114,8 +114,15 @@ qd_error_t qd_entity_configure_policy(qd_policy_t *policy, qd_entity_t *entity)
         qd_entity_opt_string(entity, "policyDir", 0); CHECK();
     policy->enableVhostPolicy = qd_entity_opt_bool(entity, "enableVhostPolicy", false); CHECK();
     policy->useVhostNamePatterns = qd_entity_opt_bool(entity, "useVhostNamePatterns", false); CHECK();
-    qd_log(policy->log_source, QD_LOG_INFO, "Policy configured maxConnections: %d, policyDir: '%s', access rules enabled: '%s', use hostname patterns: '%s'",
-           policy->max_connection_limit, policy->policyDir, (policy->enableVhostPolicy ? "true" : "false"), (policy->useVhostNamePatterns ? "true" : "false"));
+    qd_log(policy->log_source, QD_LOG_INFO,
+           "Policy configured maxConnections: %d, "
+           "policyDir: '%s',"
+           "access rules enabled: '%s', "
+           "use hostname patterns: '%s'",
+           policy->max_connection_limit,
+           policy->policyDir,
+           (policy->enableVhostPolicy ? "true" : "false"),
+           (policy->useVhostNamePatterns ? "true" : "false"));
     return QD_ERROR_NONE;
 
 error:

--- a/src/policy.c
+++ b/src/policy.c
@@ -838,17 +838,16 @@ bool qd_policy_host_pattern_add(qd_policy_t *policy, char *hostPattern)
 {
     sys_mutex_lock(policy->tree_lock);
     void *oldp = qd_parse_tree_add_pattern_str(policy->hostname_tree, hostPattern, hostPattern);
-    sys_mutex_unlock(policy->tree_lock);
     if (oldp) {
-        qd_log(policy->log_source,
-               QD_LOG_WARNING,
-               "vhost hostname pattern '%s' failed to replace optimized pattern '%s'",
-               hostPattern, oldp);
-        sys_mutex_lock(policy->tree_lock);
         void *recovered = qd_parse_tree_add_pattern_str(policy->hostname_tree, (char *)oldp, oldp);
-        sys_mutex_unlock(policy->tree_lock);
-        assert (recovered && !strcmp((char *)recovered, hostPattern));
+        assert (recovered);
     }
+    sys_mutex_unlock(policy->tree_lock);
+    if (oldp)
+        qd_log(policy->log_source,
+            QD_LOG_WARNING,
+            "vhost hostname pattern '%s' failed to replace optimized pattern '%s'",
+            hostPattern, oldp);
     return oldp == 0;
 }
 

--- a/src/policy.h
+++ b/src/policy.h
@@ -177,4 +177,23 @@ bool qd_policy_approve_link_name(const char *username,
                                   const char *proposed,
                                   bool isReceiver
                                 );
+
+/** Add a hostname to the lookup parse_tree
+ * @param[in] policy qd_policy_t
+ * @param[in] hostPattern the hostname pattern with possible parse_tree wildcards
+ */
+void qd_policy_host_pattern_add(qd_policy_t *policy, const char *hostPattern);
+
+/** Remove a hostname from the lookup parse_tree
+ * @param[in] policy qd_policy_t
+ * @param[in] hostPattern the hostname pattern with possible parse_tree wildcards
+ */
+void qd_policy_host_pattern_remove(qd_policy_t *policy, const char *hostPattern);
+
+/** Look up a hostname in the lookup parse_tree
+ * @param[in] policy qd_policy_t
+ * @param[in] hostname a concrete vhost name
+ * @return the name of the ruleset whose hostname pattern matched this actual hostname
+ */
+const char *qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPattern);
 #endif

--- a/src/policy.h
+++ b/src/policy.h
@@ -182,18 +182,18 @@ bool qd_policy_approve_link_name(const char *username,
  * @param[in] policy qd_policy_t
  * @param[in] hostPattern the hostname pattern with possible parse_tree wildcards
  */
-void qd_policy_host_pattern_add(qd_policy_t *policy, const char *hostPattern);
+void qd_policy_host_pattern_add(qd_policy_t *policy, char *hostPattern);
 
 /** Remove a hostname from the lookup parse_tree
  * @param[in] policy qd_policy_t
  * @param[in] hostPattern the hostname pattern with possible parse_tree wildcards
  */
-void qd_policy_host_pattern_remove(qd_policy_t *policy, const char *hostPattern);
+void qd_policy_host_pattern_remove(qd_policy_t *policy, char *hostPattern);
 
 /** Look up a hostname in the lookup parse_tree
  * @param[in] policy qd_policy_t
  * @param[in] hostname a concrete vhost name
  * @return the name of the ruleset whose hostname pattern matched this actual hostname
  */
-const char *qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPattern);
+char * qd_policy_host_pattern_lookup(qd_policy_t *policy, char *hostPattern);
 #endif

--- a/src/policy.h
+++ b/src/policy.h
@@ -179,10 +179,16 @@ bool qd_policy_approve_link_name(const char *username,
                                 );
 
 /** Add a hostname to the lookup parse_tree
+ * Note that the parse_tree may store an 'optimised' pattern for a given
+ * pattern. Thus the patterns a user puts in may collide with existing
+ * patterns even though the text of the host patterns is different.
+ * This function does not allow new patterns with thier optimizations 
+ * to overwrite existing patterns that may have been optimised.
  * @param[in] policy qd_policy_t
  * @param[in] hostPattern the hostname pattern with possible parse_tree wildcards
+ * @return True if the possibly optimised pattern was added to the lookup parse tree
  */
-void qd_policy_host_pattern_add(qd_policy_t *policy, char *hostPattern);
+bool qd_policy_host_pattern_add(qd_policy_t *policy, char *hostPattern);
 
 /** Remove a hostname from the lookup parse_tree
  * @param[in] policy qd_policy_t

--- a/tests/policy-8/management-access.json
+++ b/tests/policy-8/management-access.json
@@ -1,0 +1,46 @@
+##
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License
+##
+
+[
+  ["vhost", {
+      "hostname": "#.0.0",
+      "maxConnections": 50,
+      "maxConnectionsPerUser": 5,
+      "maxConnectionsPerHost": 20,
+      "allowUnknownUser": true,
+      "groups": {
+        "$default" : {
+          "users":            "*",
+          "remoteHosts":      "*",
+          "maxFrameSize":     222222,
+          "maxMessageSize":   222222,
+          "maxSessionWindow": 222222,
+          "maxSessions":           2,
+          "maxSenders":           22,
+          "maxReceivers":         22,
+          "allowDynamicSource":   true,
+          "allowAnonymousSender": true,
+          "allowUserIdProxy":     false,
+          "sources": "$management, _local/$displayname",
+          "targets": "$management, _local/$displayname"
+        }
+      }
+    }
+  ]
+]

--- a/tests/system_tests_policy.py
+++ b/tests/system_tests_policy.py
@@ -758,7 +758,7 @@ class PolicyHostamePatternTest(TestCase):
         config = Qdrouterd.Config([
             ('router', {'mode': 'standalone', 'id': 'QDR.Policy8'}),
             ('listener', {'port': listen_port}),
-            ('policy', {'maxConnections': 2, 'policyDir': policy_config_path, 'enableVhostPolicy': 'true', 'useVhostNamePatterns': 'true'})
+            ('policy', {'maxConnections': 2, 'policyDir': policy_config_path, 'enableVhostPolicy': 'true', 'enableVhostNamePatterns': 'true'})
         ])
 
         cls.router = cls.tester.qdrouterd('PolicyVhostNamePatternTest', config, wait=True)

--- a/tests/system_tests_policy.py
+++ b/tests/system_tests_policy.py
@@ -745,5 +745,80 @@ class PolicyLinkNamePatternTest(TestCase):
         self.assertTrue(exception)
 
 
+class PolicyHostamePatternTest(TestCase):
+    """
+    Verify hostname pattern matching
+    """
+    @classmethod
+    def setUpClass(cls):
+        """Start the router"""
+        super(PolicyHostamePatternTest, cls).setUpClass()
+        listen_port = cls.tester.get_port()
+        policy_config_path = os.path.join(DIR, 'policy-8')
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'QDR.Policy8'}),
+            ('listener', {'port': listen_port}),
+            ('policy', {'maxConnections': 2, 'policyDir': policy_config_path, 'enableVhostPolicy': 'true', 'useVhostNamePatterns': 'true'})
+        ])
+
+        cls.router = cls.tester.qdrouterd('PolicyVhostNamePatternTest', config, wait=True)
+        try:
+            cls.router.wait_ready(timeout = 5)
+        except Exception,  e:
+            pass
+
+    def address(self):
+        return self.router.addresses[0]
+
+    def run_qdmanage(self, cmd, input=None, expect=Process.EXIT_OK):
+        p = self.popen(
+            ['qdmanage'] + cmd.split(' ') + ['--bus', 'u1:password@' + self.address(), '--indent=-1', '--timeout', str(TIMEOUT)],
+            stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=expect)
+        out = p.communicate(input)[0]
+        try:
+            p.teardown()
+        except Exception, e:
+            raise Exception("%s\n%s" % (e, out))
+        return out
+
+    def disallowed_hostname(self):
+        return """
+{
+    "hostname": "#.#.0.0",
+    "maxConnections": 3,
+    "maxConnectionsPerHost": 3,
+    "maxConnectionsPerUser": 3,
+    "allowUnknownUser": true,
+    "groups": {
+        "$default": {
+            "allowAnonymousSender": true,
+            "maxReceivers": 99,
+            "users": "*",
+            "maxSessionWindow": 1000000,
+            "maxFrameSize": 222222,
+            "sources":       "public, private, $management",
+            "maxMessageSize": 222222,
+            "allowDynamicSource": true,
+            "remoteHosts": "*",
+            "maxSessions": 2,
+            "maxSenders": 22
+        }
+    }
+}
+"""
+
+    def test_hostname_pattern_00_hello(self):
+        rulesets = json.loads(self.run_qdmanage('query --type=vhost'))
+        self.assertEqual(len(rulesets), 1)
+
+    def test_hostname_pattern_01_denied_add(self):
+        qdm_out = "<not written>"
+        try:
+            qdm_out = self.run_qdmanage('create --type=vhost --name=#.#.0.0 --stdin', input=self.disallowed_hostname())
+        except Exception, e:
+            self.assertTrue("pattern conflicts" in e.message, msg=('Error running qdmanage %s' % e.message))
+        self.assertFalse("222222" in qdm_out)
+
+
 if __name__ == '__main__':
     unittest.main(main_module())


### PR DESCRIPTION
This adds all the code (schema, management, run time) and supporting self tests and old style doc.
This does not add anything to doc/new-book. I will coordinate that with @bhardesty