### PR TITLE
DISPATCH-1176 Prevent uninitialized delivery from crashing router

### DIFF
--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -321,8 +321,7 @@ ALLOC_DECLARE(qdr_router_ref_t);
 DEQ_DECLARE(qdr_router_ref_t, qdr_router_ref_list_t);
 
 typedef enum {
-    QDR_DELIVERY_UNINITIALIZED = 0,
-    QDR_DELIVERY_NOWHERE,
+    QDR_DELIVERY_NOWHERE = 0,
     QDR_DELIVERY_IN_UNDELIVERED,
     QDR_DELIVERY_IN_UNSETTLED,
     QDR_DELIVERY_IN_SETTLED

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -321,7 +321,8 @@ ALLOC_DECLARE(qdr_router_ref_t);
 DEQ_DECLARE(qdr_router_ref_t, qdr_router_ref_list_t);
 
 typedef enum {
-    QDR_DELIVERY_NOWHERE = 0,
+    QDR_DELIVERY_UNINITIALIZED = 0,
+    QDR_DELIVERY_NOWHERE,
     QDR_DELIVERY_IN_UNDELIVERED,
     QDR_DELIVERY_IN_UNSETTLED,
     QDR_DELIVERY_IN_SETTLED

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -1231,7 +1231,7 @@ static void qdr_deliver_continue_CT(qdr_core_t *core, qdr_action_t *action, bool
     //
     // If it is already in the undelivered list, don't try to deliver this again.
     //
-    if (in_dlv->where == QDR_DELIVERY_IN_UNDELIVERED || in_dlv->where == QDR_DELIVERY_UNINITIALIZED)
+    if (in_dlv->where == QDR_DELIVERY_IN_UNDELIVERED || in_dlv->where == QDR_DELIVERY_NOWHERE)
         return;
 
     qdr_deliver_continue_peers_CT(core, in_dlv);

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -1231,7 +1231,7 @@ static void qdr_deliver_continue_CT(qdr_core_t *core, qdr_action_t *action, bool
     //
     // If it is already in the undelivered list, don't try to deliver this again.
     //
-    if (in_dlv->where == QDR_DELIVERY_IN_UNDELIVERED)
+    if (in_dlv->where == QDR_DELIVERY_IN_UNDELIVERED || in_dlv->where == QDR_DELIVERY_UNINITIALIZED)
         return;
 
     qdr_deliver_continue_peers_CT(core, in_dlv);


### PR DESCRIPTION
This prevents the crash but I'm concerned about:
- what happens to this delivery? does it get dropped?
- what about router inter-operability between different versions of the router?
