### PR TITLE
DISPATCH-1131: add better validation of address patterns and prefixes

### DIFF
--- a/src/router_core/agent_config_address.h
+++ b/src/router_core/agent_config_address.h
@@ -32,7 +32,9 @@ void qdra_config_address_get_CT(qdr_core_t    *core,
                                 qd_iterator_t *identity,
                                 qdr_query_t   *query,
                                 const char    *qdr_config_address_columns[]);
-
+char *qdra_config_address_validate_pattern_CT(qd_parsed_field_t *pattern_field,
+                                              bool is_prefix,
+                                              const char **error);
 #define QDR_CONFIG_ADDRESS_COLUMN_COUNT 9
 
 const char *qdr_config_address_columns[QDR_CONFIG_ADDRESS_COLUMN_COUNT + 1];

--- a/src/router_core/agent_config_link_route.c
+++ b/src/router_core/agent_config_link_route.c
@@ -19,6 +19,7 @@
 
 #include <qpid/dispatch/ctools.h>
 #include "agent_config_link_route.h"
+#include "agent_config_address.h"
 #include "route_control.h"
 #include <inttypes.h>
 #include <stdio.h>
@@ -379,6 +380,8 @@ void qdra_config_link_route_create_CT(qdr_core_t        *core,
                                       qdr_query_t       *query,
                                       qd_parsed_field_t *in_body)
 {
+    char *pattern = NULL;
+
     while (true) {
         //
         // Ensure there isn't a duplicate name and that the body is a map
@@ -454,6 +457,17 @@ void qdra_config_link_route_create_CT(qdr_core_t        *core,
             break;
         }
 
+        // validate the pattern/prefix, add "/#" if prefix
+        pattern = qdra_config_address_validate_pattern_CT((prefix_field) ? prefix_field : pattern_field,
+                                                          !!prefix_field,
+                                                          &msg);
+        if (!pattern) {
+            query->status = QD_AMQP_BAD_REQUEST;
+            query->status.description = msg;
+            qd_log(core->agent_log, QD_LOG_ERROR, "Error performing CREATE of %s: %s", CONFIG_LINKROUTE_TYPE, query->status.description);
+            break;
+        }
+
         qd_direction_t dir;
         const char *error = qdra_link_route_direction_CT(dir_field, &dir);
         if (error) {
@@ -476,8 +490,10 @@ void qdra_config_link_route_create_CT(qdr_core_t        *core,
         // The request is good.  Create the entity.
         //
 
-        lr = qdr_route_add_link_route_CT(core, name, prefix_field, pattern_field, add_prefix_field, del_prefix_field, container_field, connection_field, trt, dir);
-
+        lr = qdr_route_add_link_route_CT(core, name, pattern, !!prefix_field,
+                                         add_prefix_field, del_prefix_field,
+                                         container_field, connection_field,
+                                         trt, dir);
         //
         // Compose the result map for the response.
         //
@@ -508,6 +524,7 @@ void qdra_config_link_route_create_CT(qdr_core_t        *core,
             qd_log(core->log, QD_LOG_ERROR, "Error configuring linkRoute: %s", query->status.description);
         qdr_query_free(query);
     }
+    free(pattern);
 }
 
 void qdra_config_link_route_get_CT(qdr_core_t    *core,

--- a/src/router_core/route_control.c
+++ b/src/router_core/route_control.c
@@ -298,8 +298,8 @@ static void qdr_auto_link_deactivate_CT(qdr_core_t *core, qdr_auto_link_t *al, q
 
 qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
                                               qd_iterator_t          *name,
-                                              qd_parsed_field_t      *prefix_field,
-                                              qd_parsed_field_t      *pattern_field,
+                                              const char             *addr_pattern,
+                                              bool                    is_prefix,
                                               qd_parsed_field_t      *add_prefix_field,
                                               qd_parsed_field_t      *del_prefix_field,
                                               qd_parsed_field_t      *container_field,
@@ -307,27 +307,6 @@ qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
                                               qd_address_treatment_t  treatment,
                                               qd_direction_t          dir)
 {
-    const bool is_prefix = !!prefix_field;
-    qd_iterator_t *iter = qd_parse_raw(is_prefix ? prefix_field : pattern_field);
-    int len = qd_iterator_length(iter);
-    char *pattern = malloc(len + 1 + (is_prefix ? 2 : 0));
-
-    qd_iterator_strncpy(iter, pattern, len + 1);
-
-    // forward compatibility hack: convert the old style prefix addresses into
-    // a proper pattern addresses by appending ".#"
-    // note: see parse_tree.c for acceptable separator and wildcard characters
-    if (is_prefix) {
-        char suffix = pattern[strlen(pattern) - 1];
-        if (suffix == '#') {
-            // already converted - do nothing
-        } else {
-            if (!strchr("./", suffix))
-                strcat(pattern, ".");  // use . for legacy
-            strcat(pattern, "#");
-        }
-    }
-
     //
     // Set up the link_route structure
     //
@@ -338,7 +317,7 @@ qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
     lr->dir       = dir;
     lr->treatment = treatment;
     lr->is_prefix = is_prefix;
-    lr->pattern   = pattern;
+    lr->pattern   = strdup(addr_pattern);
 
     if (!!add_prefix_field) {
         qd_iterator_t *ap_iter = qd_parse_raw(add_prefix_field);

--- a/src/router_core/route_control.h
+++ b/src/router_core/route_control.h
@@ -23,8 +23,8 @@
 
 qdr_link_route_t *qdr_route_add_link_route_CT(qdr_core_t             *core,
                                               qd_iterator_t          *name,
-                                              qd_parsed_field_t      *prefix_field,
-                                              qd_parsed_field_t      *pattern_field,
+                                              const char             *addr_pattern,
+                                              bool                    is_prefix,
                                               qd_parsed_field_t      *add_prefix_field,
                                               qd_parsed_field_t      *del_prefix_field,
                                               qd_parsed_field_t      *container_field,


### PR DESCRIPTION
This moves the address pattern/prefix validation to a common function
that can be share by both link routes add configured addresses.

This closes #385