### PR TITLE
DISPATCH-1131: add better validation of address patterns and prefixes

### DIFF
--- a/src/router_core/agent_config_address.h
+++ b/src/router_core/agent_config_address.h
@@ -32,7 +32,9 @@ void qdra_config_address_get_CT(qdr_core_t    *core,
                                 qd_iterator_t *identity,
                                 qdr_query_t   *query,
                                 const char    *qdr_config_address_columns[]);
-
+char *qdra_config_address_validate_pattern_CT(qd_parsed_field_t *pattern_field,
+                                              bool is_prefix,
+                                              const char **error);
 #define QDR_CONFIG_ADDRESS_COLUMN_COUNT 9
 
 const char *qdr_config_address_columns[QDR_CONFIG_ADDRESS_COLUMN_COUNT + 1];

--- a/src/router_core/route_control.h
+++ b/src/router_core/route_control.h
@@ -23,8 +23,8 @@
 
 qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
                                               qd_iterator_t          *name,
-                                              qd_parsed_field_t      *prefix_field,
-                                              qd_parsed_field_t      *pattern_field,
+                                              const char             *addr_pattern,
+                                              bool                    is_prefix,
                                               qd_parsed_field_t      *add_prefix_field,
                                               qd_parsed_field_t      *del_prefix_field,
                                               qd_parsed_field_t      *container_field,


### PR DESCRIPTION
This moves the address pattern/prefix validation to a common function
that can be share by both link routes add configured addresses.