### PR TITLE
DISPATCH-1262: fix GCC 8.2 format-truncation error in router/src/main.c

### DIFF
--- a/router/src/main.c
+++ b/router/src/main.c
@@ -189,7 +189,7 @@ static void daemon_process(const char *config_path, const char *python_pkgdir, b
                 int getcwd_error = 0;
                 cur_path = (char *) calloc(path_size, sizeof(char));
 
-                while ( getcwd(cur_path, path_size) == NULL ) {
+                while ((cur_path = getcwd(cur_path, path_size)) == NULL) {
                     free(cur_path);
                     if ( errno != ERANGE ) {
                         // If unable to get current directory


### PR DESCRIPTION
Gcc warns because `getcwd` on Linux may allocate and return new buffer,
so don't ignore the returned value. And cur_path may in theory be null
going in if previous `calloc` failed.

It is unlikely we would end up with cur_path = NULL as parameter to `%s`
in a formatting string later below, but it is possible, given very
careful timing and sufficiently malicious user, I think.

Change is made to silence GCC warning, so that ``-fsanitize=undefined` compiles.