### PR TITLE
DISPATCH-1325 - Treat newly attached outgoing links as stalled since …

### DIFF
--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1335,6 +1335,12 @@ static void CORE_link_second_attach(void *context, qdr_link_t *link, qdr_terminu
     // Open (attach) the link
     //
     pn_link_open(qd_link_pn(qlink));
+
+    //
+    // Mark the link as stalled and waiting for initial credit.
+    //
+    if (qdr_link_direction(link) == QD_OUTGOING)
+        qdr_link_stalled_outbound(link);
 }
 
 static void CORE_close_connection(void *context, qdr_connection_t *qdr_conn, qdr_error_t *error)


### PR DESCRIPTION
…they have not yet received initial credit.  This will prevent stalling of deliveries that arrive before the link is fully attached.