### PR TITLE
DISPATCH-1310: refactor the receive handler code

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -177,9 +177,8 @@ static void handle_link_open(qd_container_t *container, pn_link_t *pn_link)
 }
 
 
-static void do_receive(pn_delivery_t *pnd)
+static void do_receive(pn_link_t *pn_link, pn_delivery_t *pnd)
 {
-    pn_link_t     *pn_link  = pn_delivery_link(pnd);
     qd_link_t     *link     = (qd_link_t*) pn_link_get_context(pn_link);
 
     if (link) {
@@ -642,8 +641,8 @@ void qd_container_handle_event(qd_container_t *container, pn_event_t *event,
         delivery = pn_event_delivery(event);
         pn_link  = pn_event_link(event);
 
-        if (pn_link_is_receiver(pn_link))
-            do_receive(delivery);
+        if (pn_delivery_readable(delivery))
+            do_receive(pn_link, delivery);
 
         if (pn_delivery_updated(delivery) || pn_delivery_settled(delivery)) {
             do_updated(delivery);

--- a/src/router_core/delivery.h
+++ b/src/router_core/delivery.h
@@ -22,6 +22,7 @@
 
 #include "router_core_private.h"
 
+#define QDR_DELIVERY_TAG_MAX 32
 
 typedef enum {
     QDR_DELIVERY_NOWHERE = 0,
@@ -49,7 +50,7 @@ struct qdr_delivery_t {
     bool                    settled;
     bool                    presettled;
     qdr_delivery_where_t    where;
-    uint8_t                 tag[32];
+    uint8_t                 tag[QDR_DELIVERY_TAG_MAX];
     int                     tag_length;
     qd_bitmask_t           *link_exclusion;
     qdr_address_t          *tracking_addr;

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -99,9 +99,6 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
                                                 const uint8_t *tag, int tag_length,
                                                 uint64_t disposition, pn_data_t* disposition_data)
 {
-    if (tag_length > 32)
-        return 0;
-    
     qdr_action_t   *action = qdr_action(qdr_link_deliver_CT, "link_deliver");
     qdr_delivery_t *dlv    = new_qdr_delivery_t();
 
@@ -120,6 +117,7 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
     action->args.connection.delivery = dlv;
     action->args.connection.more = !qd_message_receive_complete(msg);
     action->args.connection.tag_length = tag_length;
+    assert(tag_length <= QDR_DELIVERY_TAG_MAX);
     memcpy(action->args.connection.tag, tag, tag_length);
     qdr_action_enqueue(link->core, action);
     return dlv;


### PR DESCRIPTION
Refactor the rx handler to exit early if the message is being
discarded or the delivery has already been handed to the core thread.

Avoid calling the receive code entirely if the PN_DELIVERY being read
does not contain the links current delivery.