### PR TITLE
DISPATCH-1147 Expose address priority to management and qdstat

### DIFF
--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1514,6 +1514,10 @@
                 "trackedDeliveries": {
                     "type": "integer",
                     "description": "Number of transit deliveries being tracked for this address (for balanced distribution)."
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "The message priority being handled by this address."
                 }
             }
         },

--- a/src/router_core/agent_address.c
+++ b/src/router_core/agent_address.c
@@ -39,6 +39,7 @@
 #define QDR_ADDRESS_DELIVERIES_INGRESS_ROUTE_CONTAINER 16
 #define QDR_ADDRESS_TRANSIT_OUTSTANDING                17
 #define QDR_ADDRESS_TRACKED_DELIVERIES                 18
+#define QDR_ADDRESS_PRIORITY                           19
 
 const char *qdr_address_columns[] =
     {"name",
@@ -60,6 +61,7 @@ const char *qdr_address_columns[] =
      "deliveriesIngressRouteContainer",
      "transitOutstanding",
      "trackedDeliveries",
+     "priority",
      0};
 
 
@@ -165,6 +167,10 @@ static void qdr_insert_address_columns_CT(qdr_core_t          *core,
 
     case QDR_ADDRESS_TRACKED_DELIVERIES:
         qd_compose_insert_long(body, addr->tracked_deliveries);
+        break;
+
+    case QDR_ADDRESS_PRIORITY:
+        qd_compose_insert_int(body, addr->priority);
         break;
 
     default:

--- a/src/router_core/agent_address.h
+++ b/src/router_core/agent_address.h
@@ -31,7 +31,7 @@ void qdra_address_get_CT(qdr_core_t *core,
                       const char *qdr_address_columns[]);
 
 
-#define QDR_ADDRESS_COLUMN_COUNT 19
+#define QDR_ADDRESS_COLUMN_COUNT 20
 
 const char *qdr_address_columns[QDR_ADDRESS_COLUMN_COUNT + 1];
 

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -87,6 +87,28 @@ class QdstatTest(system_test.TestCase):
         parts = out.split("\n")
         self.assertEqual(len(parts), 8)
 
+    def test_address_priority(self):
+        out = self.run_qdstat(['--address'])
+        lines = out.split("\n")
+
+        # make sure the output contains a header line
+        self.assertGreaterEqual(len(lines), 2)
+
+        # see if the header line has the word priority in it
+        priorityregexp = r'priority'
+        priority_column = re.search(priorityregexp, lines[1]).start()
+        self.assertGreater(priority_column, -1)
+
+        # extract the number in the priority column of every address
+        for i in range(3, len(lines) - 1):
+            pri = re.findall('\d+', lines[i][priority_column:])
+            # make sure the priority found is a number
+            self.assertGreater(len(pri), 0, "Can not find numeric priority in '%s'" % lines[i])
+            priority = int(pri[0])
+            # make sure the priority is from -1 to 9
+            self.assertGreaterEqual(priority, -1, "Priority was less than -1")
+            self.assertLessEqual(priority, 9, "Priority was greater than 9")
+
     def test_address_with_limit(self):
         out = self.run_qdstat(['--address', '--limit=1'])
         parts = out.split("\n")

--- a/tools/qdstat.in
+++ b/tools/qdstat.in
@@ -413,10 +413,11 @@ class BusManager(Node):
         heads.append(Header("thru", Header.COMMAS))
         heads.append(Header("to-proc", Header.COMMAS))
         heads.append(Header("from-proc", Header.COMMAS))
+        heads.append(Header("priority"))
         rows = []
         cols = ('distribution', 'inProcess', 'subscriberCount', 'remoteCount',
                 'containerCount', 'deliveriesIngress', 'deliveriesEgress',
-                'deliveriesTransit', 'deliveriesToContainer', 'deliveriesFromContainer', 'name')
+                'deliveriesTransit', 'deliveriesToContainer', 'deliveriesFromContainer', 'name', 'priority')
 
         objects = self.query('org.apache.qpid.dispatch.router.address', cols, limit=self.opts.limit)
 
@@ -435,6 +436,7 @@ class BusManager(Node):
             row.append(addr.deliveriesTransit)
             row.append(addr.deliveriesToContainer)
             row.append(addr.deliveriesFromContainer)
+            row.append(addr.priority)
             rows.append(row)
         title = "Router Addresses"
         sorter = Sorter(heads, rows, 'addr', 0, True)


### PR DESCRIPTION
Exposes router.address.priority to management
qdstat --address now lists priority
Added test to system_tests_qdstat to check if priority column is present and contains valid priority (-1 | 0-9)