### PR TITLE
DISPATCH-1276 - Added a cleanup function qdrc_address_endpoint_cleanu…

### DIFF
--- a/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
+++ b/src/router_core/modules/edge_addr_tracking/edge_addr_tracking.c
@@ -108,6 +108,8 @@ static void qdrc_address_endpoint_first_attach(void              *bind_context,
     // When all those incoming links get terminated, this endpoint state must *not* be freed. There might be more links coming that could
     // use this endpoint state. The endpoint state is freed only when the endpoint cleanup function is called where we
     // do the final decref and free the endpoint state.
+    // If the endpoint ends up getting closed before the other incoming links, the endpoint state will only be freed when the last of
+    // the referencing links detaches.
     //
     endpoint_state->ref_count = 1;
     endpoint_state->mc        = bc;

--- a/src/router_core/modules/edge_router/addr_proxy.c
+++ b/src/router_core/modules/edge_router/addr_proxy.c
@@ -160,7 +160,7 @@ static void del_inlink(qcm_edge_addr_proxy_t *ap, qdr_address_t *addr)
 
 static void add_outlink(qcm_edge_addr_proxy_t *ap, const char *key, qdr_address_t *addr)
 {
-    if (addr->edge_outlink == 0) {
+    if (addr->edge_outlink == 0 && DEQ_SIZE(addr->subscriptions) == 0) {
         //
         // Note that this link must not be bound to the address at this time.  That will
         // happen later when the interior tells us that there are upstream destinations


### PR DESCRIPTION
…p which will clean out the link's edge context in addition to cleaning out other state. This will prevent the crash outlined in the issue