### PR TITLE
DISPATCH-1322 - Prevent credit starvation in router-to-router links.

### DIFF
--- a/src/router_core/delivery.c
+++ b/src/router_core/delivery.c
@@ -303,7 +303,7 @@ bool qdr_delivery_settled_CT(qdr_core_t *core, qdr_delivery_t *dlv)
     // issued immediately even for unsettled deliveries.
     //
     if (moved && link->link_direction == QD_INCOMING &&
-        link->link_type != QD_LINK_ROUTER && !link->connected_link)
+        link->link_type != QD_LINK_ROUTER && !link->edge && !link->connected_link)
         qdr_link_issue_credit_CT(core, link, 1, false);
 
     return moved;


### PR DESCRIPTION
Added protection for deliveries held in link processing outside the lock.