### PR TITLE
DISPATCH-1139 : address priority support and test

### DIFF
--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -422,10 +422,9 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
 /**
  * Return message priority
  * @param msg A pointer to the message
- * @param priority [out] The priority value, if present
- * @return True iff the priority was present in the message header
+ * @return The message priority value. Default if not present.
  */
-bool qd_message_get_priority(qd_message_t *msg, uint8_t *priority);
+uint8_t qd_message_get_priority(qd_message_t *msg);
 
 
 ///@}

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1111,6 +1111,12 @@
                     "description": "Advanced - Override the egress phase for this address",
                     "create": true,
                     "required": false
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "All messages sent to this address which lack an intrinsic priority will be assigned this priority.",
+                    "create": true,
+                    "required": false
                 }
             }
         },

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -148,6 +148,7 @@ void qd_message_initialize();
 qd_iterator_pointer_t qd_message_cursor(qd_message_pvt_t *msg);
 
 #define QDR_N_PRIORITIES     10
+#define QDR_MAX_PRIORITY     (QDR_N_PRIORITIES - 1)
 #define QDR_DEFAULT_PRIORITY  4
 
 ///@}

--- a/src/router_config.c
+++ b/src/router_config.c
@@ -78,6 +78,7 @@ qd_error_t qd_router_configure_address(qd_router_t *router, qd_entity_t *entity)
         bool  waypoint  = qd_entity_opt_bool(entity, "waypoint", false);
         long  in_phase  = qd_entity_opt_long(entity, "ingressPhase", -1);
         long  out_phase = qd_entity_opt_long(entity, "egressPhase", -1);
+        long  priority  = qd_entity_opt_long(entity, "priority",    -1);
 
         //
         // Formulate this configuration create it through the core management API.
@@ -107,6 +108,10 @@ qd_error_t qd_router_configure_address(qd_router_t *router, qd_entity_t *entity)
 
         qd_compose_insert_string(body, "waypoint");
         qd_compose_insert_bool(body, waypoint);
