### PR TITLE
DISPATCH-1297: Fix the outgoing buffer reference counting

### DIFF
--- a/include/qpid/dispatch/buffer.h
+++ b/include/qpid/dispatch/buffer.h
@@ -121,15 +121,23 @@ void qd_buffer_list_free_buffers(qd_buffer_list_t *list);
  */
 unsigned int qd_buffer_list_length(const qd_buffer_list_t *list);
 
-/*
- * Increase the fanout by 1. How many receivers should this buffer be sent to.
+/**
+ * Set the fanout value on the buffer.
+ * @return the _old_ count before updating
  */
-void qd_buffer_add_fanout(qd_buffer_t *buf);
+uint32_t qd_buffer_set_fanout(qd_buffer_t *buf, uint32_t value);
 
 /**
- * Return the buffer's fanout.
+ * Increase the fanout by 1. How many receivers should this buffer be sent to.
+ * @return the _old_ count (pre increment)
  */
-size_t qd_buffer_fanout(qd_buffer_t *buf);
+uint32_t qd_buffer_inc_fanout(qd_buffer_t *buf);
+
+/**
+ * Decrease the fanout by one
+ * @return the _old_ count (pre decrement)
+ */
+uint32_t qd_buffer_dec_fanout(qd_buffer_t *buf);
 
 /**
  * Advance the buffer by len. Does not manipulate the contents of the buffer

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -360,24 +360,14 @@ bool qd_message_tag_sent(qd_message_t *msg);
 void qd_message_set_tag_sent(qd_message_t *msg, bool tag_sent);
 
 /**
- * Get the number of receivers for this message.
- *
- * @param msg A pointer to the message.
- */
-size_t qd_message_fanout(qd_message_t *msg);
-
-/**
  * Increase the fanout of the message by 1.
  *
- * @param msg A pointer to the message.
+ * @param in_msg A pointer to the inbound message.
+ * @param out_msg A pointer to the outbound message or 0 if forwarding to a
+ * local subscriber.
  */
-void qd_message_add_fanout(qd_message_t *msg);
-
-/**
- * Increments the num_closed_receivers by 1. This is necessary to track the number of receivers that
- * dropped out during or just before transmission of a large message.
- */
-void qd_message_add_num_closed_receivers(qd_message_t *in_msg);
+void qd_message_add_fanout(qd_message_t *in_msg,
+                           qd_message_t *out_msg);
 
 /**
  * Disable the Q2-holdoff for this message.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -53,6 +53,7 @@ qd_buffer_t *qd_buffer(void)
 void qd_buffer_free(qd_buffer_t *buf)
 {
     if (!buf) return;
+    sys_atomic_destroy(&buf->bfanout);
     free_qd_buffer_t(buf);
 }
 
@@ -87,14 +88,22 @@ void qd_buffer_insert(qd_buffer_t *buf, size_t len)
     assert(buf->size <= BUFFER_SIZE);
 }
 
-void qd_buffer_add_fanout(qd_buffer_t *buf)
+
+uint32_t qd_buffer_set_fanout(qd_buffer_t *buf, uint32_t value)
 {
-    sys_atomic_inc(&buf->bfanout);
+    return sys_atomic_set(&buf->bfanout, value);
 }
 
-size_t qd_buffer_fanout(qd_buffer_t *buf)
+
+uint32_t qd_buffer_inc_fanout(qd_buffer_t *buf)
 {
-    return buf->bfanout;
+    return sys_atomic_inc(&buf->bfanout);
+}
+
+
+uint32_t qd_buffer_dec_fanout(qd_buffer_t *buf)
+{
+    return sys_atomic_dec(&buf->bfanout);
 }
 
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -69,6 +69,8 @@ typedef struct {
     sys_atomic_t         ref_count;                       // The number of messages referencing this
     qd_buffer_list_t     buffers;                         // The buffer chain containing the message
     qd_buffer_t         *pending;                         // Buffer owned by and filled by qd_message_receive
+    uint64_t             buffers_freed;                   // count of large msg buffers freed on send
+
     qd_field_location_t  section_message_header;          // The message header list
     qd_field_location_t  section_delivery_annotation;     // The delivery annotation map
     qd_field_location_t  section_message_annotation;      // The message annotation map
@@ -107,8 +109,7 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
-    sys_atomic_t         fanout;                         // The number of receivers for this message. This number does not include in-process subscribers.
-    int                  num_closed_receivers;
+    uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t           *input_link;                     // message received on this link
 
     bool                 ma_parsed;                      // have parsed annotations in incoming message
@@ -117,7 +118,6 @@ typedef struct {
     bool                 q2_input_holdoff;               // hold off calling pn_link_recv
     bool                 aborted;                        // receive completed with abort flag set
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
-    bool                 buffers_freed;                  // Has at least one buffer been freed ?
     bool                 priority_parsed;
     bool                 priority_present;
     uint8_t              priority;                       // The priority of this message
@@ -136,6 +136,7 @@ typedef struct {
     bool                  strip_annotations_in;
     bool                  send_complete;   // Has the message been completely received and completely sent?
     bool                  tag_sent;        // Tags are sent
+    bool                  is_fanout;       // If msg is an outgoing fanout
 } qd_message_pvt_t;
 
 ALLOC_DECLARE(qd_message_t);

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -708,10 +708,6 @@ static void qdr_link_cleanup_deliveries_CT(qdr_core_t *core, qdr_connection_t *c
             peer = qdr_delivery_next_peer_CT(dlv);
         }
 
-        if (dlv->link->link_direction == QD_OUTGOING) {
-            qdr_delivery_add_num_closed_receivers(dlv);
-        }
-
         //
         // Updates global and link level delivery counters like presettled_deliveries, accepted_deliveries, released_deliveries etc
         //

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -394,12 +394,6 @@ bool qdr_delivery_is_aborted(const qdr_delivery_t *delivery)
     return qd_message_aborted(delivery->msg);
 }
 
-void qdr_delivery_add_num_closed_receivers(qdr_delivery_t *delivery)
-{
-    assert(delivery);
-    qd_message_add_num_closed_receivers(delivery->msg);
-}
-
 
 void qdr_delivery_decref(qdr_core_t *core, qdr_delivery_t *delivery, const char *label)
 {

--- a/tests/system_tests_edge_router.py
+++ b/tests/system_tests_edge_router.py
@@ -1393,8 +1393,8 @@ class MobileAddressMulticastTest(MessagingHandler):
             self.check_addr_host = self.sender_host
 
         if self.large_msg:
-            for i in range(10000):
-                self.body += "0123456789101112131415"
+            self.body = "0123456789101112131415" * 10000
+            self.properties = {'big field': 'X' * 32000}
 
     def timeout(self):
         if self.dup_msg:
@@ -1468,7 +1468,7 @@ class MobileAddressMulticastTest(MessagingHandler):
         while self.n_sent < self.count:
             msg = None
             if self.large_msg:
-                msg = Message(body=self.body)
+                msg = Message(body=self.body, properties=self.properties)
             else:
                 msg = Message(body="Message %d" % self.n_sent)
             msg.correlation_id = self.n_sent


### PR DESCRIPTION
The older code did not correctly account for the loss of a multicast
consumer.  It could end up releasing a buffer before it was sent to
all consumers.