### PR TITLE
DISPATCH-1246: clean up core link endpoints on shutdown

### DIFF
--- a/src/router_core/core_link_endpoint.h
+++ b/src/router_core/core_link_endpoint.h
@@ -117,7 +117,7 @@ typedef void (*qdrc_detach_t) (void        *link_context,
 
 
 /**
- * Event - A core-endpoint link has been cleaned up (not cleanly detached)
+ * Event - A core-endpoint link is being freed.
  *
  * This handler must free all resources associated with the link-context.
  *
@@ -263,7 +263,7 @@ void qdrc_endpoint_do_second_attach_CT(qdr_core_t *core, qdrc_endpoint_t *endpoi
 void qdrc_endpoint_do_deliver_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint, qdr_delivery_t *delivery);
 void qdrc_endpoint_do_update_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint, qdr_delivery_t *delivery, bool settled);
 void qdrc_endpoint_do_flow_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint, int credit, bool drain);
-void qdrc_endpoint_do_detach_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint, qdr_error_t *error);
+void qdrc_endpoint_do_detach_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint, qdr_error_t *error, qd_detach_type_t dt);
 void qdrc_endpoint_do_cleanup_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint);
 
 #endif

--- a/src/router_core/modules/address_lookup_client/lookup_client.c
+++ b/src/router_core/modules/address_lookup_client/lookup_client.c
@@ -752,6 +752,7 @@ static void qcm_addr_lookup_client_final_CT(void *module_context)
     qcm_lookup_client_t *client = (qcm_lookup_client_t*) module_context;
     qdrc_event_unsubscribe_CT(client->core, client->event_sub);
     client->core->addr_lookup_handler = 0;
+    qdrc_client_free_CT(client->client_api);
     free(client);
 }
 

--- a/src/router_core/modules/edge_router/link_route_proxy.c
+++ b/src/router_core/modules/edge_router/link_route_proxy.c
@@ -368,7 +368,8 @@ static void _link_route_deleted_CT(qdr_core_t *core, qdr_address_t *addr)
             lrp->proxy_state = QDR_LINK_ROUTE_PROXY_CANCELLED;
             break;
         default:
-            assert(false);
+            // close in process (connection dropped while link closing)
+            break;
         }
     }
 }

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -234,7 +234,7 @@ typedef struct qdr_connection_work_t {
 
 ALLOC_DECLARE(qdr_connection_work_t);
 DEQ_DECLARE(qdr_connection_work_t, qdr_connection_work_list_t);
-
+void qdr_connection_work_free_CT(qdr_connection_work_t *work);
 
 //
 // Link Work
@@ -947,6 +947,7 @@ qdr_query_t *qdr_query(qdr_core_t              *core,
                        qd_router_entity_type_t  type,
                        qd_composed_field_t     *body,
                        uint64_t                 conn_id);
+void qdr_modules_finalize(qdr_core_t *core);
 
 /**
  * Create a new timer which will only be used inside the code thread.


### PR DESCRIPTION
This patch makes the following changes:

o) the do_cleanup callback is always invoked then the core link
endpoint is released.  The callback is normally called right after
second detach occurs, but it can also be called when the link is freed
without cleanly detaching.

o) moved the module finalization after the cleanup of links and
endpoints on router shutdown.  This ensures that all core link
endpoints used by the modules are cleaned up before the finalization
occurs.

o) if the link has been lost (e.g. connection closed) then the detach
link endpoint callback will not be called. The do_cleanup callback
will be called instead.