### PR TITLE
Priority 2

### DIFF
--- a/include/qpid/dispatch/iterator.h
+++ b/include/qpid/dispatch/iterator.h
@@ -327,6 +327,8 @@ int qd_iterator_ncopy(qd_iterator_t *iter, unsigned char* buffer, int n);
  */
 unsigned char *qd_iterator_copy(qd_iterator_t *iter);
 
+uint8_t qd_iterator_uint8(qd_iterator_t *iter);
+
 /**
  * Return a new iterator that is a duplicate of the original iterator, referring
  * to the same base data.  If the input iterator pointer is NULL, the duplicate

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -411,6 +411,13 @@ bool qd_message_aborted(const qd_message_t *msg);
  */
 void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
 
+/**
+ * Return message priority
+ * @param msg A pointer to the message
+ */
+uint8_t qd_message_get_priority(qd_message_t *msg);
+
+
 ///@}
 
 #endif

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -768,6 +768,14 @@ char* qd_iterator_strncpy(qd_iterator_t *iter, char* buffer, int n)
 }
 
 
+uint8_t qd_iterator_uint8(qd_iterator_t *iter ) {
+    qd_iterator_reset(iter);
+    if (qd_iterator_end(iter))
+        return 0;
+    return (uint8_t) qd_iterator_octet(iter);
+}
+
+
 unsigned char *qd_iterator_copy(qd_iterator_t *iter)
 {
     if (!iter)

--- a/src/message.c
+++ b/src/message.c
@@ -1072,6 +1072,7 @@ uint8_t qd_message_get_priority(qd_message_t *in_msg)
             message_set_priority(in_msg, priority);
         }
     }
