### PR TITLE
Dispatch 1046 rev2

### DIFF
--- a/python/qpid_dispatch_internal/dispatch.py
+++ b/python/qpid_dispatch_internal/dispatch.py
@@ -38,7 +38,7 @@ from __future__ import print_function
 import sys, ctypes
 from ctypes import c_char_p, c_long, py_object
 import qpid_dispatch_site
-from .compat import UNICODE
+from .compat import IS_PY2
 
 class CError(Exception):
     """Exception raised if there is an error in a C call"""
@@ -60,9 +60,6 @@ class QdDll(ctypes.PyDLL):
         # No check on qd_error_* functions, it would be recursive
         self._prototype(self.qd_error_code, c_long, [], check=False)
         self._prototype(self.qd_error_message, c_char_p, [], check=False)
-        # in python3 c_char_p returns a byte type for the error message.  We
-        # need to convert that to a unicode string:
-        self.qd_error_message.errcheck = lambda x,y,z : UNICODE(x)
         self._prototype(self.qd_log_entity, c_long, [py_object])
         self._prototype(self.qd_dispatch_configure_router, None, [self.qd_dispatch_p, py_object])
         self._prototype(self.qd_dispatch_prepare, None, [self.qd_dispatch_p])
@@ -86,10 +83,9 @@ class QdDll(ctypes.PyDLL):
         self._prototype(self.qd_dispatch_policy_c_counts_alloc, c_long, [], check=False)
         self._prototype(self.qd_dispatch_policy_c_counts_free, None, [c_long], check=False)
         self._prototype(self.qd_dispatch_policy_c_counts_refresh, None, [c_long, py_object])
-        self._prototype(self.qd_dispatch_policy_host_pattern_add, ctypes.c_bool, [self.qd_dispatch_p, c_char_p])
-        self._prototype(self.qd_dispatch_policy_host_pattern_remove, None, [self.qd_dispatch_p, c_char_p])
-        self._prototype(self.qd_dispatch_policy_host_pattern_lookup, c_char_p, [self.qd_dispatch_p, c_char_p])
-        
+        self._prototype(self.qd_dispatch_policy_host_pattern_add, ctypes.c_bool, [self.qd_dispatch_p, py_object])
+        self._prototype(self.qd_dispatch_policy_host_pattern_remove, None, [self.qd_dispatch_p, py_object])
+        self._prototype(self.qd_dispatch_policy_host_pattern_lookup, c_char_p, [self.qd_dispatch_p, py_object])
 
         self._prototype(self.qd_dispatch_register_display_name_service, None, [self.qd_dispatch_p, py_object])
 
@@ -106,16 +102,22 @@ class QdDll(ctypes.PyDLL):
 
         self._prototype(self.qd_log_recent_py, py_object, [c_long])
 
-    def _errcheck(self, result, func, args):
-        if self.qd_error_code():
-            raise CError(self.qd_error_message())
-        return result
-
     def _prototype(self, f, restype, argtypes, check=True):
-        """Set up the return and argument types and the error checker for a ctypes function"""
+        """Set up the return and argument types and the error checker for a
+        ctypes function"""
+
+        def _do_check(result, func, args):
+            if check and self.qd_error_code():
+                raise CError(self.qd_error_message())
+            if restype is c_char_p and result and not IS_PY2:
+                # in python3 c_char_p returns a byte type for the error
+                # message. We need to convert that to a string
+                result = result.decode('utf-8')
+            return result
+
         f.restype = restype
         f.argtypes = argtypes
-        if check: f.errcheck = self._errcheck
+        f.errcheck = _do_check
         return f
 
     def function(self, fname, restype, argtypes, check=True):

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <Python.h>
+#include "python_private.h"
 #include <qpid/dispatch/python_embedded.h>
 #include <qpid/dispatch.h>
 #include <qpid/dispatch/server.h>
@@ -270,18 +270,21 @@ void qd_dispatch_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
     qd_policy_c_counts_refresh(ccounts, entity);
 }
 
-bool qd_dispatch_policy_host_pattern_add(qd_dispatch_t *qd, char *hostPattern)
+bool qd_dispatch_policy_host_pattern_add(qd_dispatch_t *qd, void *py_obj)
 {
+    char *hostPattern = py_string_2_c(py_obj);
     return qd_policy_host_pattern_add(qd->policy, hostPattern);
 }
 