+
+        qd_compose_insert_string(body, "priority");
+        qd_compose_insert_long(body, priority);
+
 
         if (in_phase >= 0) {
             qd_compose_insert_string(body, "ingressPhase");

--- a/src/router_core/agent_config_address.h
+++ b/src/router_core/agent_config_address.h
@@ -35,7 +35,7 @@ void qdra_config_address_get_CT(qdr_core_t    *core,
 char *qdra_config_address_validate_pattern_CT(qd_parsed_field_t *pattern_field,
                                               bool is_prefix,
                                               const char **error);
-#define QDR_CONFIG_ADDRESS_COLUMN_COUNT 9
+#define QDR_CONFIG_ADDRESS_COLUMN_COUNT 10
 
 const char *qdr_config_address_columns[QDR_CONFIG_ADDRESS_COLUMN_COUNT + 1];
 

--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -42,7 +42,7 @@ void qdrc_endpoint_bind_mobile_address_CT(qdr_core_t           *core,
 
     qd_hash_retrieve(core->addr_hash, iter, (void*) &addr);
     if (!addr) {
-        qd_address_treatment_t treatment = qdr_treatment_for_address_CT(core, 0, iter, 0, 0);
+        qd_address_treatment_t treatment = qdr_treatment_for_address_CT(core, 0, iter, 0, 0, 0);
         if (treatment == QD_TREATMENT_UNAVAILABLE)
             treatment = QD_TREATMENT_ANYCAST_BALANCED;
         addr = qdr_address_CT(core, treatment);

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -280,15 +280,13 @@ void qdr_forward_on_message_CT(qdr_core_t *core, qdr_subscription_t *sub, qdr_li
  * This function returns a priority value for a message (and address).  If the message
  * has no priority header, the default priority is chosen.
  *
- * TODO: Add the ability to get the priority from the address if not present in the message
+ * If the address has a defined priority, that value takes precedence.
+ * Otherwise the message priority is used, which has a default value
+ * if none was explicitly set.
  */
 static uint8_t qdr_forward_effective_priority(qd_message_t *msg, qdr_address_t *addr)
 {
-    uint8_t priority;
-    bool    has_priority = qd_message_get_priority(msg, &priority);
-    if (!has_priority)
-        priority = QDR_DEFAULT_PRIORITY;
-    return priority;
+    return addr->priority >= 0 ? addr->priority : qd_message_get_priority(msg);
 }
 
 

--- a/src/router_core/route_control.c
+++ b/src/router_core/route_control.c
@@ -472,7 +472,7 @@ qdr_auto_link_t *qdr_route_add_auto_link_CT(qdr_core_t          *core,
 
     qd_hash_retrieve(core->addr_hash, iter, (void*) &al->addr);
     if (!al->addr) {
-        qd_address_treatment_t treatment = qdr_treatment_for_address_CT(core, 0, iter, 0, 0);
+        qd_address_treatment_t treatment = qdr_treatment_for_address_CT(core, 0, iter, 0, 0, 0);
         if (treatment == QD_TREATMENT_UNAVAILABLE) {
             //if associated address is not defined, assume balanced
             treatment = QD_TREATMENT_ANYCAST_BALANCED;

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -299,6 +299,7 @@ qdr_address_t *qdr_address_CT(qdr_core_t *core, qd_address_treatment_t treatment
     addr->rnodes    = qd_bitmask(0);
     addr->add_prefix = 0;
     addr->del_prefix = 0;
+    addr->priority   = -1;
     return addr;
 }
 

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -284,6 +284,7 @@ struct qdr_query_t {
     int                      next_offset;
     bool                     more;
     qd_amqp_error_t          status;
+    uint8_t                  priority;
 };
 
 DEQ_DECLARE(qdr_query_t, qdr_query_list_t); 
@@ -521,6 +522,8 @@ struct qdr_address_t {
     uint64_t deliveries_ingress_route_container;
 
     ///@}
+
+    int priority;
 };
 
 ALLOC_DECLARE(qdr_address_t);
@@ -544,6 +547,7 @@ struct qdr_address_config_t {
     qd_address_treatment_t  treatment;
     int                     in_phase;
     int                     out_phase;
+    int                     priority;
 };
 
 ALLOC_DECLARE(qdr_address_config_t);
@@ -877,7 +881,7 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *pe
 void qdr_forward_deliver_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery_t *dlv);
 void qdr_connection_free(qdr_connection_t *conn);
 void qdr_connection_activate_CT(qdr_core_t *core, qdr_connection_t *conn);
-qd_address_treatment_t qdr_treatment_for_address_CT(qdr_core_t *core, qdr_connection_t *conn, qd_iterator_t *iter, int *in_phase, int *out_phase);
+qd_address_treatment_t qdr_treatment_for_address_CT(qdr_core_t *core, qdr_connection_t *conn, qd_iterator_t *iter, int *in_phase, int *out_phase, int *priority);
 qd_address_treatment_t qdr_treatment_for_address_hash_CT(qdr_core_t *core, qd_iterator_t *iter);
 qdr_edge_t *qdr_edge(qdr_core_t *);
 void qdr_edge_free(qdr_edge_t *);

--- a/tests/system_tests_priority.py
+++ b/tests/system_tests_priority.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+
 from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
@@ -24,19 +25,21 @@ from __future__ import print_function
 
 import unittest2 as unittest
 from proton          import Message, Timeout
-from system_test     import TestCase, Qdrouterd, main_module
+from system_test     import TestCase, Qdrouterd, main_module, Process
 from proton.handlers import MessagingHandler
 from proton.reactor  import Container
 
 import time
 import math
+from qpid_dispatch_internal.compat import UNICODE
 
-import pdb
 
 
-#================================================================
+
+
+#------------------------------------------------
 # Helper classes for all tests.
-#================================================================
+#------------------------------------------------
 
 class Timeout(object):
     """
@@ -50,6 +53,31 @@ class Timeout(object):
     def on_timer_task ( self, event ):
         self.parent.timeout ( self.name )
 
+
+
+class ManagementMessageHelper ( object ):
+    """
+    Format management messages.
+    """
+    def __init__ ( self, reply_addr ):
+        self.reply_addr = reply_addr
+
+    def make_router_link_query ( self ) :
+        props = { 'count':      '100',
+                  'operation':  'QUERY',
+                  'entityType': 'org.apache.qpid.dispatch.router.link',
+                  'name':       'self',
+                  'type':       'org.amqp.management'
+                }
+        attrs = []
+        attrs.append ( UNICODE('linkType') )
+        attrs.append ( UNICODE('linkDir') )
+        attrs.append ( UNICODE('deliveryCount') )
+        attrs.append ( UNICODE('priority') )
+
+        msg_body = { }
+        msg_body [ 'attributeNames' ] = attrs
+        return Message ( body=msg_body, properties=props, reply_to=self.reply_addr )
 
 
 
@@ -79,102 +107,124 @@ class PriorityTests ( TestCase ):
 
         cls.routers = []
 
+        # The sender will send all its messages with magic_message_priority.
+        # The first router will set target addr priority to magic_address_priority.
+        # It is important *not* to choose 4 for either of these priorities,
+        # since that is the default message priority.
+        cls.magic_message_priority = 3
+        cls.magic_address_priority = 7
+
         link_cap = 100
         A_client_port = cls.tester.get_port()
         B_client_port = cls.tester.get_port()
+        C_client_port = cls.tester.get_port()
 
         A_inter_router_port = cls.tester.get_port()
         B_inter_router_port = cls.tester.get_port()
+        C_inter_router_port = cls.tester.get_port()
 
         A_config = [
                      ( 'listener',
-                       { 'port': A_client_port,
-                         'role': 'normal',
-                         'stripAnnotations': 'no',
-                         'linkCapacity': link_cap
+                       { 'port'             : A_client_port,
+                         'role'             : 'normal',
+                         'linkCapacity'     : link_cap,
+                         'stripAnnotations' : 'no'
                        }
                      ),
                      ( 'listener',
-                       { 'role': 'inter-router',
-                         'port': A_inter_router_port,
-                         'stripAnnotations': 'no',
-                         'linkCapacity': link_cap
+                       { 'role'             : 'inter-router',
+                         'port'             : A_inter_router_port,
+                         'linkCapacity'     : link_cap,
+                         'stripAnnotations' : 'no'
                        }
-                     )
+                     ),
+                     ( 'address',
+                       { 'prefix'       : 'speedy',
+                         'priority'     : cls.magic_address_priority,
+                         'distribution' : 'closest'
+                       }
+                     ),
                    ]
 
         cls.B_config = [
                          ( 'listener',
-                           { 'port': B_client_port,
-                             'role': 'normal',
-                             'stripAnnotations': 'no',
-                             'linkCapacity': link_cap
+                           { 'port'             : B_client_port,
+                             'role'             : 'normal',
+                             'linkCapacity'     : link_cap,
+                             'stripAnnotations' : 'no'
                            }
                          ),
                          ( 'listener',
-                           { 'role': 'inter-router',
-                             'port': B_inter_router_port,
-                             'stripAnnotations': 'no',
-                             'linkCapacity': link_cap
+                           { 'role'             : 'inter-router',
+                             'port'             : B_inter_router_port,
+                             'linkCapacity'     : link_cap,
+                             'stripAnnotations' : 'no'
                            }
                          ),
                          ( 'connector',
-                           {  'name': 'BA_connector',
-                              'role': 'inter-router',
-                              'port': A_inter_router_port,
-                              'verifyHostname': 'no',
-                              'stripAnnotations': 'no',
-                              'linkCapacity': link_cap
+                           { 'name'             : 'BA_connector',
+                             'role'             : 'inter-router',
+                             'port'             : A_inter_router_port,
+                             'verifyHostname'   : 'no',
+                             'linkCapacity'     : link_cap,
+                             'stripAnnotations' : 'no'
                            }
                          )
                       ]
 
+        C_config = [
+                     ( 'listener',
+                       { 'port'             : C_client_port,
+                         'role'             : 'normal',
+                         'linkCapacity'     : link_cap,
+                         'stripAnnotations' : 'no'
+                       }
+                     ),
+                     ( 'listener',
+                       { 'role'             : 'inter-router',
+                         'port'             : C_inter_router_port,
+                         'linkCapacity'     : link_cap,
+                         'stripAnnotations' : 'no'
+                       }
+                     ),
+                     ( 'connector',
+                       { 'name'             : 'CB_connector',
+                         'role'             : 'inter-router',
+                         'port'             : B_inter_router_port,
+                         'verifyHostname'   : 'no',
+                         'linkCapacity'     : link_cap,
+                         'stripAnnotations' : 'no'
+                       }
+                     )
+                  ]
+
 
         router ( 'A', A_config )
         router ( 'B', cls.B_config )
+        router ( 'C', C_config )
 
 
         router_A = cls.routers[0]
         router_B = cls.routers[1]
+        router_C = cls.routers[2]
 
         router_A.wait_router_connected('B')
+        router_A.wait_router_connected('C')
 
         cls.client_addrs = ( router_A.addresses[0],
-                             router_B.addresses[0]
+                             router_B.addresses[0],
+                             router_C.addresses[0]
                            )
 
-    def kill_router_B ( self ) :
-        status = self.routers[1].poll()
-        self.routers[1].teardown()
-        status = self.routers[1].poll()
-        del self.routers[1]
 
-    
-    def new_router_B ( self ) :
-        name = 'B'
-        config = [ ('router',  {'mode': 'interior', 'id': name}),
-                   ('address', {'prefix': 'closest',   'distribution': 'closest'}),
-                   ('address', {'prefix': 'balanced',  'distribution': 'balanced'}),
-                   ('address', {'prefix': 'multicast', 'distribution': 'multicast'})
-                 ]    \
-                 + self.B_config
-
-        config = Qdrouterd.Config(config)
-        self.routers.append(self.tester.qdrouterd(name, config, wait=False))
-        # We need a little pause here, or A will always show 
-        # a status of None (i.e. Good) even if it is, in fact, 
-        # dying. (i.e. Bad)
-        time.sleep ( 2 )
-        status = self.routers[0].poll()
-        return status
-
-    
     def test_priority ( self ):
         name = 'test_01'
         test = Priority ( self,
                           name,
                           self.client_addrs,
-                          "closest/01"
+                          "speedy/01",
+                          self.magic_message_priority,
+                          self.magic_address_priority
                         )
         test.run()
         self.assertEqual ( None, test.error )
@@ -185,87 +235,246 @@ class PriorityTests ( TestCase ):
 #     Tests
 #================================================================
 
+
 class Priority ( MessagingHandler ):
 
-    def __init__ ( self, parent, test_name, client_addrs, destination ):
+    # In this test we will have a linear network of 3 routers.
+    # The sender attaches at A, and the receiver at C.
+    #
+    #  receiver <--- C <--- B <--- A <--- sender
+    #
+    # Priority -- whether message or address -- only operates
+    # on inter-router links. The links from A to B will show
+    # address-priority overriding message-priority. When a
+    # router does not set any message priority, then messages
+    # are routed acording to their intrinsic priority which
+    # was assigned by the sender. This will be shown by the
+    # connection from router B to C.
+    #
+    # The address that the clients use has a prefix of 'speedy'.
+    # Router A will assign a priority of magic_addr_priority to all
+    # 'speedy' addresses.
+    # No other routers will assign any address priorities.
+    #
+    # The sending client will assign a priority of magic_msg_priority
+    # to all the messages it sends.
+    #
+    # So what should happen is:
+    #
+    # 1. at router A, all the 'speedy' messages go out with
+    #    magic_addr_priority, because addr priority takes precedence.
+    #
+    # 2. at router B, they all go out with magic_msg_priority,
+    #    because that router has not assigned any addr priority,
+    #    so the intrinsic message priorities are used.
+    #
+    # 3. Nothing special happens at router C, because it is sending
+    #    the messages out over a connection to an endpoint, which
+    #    is not an inter-router connection.
+    #
+    # In this test we will send a known number of messages and
+    # then send management queries to A and B to learn at what
+    # priorities the messages actually travelled.
+
+    def __init__ ( self, parent, test_name, client_addrs, destination, magic_msg_priority, magic_addr_priority ):
         super(Priority, self).__init__(prefetch=10)
 
         self.parent          = parent
         self.client_addrs    = client_addrs
         self.dest            = destination
 
+        self.magic_msg_priority  = magic_msg_priority
+        self.magic_addr_priority = magic_addr_priority
+
         self.error           = None
         self.sender          = None
         self.receiver        = None
-        self.test_timer      = None
-        self.fail_timer      = None
+        self.send_timer      = None
+        self.n_messages      = 100
         self.n_sent          = 0
-        self.n_accepted      = 0
-        self.n_released      = 0
         self.send_conn       = None
         self.recv_conn       = None
-        self.n_messages      = 100
         self.n_received      = 0
-        self.test_start_time = None
-        self.test_end_time   = None
-        self.timer_count     = 0
         self.reactor         = None
-        self.router_B_count  = 0
+        self.timer_count     = 0
+        self.sent_queries    = False
+        self.finishing       = False
+        self.goals           = 0
+        self.n_goals         = 2
+        self.connections     = list()
+        self.A_addr          = self.client_addrs[0]
+        self.B_addr          = self.client_addrs[1]
+        self.C_addr          = self.client_addrs[2]
+        self.routers = {
+                         'A' : dict(),
+                         'B' : dict()
+                       }
 
 
     # Shut down everything and exit.
     def bail ( self, text ):
+        self.send_timer.cancel ( )
+        self.finishing = True
         self.error = text
-
-        self.send_conn.close()
-        self.recv_conn.close ( )
-        self.test_timer.cancel ( )
-        self.fail_timer.cancel ( )
+        for conn in self.connections :
+            conn.close()
 
 
-    # There is no need in this test to send messages at all. Just the
-    # process of killing and replacing router B will kill router A if
-    # it is not cleaning up its sheafs of prioritized links properly.
-    #
-    # Each time this timer goes off we will kill router B and make a 
-    # replacement for it, then make sure that A has survived the process.
-    #
-    # To see A die in this test, comment out the call to qdr_reset_sheaf()
-    # in connections.c, rebuild, and run this test.
-    def timeout ( self, name ):
-        if name == 'fail':
-            self.bail ( "Test hanging." )
-            return
-        if name == 'test':
-            self.timer_count += 1
-            if 0 == (self.timer_count % 3 ) :
-                self.parent.kill_router_B ( )
-                self.kill_B = 0
-                time.sleep(2)
-                # Make a new B router, and see if A survives.
-                A_status = self.parent.new_router_B ( )
-                if A_status != None :
-                    self.bail ( "Router A died when new router B was created." )
-                    return
-                if self.router_B_count >= 2 :
-                    # We have killed & restarted B 2 times. Good enough.
-                    self.bail ( None )
-                    return
-                self.router_B_count += 1
-            self.test_timer = self.reactor.schedule ( 1, Timeout(self, "test") )
-
+    def make_connection ( self, event, addr ) :
+        cnx = event.container.connect ( addr )
+        self.connections.append ( cnx )
+        return cnx
 
 
     def on_start ( self, event ):
         self.reactor = event.reactor
-        self.test_timer = event.reactor.schedule ( 1,  Timeout(self, "test") )
-        self.fail_timer = event.reactor.schedule ( 30, Timeout(self, "fail") )
-        self.send_conn  = event.container.connect ( self.client_addrs[0] ) # A
-        self.recv_conn  = event.container.connect ( self.client_addrs[1] ) # B
+        self.send_conn  = self.make_connection ( event,  self.A_addr )
+        self.recv_conn  = self.make_connection ( event,  self.C_addr )
+
+        self.sender     = event.container.create_sender   ( self.send_conn, self.dest )
+        self.receiver   = event.container.create_receiver ( self.recv_conn, self.dest )
+        self.receiver.flow ( 100 )
+
+        self.routers['A'] ['mgmt_conn']     = self.make_connection ( event, self.A_addr )
+        self.routers['A'] ['mgmt_receiver'] = event.container.create_receiver ( self.routers['A'] ['mgmt_conn'], dynamic=True )
+        self.routers['A'] ['mgmt_sender']   = event.container.create_sender   ( self.routers['A'] ['mgmt_conn'], "$management" )
+
+        self.routers['B'] ['mgmt_conn']     = self.make_connection ( event, self.B_addr )
+        self.routers['B'] ['mgmt_receiver'] = event.container.create_receiver ( self.routers['B'] ['mgmt_conn'], dynamic=True )
+        self.routers['B'] ['mgmt_sender']   = event.container.create_sender   ( self.routers['B'] ['mgmt_conn'], "$management" )
+
+        self.send_timer = event.reactor.schedule ( 2, Timeout(self, "send") )
+
+
+    def timeout ( self, name ):
+        if name == 'send':
+            self.send ( )
+            if not self.sent_queries :
+                self.test_timer = self.reactor.schedule ( 1, Timeout(self, "send") )
+
+
+    def on_link_opened ( self, event ) :
+        # A mgmt link has opened. Create its management helper.
+        # ( Now we know the address that the management helper should use as
+        # the "reply-to" in its management message. )
+        if event.receiver == self.routers['A'] ['mgmt_receiver'] :
+            event.receiver.flow ( 1000 )
+            self.routers['A'] ['mgmt_helper'] = ManagementMessageHelper ( event.receiver.remote_source.address )
+
+        elif event.receiver == self.routers['B'] ['mgmt_receiver'] :
+            event.receiver.flow ( 1000 )
+            self.routers['B'] ['mgmt_helper'] = ManagementMessageHelper ( event.receiver.remote_source.address )
+
+
+    def send ( self ) :
+        if self.sender.credit <= 0:
+            self.receiver.flow ( 100 )
+            return
+
+        # First send the payload messages.
+        if self.n_sent < self.n_messages :
+            for i in xrange(50) :
+                msg = Message ( body=self.n_sent )
+                msg.priority = 3
+                self.sender.send ( msg )
+                self.n_sent += 1
+        # Then send the management queries.
+        # But only send them once.
+        elif not self.sent_queries  :
+            # Query router A.
+            mgmt_helper = self.routers['A'] ['mgmt_helper']
+            mgmt_sender = self.routers['A'] ['mgmt_sender']
+            msg = mgmt_helper.make_router_link_query ( )
+            mgmt_sender.send ( msg )
+
+            # Query router B.
+            mgmt_helper = self.routers['B'] ['mgmt_helper']
+            mgmt_sender = self.routers['B'] ['mgmt_sender']
+            msg = mgmt_helper.make_router_link_query ( )
+            mgmt_sender.send ( msg )
+
+            self.sent_queries = True
+
+
+    # This test has two goals: get the response from router A
+    # and from router B. As they come in, we check them. If
+    # the response is unsatisfactory we bail out
+    def goal_satisfied ( self ) :
+        self.goals += 1
+        if self.goals >= self.n_goals :
+            self.bail ( None )
+
+
+    def on_message ( self, event ) :
+
+        # Don't take any more messages if 'bail' has been called.
+        if self.finishing :
+            return
+
+        msg = event.message
+
+        if event.receiver == self.routers['A'] ['mgmt_receiver'] :
+            # Router A has only one set of outgoing links, and it
+            # has set a priority for our target address. We should
+            # see all the messages we sent go out with that priority.
+            magic = self.magic_addr_priority
+            if 'results' in msg.body :
+                results = msg.body['results']
+                # I do not want to trust the possibility that the
+                # results will be returned to me in priority-order.
+                # Instead, I explicitly asked for the link priority
+                # in the management query that was sent. Now I will
+                # loop through all the results, and look for the one
+                # with the desired priority.
+                for i in range(len(results)) :
+                    result = results[i]
+                    role          = result[0]
+                    dir           = result[1]
+                    message_count = result[2]
+                    priority      = result[3]
+                    if role == "inter-router" and dir == "out" and priority == magic  :
+                        if message_count >= self.n_messages :
+                            self.goal_satisfied ( )
+                            return
+                        else :
+                            self.bail ( "Router A priority %d had %d messages instead of %d." %
+                                        (magic, message_count, self.n_messages) )
+                            return
+
+        elif event.receiver == self.routers['B'] ['mgmt_receiver'] :
+            # Router B has two sets of outgoing links, and it has not
+            # set a priority for the target address. We should see all
+            # of our messages going out over the message-intrinsic
+            # priority that the sending client used -- one one of those
+            # two sets of outgoing links.
+            magic = self.magic_msg_priority
+            if 'results' in msg.body :
+                message_counts = list()
+                results = msg.body['results']
+                for i in range(len(results)) :
+                    result = results[i]
+                    role          = result[0]
+                    dir           = result[1]
+                    message_count = result[2]
+                    priority      = result[3]
+                    if role == "inter-router" and dir == "out" :
+                        if priority == magic :
+                            message_counts.append ( message_count )
+
+                if self.n_messages in message_counts :
+                    self.goal_satisfied ( )
+                else :
+                    self.bail ( "No outgoing link on router B had %d messages at priority 3" % self.n_messages )
+
+        else :
+            # This is a payload message -- not management. Just count it.
+            self.n_received += 1
 
 
     def run(self):
         Container(self).run()
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Code that implements address-priority. Also changes things so that address priority takes precedence if present, otherwise defaults to message priority -- and messages now always have priority, defaulting to 4 if not specified. (Same as Proton default.)
Also a python test that tests both message and address priority.
