### PR TITLE
DISPATCH-1276 - Added a cleanup function qdrc_address_endpoint_cleanu…

### DIFF
--- a/include/qpid/dispatch/container.h
+++ b/include/qpid/dispatch/container.h
@@ -62,9 +62,10 @@ typedef enum {
 
 
 typedef enum {
-    QD_DETACHED,  // Protocol detach
-    QD_CLOSED,    // Protocol close
-    QD_LOST       // Connection or session closed
+    QD_DETACHED,        // Protocol detach
+    QD_CLOSED,          // Protocol close
+    QD_CONNECTION_LOST, // Connection closed
+    QD_SESSION_LOST     // Session closed
 } qd_detach_type_t;
 
 

--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -461,11 +461,27 @@ pn_data_t *qdr_error_info(const qdr_error_t *err);
 void qdr_link_set_context(qdr_link_t *link, void *context);
 
 /**
+ * qdr_link_set_connection_closed
+ *
+ * Set the closed flag to true on the stored connection pointer from the link object.
+ */
+void qdr_link_set_connection_closed(const qdr_link_t *link);
+
+/**
+ * qdr_link_is_connection_closed
+ *
+ *  Get the closed flag to true on the stored connection pointer from the link object.
+ */
+bool qdr_link_is_connection_closed(const qdr_link_t *link);
+
+
+/**
  * qdr_link_get_context
  *
  * Retrieve the stored void pointer from the link object.
  */
 void *qdr_link_get_context(const qdr_link_t *link);
+
 
 /**
  * qdr_link_type

--- a/src/container.c
+++ b/src/container.c
@@ -295,7 +295,7 @@ static void close_links(qd_container_t *container, pn_connection_t *conn, bool p
                 qd_log(container->log_source, QD_LOG_DEBUG,
                        "Aborting link '%s' due to parent connection end",
                        pn_link_name(pn_link));
-            node->ntype->link_detach_handler(node->context, qd_link, QD_LOST);
+            node->ntype->link_detach_handler(node->context, qd_link, QD_CONNECTION_LOST);
         }
         pn_link = pn_link_next(pn_link, 0);
     }
@@ -305,7 +305,7 @@ static void close_links(qd_container_t *container, pn_connection_t *conn, bool p
 static int close_handler(qd_container_t *container, pn_connection_t *conn, qd_connection_t* qd_conn)
 {
     //
-    // Close all links, passing QD_LOST as the reason.  These links are not
+    // Close all links, passing QD_CONNECTION_LOST as the reason.  These links are not
     // being properly 'detached'.  They are being orphaned.
     //
     close_links(container, conn, true);
@@ -524,7 +524,7 @@ void qd_container_handle_event(qd_container_t *container, pn_event_t *event,
                                    "Aborting link '%s' due to parent session end",
                                    pn_link_name(pn_link));
                             qd_link->node->ntype->link_detach_handler(qd_link->node->context,
-                                                                      qd_link, QD_LOST);
+                                                                      qd_link, QD_SESSION_LOST);
                         }
                     }
                     pn_link = pn_link_next(pn_link, PN_LOCAL_ACTIVE | PN_REMOTE_ACTIVE);

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -222,6 +222,9 @@ int qdr_connection_process(qdr_connection_t *conn)
 
     int event_count = 0;
 
+    if (conn->closed)
+        return 0;
+
     sys_mutex_lock(conn->work_lock);
     DEQ_MOVE(conn->work_list, work_list);
     for (int priority = 0; priority <= QDR_MAX_PRIORITY; ++ priority) {
@@ -365,6 +368,16 @@ void qdr_link_set_context(qdr_link_t *link, void *context)
 {
     if (link)
         link->user_context = context;
+}
+
+void qdr_link_set_connection_closed(const qdr_link_t *link)
+{
+    link->conn->closed = true;
+}
+
+bool qdr_link_is_connection_closed(const qdr_link_t *link)
+{
+    return link->conn->closed;
 }
 
 
@@ -669,6 +682,7 @@ static void qdr_link_cleanup_deliveries_CT(qdr_core_t *core, qdr_connection_t *c
         // Now our reference
         //
         qdr_delivery_decref_CT(core, ref->dlv, "qdr_link_cleanup_deliveries_CT - remove from updated list");
+
         qdr_del_delivery_ref(&updated_deliveries, ref);
         ref = DEQ_HEAD(updated_deliveries);
     }
@@ -708,6 +722,7 @@ static void qdr_link_cleanup_deliveries_CT(qdr_core_t *core, qdr_connection_t *c
         //
         // Now the undelivered-list reference
         //
+
         qdr_delivery_decref_CT(core, dlv, "qdr_link_cleanup_deliveries_CT - remove from undelivered list");
 
         dlv = DEQ_HEAD(undelivered);
@@ -1582,7 +1597,7 @@ static void qdr_link_inbound_detach_CT(qdr_core_t *core, qdr_action_t *action, b
             if (link->connected_link->link_direction == QD_OUTGOING)
                 qdr_link_abort_undelivered_CT(core, link->connected_link);
 
-            if (dt != QD_LOST)
+            if (dt != QD_CONNECTION_LOST && dt != QD_SESSION_LOST)
                 qdr_link_outbound_detach_CT(core, link->connected_link, error, QDR_CONDITION_NONE, dt == QD_CLOSED);
             else {
                 qdr_link_outbound_detach_CT(core, link->connected_link, 0, QDR_CONDITION_ROUTED_LINK_LOST, !link->terminus_survives_disconnect);
@@ -1682,7 +1697,7 @@ static void qdr_link_inbound_detach_CT(qdr_core_t *core, qdr_action_t *action, b
         //
         // If the detach occurred via protocol, send a detach back.
         //
-        if (dt != QD_LOST) {
+        if (dt != QD_CONNECTION_LOST && dt != QD_SESSION_LOST) {
             qdr_link_outbound_detach_CT(core, link, 0, QDR_CONDITION_NONE, dt == QD_CLOSED);
         } else {
             // no detach can be sent out because the connection was lost

--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -206,7 +206,7 @@ void qdrc_endpoint_do_flow_CT(qdr_core_t *core, qdrc_endpoint_t *ep, int credit,
 
 void qdrc_endpoint_do_detach_CT(qdr_core_t *core, qdrc_endpoint_t *ep, qdr_error_t *error, qd_detach_type_t dt)
 {
-    if (dt == QD_LOST) {
+    if (dt == QD_CONNECTION_LOST || dt == QD_SESSION_LOST) {
         qdrc_endpoint_do_cleanup_CT(core, ep);
         qdr_error_free(error);
 

--- a/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
+++ b/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
@@ -130,6 +130,7 @@ static void qdrc_address_endpoint_on_first_detach(void *link_context,
 {
     qdr_addr_endpoint_state_t *endpoint_state  = (qdr_addr_endpoint_state_t *)link_context;
     qdrc_endpoint_detach_CT(endpoint_state->mc->core, endpoint_state->endpoint, 0);
+    qdr_error_free(error);
 }
 
 static void qdrc_address_endpoint_cleanup(void *link_context)

--- a/src/router_core/modules/edge_router/addr_proxy.c
+++ b/src/router_core/modules/edge_router/addr_proxy.c
@@ -160,7 +160,7 @@ static void del_inlink(qcm_edge_addr_proxy_t *ap, qdr_address_t *addr)
 
 static void add_outlink(qcm_edge_addr_proxy_t *ap, const char *key, qdr_address_t *addr)
 {
-    if (addr->edge_outlink == 0) {
+    if (addr->edge_outlink == 0 && DEQ_SIZE(addr->subscriptions) == 0) {
         //
         // Note that this link must not be bound to the address at this time.  That will
         // happen later when the interior tells us that there are upstream destinations

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -627,6 +627,7 @@ struct qdr_connection_t {
     qdr_connection_info_t      *connection_info;
     void                       *user_context; /* Updated from IO thread, use work_lock */
     qdr_link_route_list_t       conn_link_routes;  // connection scoped link routes
+    bool                        closed;
 };
 
 ALLOC_DECLARE(qdr_connection_t);
@@ -902,7 +903,6 @@ qdr_delivery_t *qdr_delivery_first_peer_CT(qdr_delivery_t *dlv);
  * Returns the next peer of the passed in delivery.
  */
 qdr_delivery_t *qdr_delivery_next_peer_CT(qdr_delivery_t *dlv);
-
 
 void qdr_agent_enqueue_response_CT(qdr_core_t *core, qdr_query_t *query);
 

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -609,7 +609,8 @@ static void qdr_delete_delivery_internal_CT(qdr_core_t *core, qdr_delivery_t *de
         }
 
         if (qd_bitmask_valid_bit_value(delivery->ingress_index) && link->ingress_histogram)
-            link->ingress_histogram[delivery->ingress_index]++;    }
+            link->ingress_histogram[delivery->ingress_index]++;
+    }
 
     //
     // Free all the peer qdr_delivery_ref_t references


### PR DESCRIPTION
…p which will clean out the link's edge context in addition to cleaning out other state. This will prevent the crash outlined in the issue