### PR TITLE
NO-JIRA: enable code coverage report in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ addons:
     - dblatex
     # unit test requirement
     - python-unittest2
+    # code coverage
+    - lcov
 
 install:
 - PREFIX=$PWD/install
@@ -60,13 +62,18 @@ before_script:
 - source qpid-proton/build/config.sh
 - mkdir build
 - pushd build
-- cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DUSE_VALGRIND=NO
+- cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DUSE_VALGRIND=NO -DCMAKE_BUILD_TYPE=Coverage
 - cmake --build . --target install
 
 script:
 - pushd ../qpid-proton
 - echo $(echo "Current proton checkout:") $(git rev-parse HEAD)
 - popd
-- ctest -V
+- ctest -V && cmake --build . --target coverage
 - popd
 - mvn apache-rat:check
+
+after_success:
+- pushd build
+- bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+


### PR DESCRIPTION
This patch enables code coverage reporting on travis.

If the build + tests are successful, at the end of the output log a url will be printed.  That url can be used to view the coverage report.  Example:

==> Uploading reports
    url: https://codecov.io
    query: branch=travis-coverage&commit=99e369453e37f96268e8b08b340b78dd616c2673&build=42.1&build_url=&name=&tag=&slug=kgiusti%2Fdispatch&service=travis&flags=&pr=false&job=391325606
    -> Pinging Codecov
    -> Uploading
    -> View reports at https://codecov.io/github/kgiusti/dispatch/commit/99e369453e37f96268e8b08b340b78dd616c2673


Open the "View reports...." link in a browser, and click on the Files header for the coverage results.