+    qd_iterator_free(priority_iterator);
     return msg->content->priority;
 }
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -77,6 +77,14 @@ typedef struct {
     qd_field_location_t  section_body;                    // The message body: Data
     qd_field_location_t  section_footer;                  // The footer
     qd_field_location_t  field_user_annotations;          // Opaque user message annotations, not a real field.
+
+    // header fields
+    qd_field_location_t  field_durable;
+    qd_field_location_t  field_priority;
+    qd_field_location_t  field_ttl;
+    qd_field_location_t  field_first_acquirer;
+    qd_field_location_t  field_delivery_count;
+
     qd_field_location_t  field_message_id;                // The string value of the message-id
     qd_field_location_t  field_user_id;                   // The string value of the user-id
     qd_field_location_t  field_to;                        // The string value of the to field
@@ -115,6 +123,7 @@ typedef struct {
     bool                 q2_input_holdoff;               // hold off calling pn_link_recv
     bool                 aborted;                        // receive completed with abort flag set
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
+    uint8_t              priority;
 } qd_message_content_t;
 
 typedef struct {
@@ -141,6 +150,8 @@ ALLOC_DECLARE(qd_message_content_t);
 void qd_message_initialize();
 
 qd_iterator_pointer_t qd_message_cursor(qd_message_pvt_t *msg);
+
+#define QDR_N_PRIORITIES 10
 
 ///@}
 

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -205,7 +205,7 @@ const char *qdr_connection_get_tenant_space(const qdr_connection_t *conn, int *l
 int qdr_connection_process(qdr_connection_t *conn)
 {
     qdr_connection_work_list_t  work_list;
-    qdr_link_ref_list_t         links_with_work;
+    qdr_link_ref_list_t         links_with_work[QDR_N_PRIORITIES];
     qdr_core_t                 *core = conn->core;
 
     qdr_link_ref_t *ref;
@@ -216,7 +216,9 @@ int qdr_connection_process(qdr_connection_t *conn)
 
     sys_mutex_lock(conn->work_lock);
     DEQ_MOVE(conn->work_list, work_list);
-    DEQ_MOVE(conn->links_with_work, links_with_work);
+    for (int priority = 0; priority < QDR_N_PRIORITIES; ++ priority) {
+        DEQ_MOVE(conn->links_with_work[priority], links_with_work[priority]);
+    }
     sys_mutex_unlock(conn->work_lock);
 
     event_count += DEQ_SIZE(work_list);
@@ -241,97 +243,100 @@ int qdr_connection_process(qdr_connection_t *conn)
         work = DEQ_HEAD(work_list);
     }
 
-    do {
-        qdr_link_work_t *link_work;
-        free_link = false;
+    // Process the links_with_work array from highest to lowest priority.
+    for (int priority = QDR_N_PRIORITIES - 1; priority >= 0; -- priority) {
+        do {
+            qdr_link_work_t *link_work;
+            free_link = false;
 
-        sys_mutex_lock(conn->work_lock);
-        ref = DEQ_HEAD(links_with_work);
-        if (ref) {
-            link = ref->link;
-            qdr_del_link_ref(&links_with_work, ref->link, QDR_LINK_LIST_CLASS_WORK);
-
-            link_work = DEQ_HEAD(link->work_list);
-            if (link_work) {
-                DEQ_REMOVE_HEAD(link->work_list);
-                link_work->processing = true;
-            }
-        } else
-            link = 0;
-        sys_mutex_unlock(conn->work_lock);
-
-        if (link) {
-
-            //
-            // Handle disposition/settlement updates
-            //
-            qdr_delivery_ref_list_t updated_deliveries;
             sys_mutex_lock(conn->work_lock);
-            DEQ_MOVE(link->updated_deliveries, updated_deliveries);
+            ref = DEQ_HEAD(links_with_work[priority]);
+            if (ref) {
+                link = ref->link;
+                qdr_del_link_ref(links_with_work + priority, ref->link, QDR_LINK_LIST_CLASS_WORK);
+
+                link_work = DEQ_HEAD(link->work_list);
+                if (link_work) {
+                    DEQ_REMOVE_HEAD(link->work_list);
+                    link_work->processing = true;
+                }
+            } else
+                link = 0;
             sys_mutex_unlock(conn->work_lock);
 
-            qdr_delivery_ref_t *dref = DEQ_HEAD(updated_deliveries);
-            while (dref) {
-                core->delivery_update_handler(core->user_context, dref->dlv, dref->dlv->disposition, dref->dlv->settled);
-                qdr_delivery_decref(core, dref->dlv, "qdr_connection_process - remove from updated list");
-                qdr_del_delivery_ref(&updated_deliveries, dref);
-                dref = DEQ_HEAD(updated_deliveries);
-                event_count++;
-            }
+            if (link) {
 
-            while (link_work) {
-                switch (link_work->work_type) {
-                case QDR_LINK_WORK_DELIVERY :
-                    {
-                        int count = core->push_handler(core->user_context, link, link_work->value);
-                        assert(count <= link_work->value);
-                        link_work->value -= count;
+                //
+                // Handle disposition/settlement updates
+                //
+                qdr_delivery_ref_list_t updated_deliveries;
+                sys_mutex_lock(conn->work_lock);
+                DEQ_MOVE(link->updated_deliveries, updated_deliveries);
+                sys_mutex_unlock(conn->work_lock);
+
+                qdr_delivery_ref_t *dref = DEQ_HEAD(updated_deliveries);
+                while (dref) {
+                    core->delivery_update_handler(core->user_context, dref->dlv, dref->dlv->disposition, dref->dlv->settled);
+                    qdr_delivery_decref(core, dref->dlv, "qdr_connection_process - remove from updated list");
+                    qdr_del_delivery_ref(&updated_deliveries, dref);
+                    dref = DEQ_HEAD(updated_deliveries);
+                    event_count++;
+                }
+
+                while (link_work) {
+                    switch (link_work->work_type) {
+                    case QDR_LINK_WORK_DELIVERY :
+                        {
+                            int count = core->push_handler(core->user_context, link, link_work->value);
+                            assert(count <= link_work->value);
+                            link_work->value -= count;
+                            break;
+                        }
+
+                    case QDR_LINK_WORK_FLOW :
+                        if (link_work->value > 0)
+                            core->flow_handler(core->user_context, link, link_work->value);
+                        if      (link_work->drain_action == QDR_LINK_WORK_DRAIN_ACTION_SET)
+                            core->drain_handler(core->user_context, link, true);
+                        else if (link_work->drain_action == QDR_LINK_WORK_DRAIN_ACTION_CLEAR)
+                            core->drain_handler(core->user_context, link, false);
+                        else if (link_work->drain_action == QDR_LINK_WORK_DRAIN_ACTION_DRAINED)
+                            core->drained_handler(core->user_context, link);
+                        break;
+
+                    case QDR_LINK_WORK_FIRST_DETACH :
+                        core->detach_handler(core->user_context, link, link_work->error, true, link_work->close_link);
+                        break;
+
+                    case QDR_LINK_WORK_SECOND_DETACH :
+                        core->detach_handler(core->user_context, link, link_work->error, false, link_work->close_link);
+                        free_link = true;
                         break;
                     }
 
-                case QDR_LINK_WORK_FLOW :
-                    if (link_work->value > 0)
-                        core->flow_handler(core->user_context, link, link_work->value);
-                    if      (link_work->drain_action == QDR_LINK_WORK_DRAIN_ACTION_SET)
-                        core->drain_handler(core->user_context, link, true);
-                    else if (link_work->drain_action == QDR_LINK_WORK_DRAIN_ACTION_CLEAR)
-                        core->drain_handler(core->user_context, link, false);
-                    else if (link_work->drain_action == QDR_LINK_WORK_DRAIN_ACTION_DRAINED)
-                        core->drained_handler(core->user_context, link);
-                    break;
-
-                case QDR_LINK_WORK_FIRST_DETACH :
-                    core->detach_handler(core->user_context, link, link_work->error, true, link_work->close_link);
-                    break;
-
-                case QDR_LINK_WORK_SECOND_DETACH :
-                    core->detach_handler(core->user_context, link, link_work->error, false, link_work->close_link);
-                    free_link = true;
-                    break;
-                }
-
-                sys_mutex_lock(conn->work_lock);
-                if (link_work->work_type == QDR_LINK_WORK_DELIVERY && link_work->value > 0) {
-                    DEQ_INSERT_HEAD(link->work_list, link_work);
-                    link_work->processing = false;
-                    link_work = 0; // Halt work processing
-                } else {
-                    qdr_error_free(link_work->error);
-                    free_qdr_link_work_t(link_work);
-                    link_work = DEQ_HEAD(link->work_list);
-                    if (link_work) {
-                        DEQ_REMOVE_HEAD(link->work_list);
-                        link_work->processing = true;
+                    sys_mutex_lock(conn->work_lock);
+                    if (link_work->work_type == QDR_LINK_WORK_DELIVERY && link_work->value > 0) {
+                        DEQ_INSERT_HEAD(link->work_list, link_work);
+                        link_work->processing = false;
+                        link_work = 0; // Halt work processing
+                    } else {
+                        qdr_error_free(link_work->error);
+                        free_qdr_link_work_t(link_work);
+                        link_work = DEQ_HEAD(link->work_list);
+                        if (link_work) {
+                            DEQ_REMOVE_HEAD(link->work_list);
+                            link_work->processing = true;
+                        }
                     }
+                    sys_mutex_unlock(conn->work_lock);
+                    event_count++;
                 }
-                sys_mutex_unlock(conn->work_lock);
-                event_count++;
-            }
 
-            if (free_link)
-                qdr_link_delete(link);
-        }
-    } while (free_link || link);
+                if (free_link)
+                    qdr_link_delete(link);
+            }
+        } while (free_link || link);
+    }
 
     return event_count;
 }
@@ -569,7 +574,8 @@ void qdr_link_enqueue_work_CT(qdr_core_t      *core,
 
     sys_mutex_lock(conn->work_lock);
     DEQ_INSERT_TAIL(link->work_list, work);
-    qdr_add_link_ref(&conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
+    // Enqueue work at priority 0.
+    qdr_add_link_ref(conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
     sys_mutex_unlock(conn->work_lock);
 
     qdr_connection_activate_CT(core, conn);
@@ -846,7 +852,9 @@ static void qdr_link_cleanup_CT(qdr_core_t *core, qdr_connection_t *conn, qdr_li
     //
     qdr_del_link_ref(&conn->links, link, QDR_LINK_LIST_CLASS_CONNECTION);
     sys_mutex_lock(conn->work_lock);
-    qdr_del_link_ref(&conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
+    for (int priority = 0; priority < QDR_N_PRIORITIES; ++ priority) {
+        qdr_del_link_ref(conn->links_with_work + priority, link, QDR_LINK_LIST_CLASS_WORK);
+    }
     sys_mutex_unlock(conn->work_lock);
 
     //
@@ -1322,10 +1330,13 @@ static void qdr_connection_closed_CT(qdr_core_t *core, qdr_action_t *action, boo
     //
     // Remove the references in the links_with_work list
     //
-    qdr_link_ref_t *link_ref = DEQ_HEAD(conn->links_with_work);
-    while (link_ref) {
-        qdr_del_link_ref(&conn->links_with_work, link_ref->link, QDR_LINK_LIST_CLASS_WORK);
-        link_ref = DEQ_HEAD(conn->links_with_work);
+    qdr_link_ref_t *link_ref;
+    for (int priority = 0; priority < QDR_N_PRIORITIES; ++ priority) {
+        link_ref = DEQ_HEAD(conn->links_with_work[priority]);
+        while (link_ref) {
+            qdr_del_link_ref(conn->links_with_work + priority, link_ref->link, QDR_LINK_LIST_CLASS_WORK);
+            link_ref = DEQ_HEAD(conn->links_with_work[priority]);
+        }
     }
 
     //

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -24,6 +24,28 @@
 #include "forwarder.h"
 
 
+static qdr_link_t * peer_data_link(qdr_core_t *core,
+                                   qdr_node_t *node,
+                                   int         priority)
+{
+  int nlmb = node->link_mask_bit;
+
+  if (nlmb < 0 || priority < 0)
+      return 0;
+
+  // Try to return the requested priority link, but if it does
+  // not exist, return the closest one that is lower.
+  qdr_link_t * link = 0;
+  while (1) {
+      if ((link = core->data_links_by_mask_bit[nlmb].links[priority]))
+          return link;
+      if (-- priority < 0)
+          return 0;
+  }
+  return link;
+}
+
+
 //==================================================================================
 // Built-in Forwarders
 //==================================================================================
@@ -243,6 +265,7 @@ int qdr_forward_multicast_CT(qdr_core_t      *core,
     qd_bitmask_t *link_exclusion       = !!in_delivery ? in_delivery->link_exclusion : 0;
     bool          presettled           = !!in_delivery ? in_delivery->settled : true;
     bool          receive_complete     = qd_message_receive_complete(qdr_delivery_message(in_delivery));
+    int           priority             = qd_message_get_priority(msg);
 
     //
     // If the delivery is not presettled, set the settled flag for forwarding so all
@@ -321,7 +344,7 @@ int qdr_forward_multicast_CT(qdr_core_t      *core,
             else
                 next_node = rnode;
 
-            dest_link = control ? PEER_CONTROL_LINK(core, next_node) : PEER_DATA_LINK(core, next_node);
+            dest_link = control ? PEER_CONTROL_LINK(core, next_node) : peer_data_link(core, next_node, priority);
             if (dest_link && qd_bitmask_value(rnode->valid_origins, origin))
                 qd_bitmask_set_bit(link_set, dest_link->conn->mask_bit);
         }
@@ -334,7 +357,7 @@ int qdr_forward_multicast_CT(qdr_core_t      *core,
             qd_bitmask_clear_bit(link_set, link_bit);
             dest_link = control ?
                 core->control_links_by_mask_bit[link_bit] :
-                core->data_links_by_mask_bit[link_bit];
+                core->data_links_by_mask_bit[link_bit].links[priority];
             if (dest_link && (!link_exclusion || qd_bitmask_value(link_exclusion, link_bit) == 0)) {
                 qdr_delivery_t *out_delivery = qdr_forward_new_delivery_CT(core, in_delivery, dest_link, msg);
                 qdr_forward_deliver_CT(core, dest_link, out_delivery);
@@ -509,7 +532,8 @@ int qdr_forward_closest_CT(qdr_core_t      *core,
             else
                 next_node = rnode;
 
-            out_link = control ? PEER_CONTROL_LINK(core, next_node) : PEER_DATA_LINK(core, next_node);
+            uint8_t priority = qd_message_get_priority(msg);
+            out_link = control ? PEER_CONTROL_LINK(core, next_node) : peer_data_link(core, next_node, priority);
             if (out_link) {
                 out_delivery = qdr_forward_new_delivery_CT(core, in_delivery, out_link, msg);
                 qdr_forward_deliver_CT(core, out_link, out_delivery);
@@ -613,7 +637,8 @@ int qdr_forward_balanced_CT(qdr_core_t      *core,
         for (QD_BITMASK_EACH(addr->rnodes, node_bit, c)) {
             qdr_node_t *rnode     = core->routers_by_mask_bit[node_bit];
             qdr_node_t *next_node = rnode->next_hop ? rnode->next_hop : rnode;
-            qdr_link_t *link      = PEER_DATA_LINK(core, next_node);
+            uint8_t     priority  = qd_message_get_priority(msg);
+            qdr_link_t *link      = peer_data_link(core, next_node, priority);
             if (!link) continue;
             int         link_bit  = link->conn->mask_bit;
             int         value     = addr->outstanding_deliveries[link_bit];
@@ -761,8 +786,9 @@ bool qdr_forward_link_balanced_CT(qdr_core_t     *core,
                 else
                     next_node = rnode;
 
-                if (next_node && PEER_DATA_LINK(core, next_node))
-                    conn = PEER_DATA_LINK(core, next_node)->conn;
+                qdr_link_t * pdl = peer_data_link(core, next_node, 0);
+                if (next_node && pdl)
+                    conn = pdl->conn;
             }
         }
     }

--- a/src/router_core/route_tables.c
+++ b/src/router_core/route_tables.c
@@ -242,11 +242,14 @@ void qdr_route_table_setup_CT(qdr_core_t *core)
 
         core->routers_by_mask_bit       = NEW_PTR_ARRAY(qdr_node_t, qd_bitmask_width());
         core->control_links_by_mask_bit = NEW_PTR_ARRAY(qdr_link_t, qd_bitmask_width());
-        core->data_links_by_mask_bit    = NEW_PTR_ARRAY(qdr_link_t, qd_bitmask_width());
+        core->data_links_by_mask_bit    = NEW_ARRAY(qdr_priority_sheaf_t, qd_bitmask_width());
         for (int idx = 0; idx < qd_bitmask_width(); idx++) {
             core->routers_by_mask_bit[idx]   = 0;
             core->control_links_by_mask_bit[idx] = 0;
-            core->data_links_by_mask_bit[idx] = 0;
+            core->data_links_by_mask_bit[idx].count = 0;
+            for (int priority = 0; priority < QDR_N_PRIORITIES; ++ priority)
+              core->data_links_by_mask_bit[idx].links[priority] = 0;
+
         }
     }
 

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -567,7 +567,7 @@ struct qdr_connection_t {
     qdr_connection_work_list_t  work_list;
     sys_mutex_t                *work_lock;
     qdr_link_ref_list_t         links;
-    qdr_link_ref_list_t         links_with_work;
+    qdr_link_ref_list_t         links_with_work[QDR_N_PRIORITIES];
     char                       *tenant_space;
     int                         tenant_space_len;
     qdr_connection_info_t      *connection_info;
@@ -843,7 +843,7 @@ void qdr_post_general_work_CT(qdr_core_t *core, qdr_general_work_t *work);
 void qdr_check_addr_CT(qdr_core_t *core, qdr_address_t *addr, bool was_local);
 bool qdr_is_addr_treatment_multicast(qdr_address_t *addr);
 qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *peer, qdr_link_t *link, qd_message_t *msg);
-void qdr_forward_deliver_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery_t *dlv);
+void qdr_forward_deliver_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery_t *dlv, int priority);
 void qdr_connection_free(qdr_connection_t *conn);
 void qdr_connection_activate_CT(qdr_core_t *core, qdr_connection_t *conn);
 qd_address_treatment_t qdr_treatment_for_address_CT(qdr_core_t *core, qdr_connection_t *conn, qd_iterator_t *iter, int *in_phase, int *out_phase);

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -738,7 +738,8 @@ static void qdr_link_flow_CT(qdr_core_t *core, qdr_action_t *action, bool discar
     //
     if (link->stalled_outbound) {
         link->stalled_outbound = false;
-        qdr_add_link_ref(&link->conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
+        // Adding this work at priority 0.
+        qdr_add_link_ref(link->conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
         activate = true;
     }
 
@@ -776,7 +777,8 @@ static void qdr_link_flow_CT(qdr_core_t *core, qdr_action_t *action, bool discar
             if (work)
                 DEQ_INSERT_TAIL(link->work_list, work);
             if (DEQ_SIZE(link->undelivered) > 0 || drain_was_set) {
-                qdr_add_link_ref(&link->conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
+                // Adding this work at priority 0.
+                qdr_add_link_ref(link->conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
                 activate = true;
             }
             sys_mutex_unlock(link->conn->work_lock);
@@ -990,7 +992,8 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         peer->tag_length = action->args.connection.tag_length;
         memcpy(peer->tag, action->args.connection.tag, peer->tag_length);
 
-        qdr_forward_deliver_CT(core, link->connected_link, peer);
+        // Adding this work at priority 0.
+        qdr_forward_deliver_CT(core, link->connected_link, peer, 0);
 
         link->total_deliveries++;
 
@@ -1162,7 +1165,8 @@ void qdr_deliver_continue_peers_CT(qdr_core_t *core, qdr_delivery_t *in_dlv)
         if (work) {
             sys_mutex_lock(peer->link->conn->work_lock);
             if (work->processing || work == DEQ_HEAD(peer->link->work_list)) {
-                qdr_add_link_ref(&peer->link->conn->links_with_work, peer->link, QDR_LINK_LIST_CLASS_WORK);
+                // Adding this work at priority 0.
+                qdr_add_link_ref(peer->link->conn->links_with_work, peer->link, QDR_LINK_LIST_CLASS_WORK);
                 sys_mutex_unlock(peer->link->conn->work_lock);
 
                 //
@@ -1348,7 +1352,8 @@ void qdr_delivery_push_CT(qdr_core_t *core, qdr_delivery_t *dlv)
     if (dlv->where != QDR_DELIVERY_IN_UNDELIVERED) {
         qdr_delivery_incref(dlv, "qdr_delivery_push_CT - add to updated list");
         qdr_add_delivery_ref_CT(&link->updated_deliveries, dlv);
-        qdr_add_link_ref(&link->conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
+        // Adding this work at priority 0.
+        qdr_add_link_ref(link->conn->links_with_work, link, QDR_LINK_LIST_CLASS_WORK);
         activate = true;
     }
     sys_mutex_unlock(link->conn->work_lock);


### PR DESCRIPTION
passed all unit tests 5 times, both Debug & Release builds.

in a linear 5-router test 
    * advantage to high-priority messages is 2.4x less latency
    * cost of this code compared to recent 1.3 release is 0.9% extra latency for all messages (i.e. how much do you pay even if you don't use it?)

Above results were calculated by taking average of 3 tests, each of 5 million messages -- 1 million each from 5 senders, all going to one receiver -- with one of the senders sending a high-priority message every thousandth. ( So high-priority messages outnumbered by a factor of 5000.)
