### PR TITLE
DISPATCH-1295 - Reduce lock contention and make fewer system calls.

### DIFF
--- a/src/immediate_private.h
+++ b/src/immediate_private.h
@@ -24,10 +24,17 @@
 #include <qpid/dispatch/server.h>
 #include <stdint.h>
 
-/* Immediate actions - used by timer to optimize schedule(0) */
+/*
+ * Immediate actions - used by timer to optimize schedule(0)
+ * disarm() and set_armed() are fast.
+ * arm() and schedule_visit() are not.
+*/
+
 
 void qd_immediate_initialize(void);
 void qd_immediate_finalize(void);
+
+/* Call each armed action in the calling thread. */
 void qd_immediate_visit(void);
 
 typedef struct qd_immediate_t qd_immediate_t;
@@ -39,6 +46,12 @@ void qd_immediate_arm(qd_immediate_t *);
 
 /* After disarm() returns, there will be no handler() call unless re-armed. */
 void qd_immediate_disarm(qd_immediate_t *);
+
+/* Mark action as armed, handler will be called at earlist qd_immediate_visit() */
+void qd_immediate_set_armed(qd_immediate_t *);
+
+/* At least one call to qd_immediate_visit will be made. */
+void qd_immediate_schedule_visit(qd_server_t*);
 
 void qd_immediate_free(qd_immediate_t *);
 


### PR DESCRIPTION
Flamegraphs show on a single quiver run that there is lock contention in setting timers.  Locks are held across system calls and also cause thread stalls as seen in offcpu runs.

This change restricts the main timer lock to updating internal data structures.  A second lock is used to prevent setting timer values out of order.

The main benefit is that immediate timer calls have much less contention with non-immediate timers.

Using a standard quiver C client run of 9,000,000 message, which lasts about a minute, we get 19% of the offcpu related to qd_timer_schedule and qd_timer_visit.  This drops to 0 with the change.

Regular on-cpu profiling samples in qd_timer drop from 9.1% of samples to 0.2%.  Samples in qd_immediate drop modestly from 0.6% to 0.5%.