-void qd_dispatch_policy_host_pattern_remove(qd_dispatch_t *qd, char *hostPattern)
+void qd_dispatch_policy_host_pattern_remove(qd_dispatch_t *qd, void *py_obj)
 {
+    char *hostPattern = py_string_2_c(py_obj);
     qd_policy_host_pattern_remove(qd->policy, hostPattern);
 }
 
-char * qd_dispatch_policy_host_pattern_lookup(qd_dispatch_t *qd, char *hostPattern)
+const char * qd_dispatch_policy_host_pattern_lookup(qd_dispatch_t *qd, void *py_obj)
 {
+    char *hostPattern = py_string_2_c(py_obj);
     return qd_policy_host_pattern_lookup(qd->policy, hostPattern);
 }
 

--- a/src/policy.h
+++ b/src/policy.h
@@ -201,7 +201,7 @@ void qd_policy_host_pattern_remove(qd_policy_t *policy, char *hostPattern);
  * @param[in] hostname a concrete vhost name
  * @return the name of the ruleset whose hostname pattern matched this actual hostname
  */
-char * qd_policy_host_pattern_lookup(qd_policy_t *policy, char *hostPattern);
+const char * qd_policy_host_pattern_lookup(qd_policy_t *policy, char *hostPattern);
 
 /**
  * Compile raw CSV spec of allowed sources/targets and return

--- a/tests/system_tests_policy.py
+++ b/tests/system_tests_policy.py
@@ -817,8 +817,8 @@ class PolicyLinkNamePatternTest(TestCase):
             qdm_out = self.run_qdmanage('create --type=vhost --name=DISPATCH-1993-3 --stdin', input=self.disallowed_source_pattern1())
         except Exception as e:
             exception = True
-            self.assertTrue("InternalServerErrorStatus: PolicyError:" in e.message)
-            self.assertTrue("Policy 'DISPATCH-1993-3' is invalid:" in e.message)
+            self.assertTrue("InternalServerErrorStatus: PolicyError:" in str(e))
+            self.assertTrue("Policy 'DISPATCH-1993-3' is invalid:" in str(e))
         self.assertTrue(exception)
 
         # attempt another create that should be rejected - name subst must be prefix or suffix
@@ -828,8 +828,8 @@ class PolicyLinkNamePatternTest(TestCase):
             qdm_out = self.run_qdmanage('create --type=vhost --name=DISPATCH-1993-3 --stdin', input=self.disallowed_source_pattern2())
         except Exception as e:
             exception = True
-            self.assertTrue("InternalServerErrorStatus: PolicyError:" in e.message)
-            self.assertTrue("Policy 'DISPATCH-1993-3' is invalid:" in e.message)
+            self.assertTrue("InternalServerErrorStatus: PolicyError:" in str(e))
+            self.assertTrue("Policy 'DISPATCH-1993-3' is invalid:" in str(e))
         self.assertTrue(exception)
 
 
@@ -904,7 +904,7 @@ class PolicyHostamePatternTest(TestCase):
         try:
             qdm_out = self.run_qdmanage('create --type=vhost --name=#.#.0.0 --stdin', input=self.disallowed_hostname())
         except Exception as e:
-            self.assertTrue("pattern conflicts" in e.message, msg=('Error running qdmanage %s' % e.message))
+            self.assertTrue("pattern conflicts" in str(e), msg=('Error running qdmanage %s' % str(e)))
         self.assertFalse("222222" in qdm_out)
 
 

--- a/tests/system_tests_policy.py
+++ b/tests/system_tests_policy.py
@@ -861,7 +861,8 @@ class PolicyHostamePatternTest(TestCase):
     def run_qdmanage(self, cmd, input=None, expect=Process.EXIT_OK):
         p = self.popen(
             ['qdmanage'] + cmd.split(' ') + ['--bus', re.sub(r'amqp://', 'amqp://u1:password@', self.address()), '--indent=-1', '--timeout', str(TIMEOUT)],
-            stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=expect)
+            stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=expect,
+            universal_newlines=True)
         out = p.communicate(input)[0]
         try:
             p.teardown()


### PR DESCRIPTION
Had to change the way we pass args to the host address parse tree api under python3

c_char_p is a bytes type under python3.  Passing and returning a unicode string causes it to fail.  Had to manually convert between the two.  Also need to save a copy of the pattern in the tree as a payload.