### PR TITLE
Logging

### DIFF
--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -346,7 +346,7 @@ void qdr_delivery_incref(qdr_delivery_t *delivery, const char *label)
     assert(rc > 0 || !delivery->ref_counted);
     delivery->ref_counted = true;
     if (delivery->link)
-        qd_log(delivery->link->core->log, QD_LOG_DEBUG,
+        qd_log(delivery->link->core->log, QD_LOG_TRACE,
                "Delivery incref:    dlv:%lx rc:%"PRIu32" %s", (long) delivery, rc + 1, label);
 }
 
@@ -370,7 +370,7 @@ void qdr_delivery_decref(qdr_core_t *core, qdr_delivery_t *delivery, const char 
 {
     uint32_t ref_count = sys_atomic_dec(&delivery->ref_count);
     assert(ref_count > 0);
-    qd_log(core->log, QD_LOG_DEBUG, "Delivery decref:    dlv:%lx rc:%"PRIu32" %s", (long) delivery, ref_count - 1, label);
+    qd_log(core->log, QD_LOG_TRACE, "Delivery decref:    dlv:%lx rc:%"PRIu32" %s", (long) delivery, ref_count - 1, label);
 
     if (ref_count == 1) {
         //
@@ -695,7 +695,7 @@ qdr_delivery_t *qdr_delivery_next_peer_CT(qdr_delivery_t *dlv)
 void qdr_delivery_decref_CT(qdr_core_t *core, qdr_delivery_t *dlv, const char *label)
 {
     uint32_t ref_count = sys_atomic_dec(&dlv->ref_count);
-    qd_log(core->log, QD_LOG_DEBUG, "Delivery decref_CT: dlv:%lx rc:%"PRIu32" %s", (long) dlv, ref_count - 1, label);
+    qd_log(core->log, QD_LOG_TRACE, "Delivery decref_CT: dlv:%lx rc:%"PRIu32" %s", (long) dlv, ref_count - 1, label);
     assert(ref_count > 0);
 
     if (ref_count == 1)

--- a/src/server.c
+++ b/src/server.c
@@ -543,8 +543,8 @@ static void on_accept(pn_event_t *e)
     }
     ctx->listener = listener;
     qd_log(listener->server->log_source, QD_LOG_TRACE,
-           "[%"PRIu64"] Accepting incoming connection from %s to %s",
-           ctx->connection_id, qd_connection_name(ctx), ctx->listener->config.host_port);
+           "[%"PRIu64"] Accepting incoming connection to %s",
+           ctx->connection_id, ctx->listener->config.host_port);
     /* Asynchronous accept, configure the transport on PN_CONNECTION_BOUND */
     pn_listener_accept(pn_listener, ctx->pn_conn);
  }
@@ -651,8 +651,9 @@ static void on_connection_bound(qd_server_t *server, pn_event_t *e) {
         pn_sasl_set_allow_insecure_mechs(sasl, config->allowInsecureAuthentication);
         sys_mutex_unlock(ctx->server->lock);
 
-        qd_log(ctx->server->log_source, QD_LOG_INFO, "Accepted connection to %s from %s",
-               name, ctx->rhost_port);
+        qd_log(ctx->server->log_source, QD_LOG_INFO,
+               "[%"PRIu64"]: Accepted connection to %s from %s",
+               ctx->connection_id, name, ctx->rhost_port);
     } else if (ctx->connector) { /* Establishing an outgoing connection */
         config = &ctx->connector->config;
         setup_ssl_sasl_and_open(ctx);
@@ -723,7 +724,6 @@ static void handle_listener(pn_event_t *e, qd_server_t *qd_server) {
     }
 
     case PN_LISTENER_ACCEPT:
-        qd_log(log, QD_LOG_TRACE, "Accepting connection on %s", host_port);
         on_accept(e);
         break;
 

--- a/src/server.c
+++ b/src/server.c
@@ -907,14 +907,14 @@ static bool handle(qd_server_t *qd_server, pn_event_t *e) {
         if (ctx && ctx->connector) { /* Outgoing connection */
             const qd_server_config_t *config = &ctx->connector->config;
             if (condition  && pn_condition_is_set(condition)) {
-                qd_log(qd_server->log_source, QD_LOG_INFO, "Connection to %s failed: %s %s", config->host_port,
+                qd_log(qd_server->log_source, QD_LOG_WARNING, "Connection to %s failed: %s %s", config->host_port,
                        pn_condition_get_name(condition), pn_condition_get_description(condition));
             } else {
-                qd_log(qd_server->log_source, QD_LOG_INFO, "Connection to %s failed", config->host_port);
+                qd_log(qd_server->log_source, QD_LOG_WARNING, "Connection to %s failed", config->host_port);
             }
         } else if (ctx && ctx->listener) { /* Incoming connection */
             if (condition && pn_condition_is_set(condition)) {
-                qd_log(ctx->server->log_source, QD_LOG_INFO, "Connection from %s (to %s) failed: %s %s",
+                qd_log(ctx->server->log_source, QD_LOG_WARNING, "Connection from %s (to %s) failed: %s %s",
                        ctx->rhost_port, ctx->listener->config.host_port, pn_condition_get_name(condition),
                        pn_condition_get_description(condition));
             }


### PR DESCRIPTION
Some minor changes to dispatch logging based on experience debugging the HTTP Envoy bridge.
See the commit comments for explanation.

One additional question: I was confused by the new messageLoggingComponents config, when I set MESSAGE enable trace+ I saw nothing at all, which was surprising. Perhaps the default should be "all" so that enabling MESSAGE trace does what folks expect and they can turn the logging down per connector/listener if they wish. Since trace logging will be off in production (I hope!) this won't have any effect except on users that are deliberately debugging AND have turned on trace logging for at least the MESSAGE module, so are expecting a lot of log data.