### PR TITLE
DISPATCH-1098: Adjust name of unit2 executable for python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,10 @@ include(FindPythonLibs)
 
 if (PYTHON_VERSION_MAJOR STREQUAL 3)
     set(PY_STRING "python3")
+    set(PY_UNIT2_STRING "unit2-3")
 elseif(PYTHON_VERSION_MAJOR STREQUAL 2)
     set(PY_STRING "python")
+    set(PY_UNIT2_STRING "unit2")
 endif()
 
 # Find python-unittest2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,9 +66,9 @@ add_test(unit_tests_size_1     ${TEST_WRAP} -x unit_tests_size 1)
 add_test(unit_tests            ${TEST_WRAP} -x unit_tests ${CMAKE_CURRENT_SOURCE_DIR}/threads4.conf)
 
 # Unit test python modules
-add_test(router_engine_test    ${TEST_WRAP} -x unit2 -v router_engine_test)
-add_test(management_test       ${TEST_WRAP} -x unit2 -v management)
-add_test(router_policy_test    ${TEST_WRAP} -x unit2 -v router_policy_test)
+add_test(router_engine_test    ${TEST_WRAP} -x ${PY_UNIT2_STRING} -v router_engine_test)
+add_test(management_test       ${TEST_WRAP} -x ${PY_UNIT2_STRING} -v management)
+add_test(router_policy_test    ${TEST_WRAP} -x ${PY_UNIT2_STRING} -v router_policy_test)
 
 if(USE_LIBWEBSOCKETS)
   set(SYSTEM_TESTS_HTTP system_tests_http)
@@ -120,7 +120,7 @@ foreach(py_test_module
     ${CONSOLE_TEST}
     )
 
-  add_test(${py_test_module} ${TEST_WRAP} -x unit2 -v ${py_test_module})
+  add_test(${py_test_module} ${TEST_WRAP} -x ${PY_UNIT2_STRING} -v ${py_test_module})
   list(APPEND SYSTEM_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${py_test_module}.py)
 endforeach()
 


### PR DESCRIPTION
CMake chooses between 'python' and 'python3'.
Make a similar choice for 'unit2' and 'unit2-3'.

This lets both python2 and python3 versions to be installed on a system and chooses between them based on the result of PYTHON_VERSING_MAJOR.

Tested on Fedora only.