### PR TITLE
DISPATCH-1130 Expose link priority

### DIFF
--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1423,6 +1423,10 @@
                 "ingressHistogram": {
                     "type": "list",
                     "description": "For outgoing links on connections with 'normal' role.  This histogram shows the number of settled deliveries on the link that ingressed the network at each interior router node."
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "For inter-router links, this is the message priority being handled."
                 }
             }
         },

--- a/src/router_core/agent_link.c
+++ b/src/router_core/agent_link.c
@@ -43,6 +43,7 @@
 #define QDR_LINK_RELEASED_COUNT           19
 #define QDR_LINK_MODIFIED_COUNT           20
 #define QDR_LINK_INGRESS_HISTOGRAM        21
+#define QDR_LINK_PRIORITY                 22
 
 const char *qdr_link_columns[] =
     {"name",
@@ -67,6 +68,7 @@ const char *qdr_link_columns[] =
      "releasedCount",
      "modifiedCount",
      "ingressHistogram",
+     "priority",
      0};
 
 static const char *qd_link_type_name(qd_link_type_t lt)
@@ -218,6 +220,10 @@ static void qdr_agent_write_column_CT(qd_composed_field_t *body, int col, qdr_li
             qd_compose_end_list(body);
         } else
             qd_compose_insert_null(body);
+        break;
+
+    case QDR_LINK_PRIORITY:
+        qd_compose_insert_uint(body, link->priority);
         break;
 
     default:

--- a/src/router_core/agent_link.h
+++ b/src/router_core/agent_link.h
@@ -29,7 +29,7 @@ void qdra_link_update_CT(qdr_core_t          *core,
                          qdr_query_t         *query,
                          qd_parsed_field_t   *in_body);
 
-#define QDR_LINK_COLUMN_COUNT  22
+#define QDR_LINK_COLUMN_COUNT  23
 
 const char *qdr_link_columns[QDR_LINK_COLUMN_COUNT + 1];
 

--- a/tools/qdstat.in
+++ b/tools/qdstat.in
@@ -293,7 +293,7 @@ class BusManager(Node):
         cols = ('linkType', 'linkDir', 'connectionId', 'identity', 'peer', 'owningAddr',
                 'capacity', 'undeliveredCount', 'unsettledCount', 'deliveryCount',
                 'presettledCount', 'droppedPresettledCount', 'acceptedCount', 'rejectedCount', 'releasedCount',
-                'modifiedCount', 'adminStatus', 'operStatus', 'linkName')
+                'modifiedCount', 'adminStatus', 'operStatus', 'linkName', 'priority')
 
         objects = self.query('org.apache.qpid.dispatch.router.link', cols, limit=self.opts.limit)
 
@@ -314,6 +314,7 @@ class BusManager(Node):
         heads.append(Header("mod"))
         heads.append(Header("admin"))
         heads.append(Header("oper"))
+        heads.append(Header("priority"))
         if self.opts.verbose:
             heads.append(Header("name"))
 
@@ -340,6 +341,7 @@ class BusManager(Node):
             row.append(link.modifiedCount)
             row.append(link.adminStatus)
             row.append(link.operStatus)
+            row.append(link.priority)
             if self.opts.verbose:
                 row.append(link.linkName)
             rows.append(row)


### PR DESCRIPTION
Adds priority to router.link management entity in the schema.
Connects link.priority to schema attribute.
Adds priority column to qdstat -l
