### PR TITLE
DISPATCH-1328 Added deliveries_delayed statistics to /metrics results

### DIFF
--- a/include/qpid/dispatch/router_core.h
+++ b/include/qpid/dispatch/router_core.h
@@ -842,6 +842,8 @@ typedef struct {
     size_t deliveries_transit;
     size_t deliveries_ingress_route_container;
     size_t deliveries_egress_route_container;
+    size_t deliveries_delayed_1sec;
+    size_t deliveries_delayed_10sec;
 }  qdr_global_stats_t;
 ALLOC_DECLARE(qdr_global_stats_t);
 typedef void (*qdr_global_stats_handler_t) (void *context);

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -469,6 +469,8 @@ static int stats_get_deliveries_egress(qdr_global_stats_t *stats) { return stats
 static int stats_get_deliveries_transit(qdr_global_stats_t *stats) { return stats->deliveries_transit; }
 static int stats_get_deliveries_ingress_route_container(qdr_global_stats_t *stats) { return stats->deliveries_ingress_route_container; }
 static int stats_get_deliveries_egress_route_container(qdr_global_stats_t *stats) { return stats->deliveries_egress_route_container; }
+static int stats_get_deliveries_delayed_1sec(qdr_global_stats_t *stats) { return stats->deliveries_delayed_1sec; }
+static int stats_get_deliveries_delayed_10sec(qdr_global_stats_t *stats) { return stats->deliveries_delayed_10sec; }
 
 static struct metric_definition metrics[] = {
     {"connections", "gauge", stats_get_connections},
@@ -487,7 +489,9 @@ static struct metric_definition metrics[] = {
     {"deliveries_egress", "counter", stats_get_deliveries_egress},
     {"deliveries_transit", "counter", stats_get_deliveries_transit},
     {"deliveries_ingress_route_container", "counter", stats_get_deliveries_ingress_route_container},
-    {"deliveries_egress_route_container", "counter", stats_get_deliveries_egress_route_container}
+    {"deliveries_egress_route_container", "counter", stats_get_deliveries_egress_route_container},
+    {"deliveries_delayed_1sec", "counter", stats_get_deliveries_delayed_1sec},
+    {"deliveries_delayed_10sec", "counter", stats_get_deliveries_delayed_10sec}
 };
 static size_t metrics_length = sizeof(metrics)/sizeof(metrics[0]);
 

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -776,6 +776,8 @@ static void qdr_global_stats_request_CT(qdr_core_t *core, qdr_action_t *action, 
         stats->deliveries_transit = core->deliveries_transit;
         stats->deliveries_ingress_route_container = core->deliveries_ingress_route_container;
         stats->deliveries_egress_route_container = core->deliveries_egress_route_container;
+        stats->deliveries_delayed_1sec = core->deliveries_delayed_1sec;
+        stats->deliveries_delayed_1sec = core->deliveries_delayed_10sec;
     }
     qdr_general_work_t *work = qdr_general_work(qdr_post_global_stats_response);
     work->stats_handler = action->args.stats_request.handler;

--- a/tests/system_tests_http.py
+++ b/tests/system_tests_http.py
@@ -170,6 +170,8 @@ class RouterTestHttp(TestCase):
             data = result.read().decode('utf-8')
             assert('connections' in data)
             assert('deliveries_ingress' in data)
+            assert('deliveries_delayed_1sec' in data)
+            assert('deliveries_delayed_10sec' in data)
 
         # Sequential calls on multiple ports
         for port in r.ports: test(port)


### PR DESCRIPTION
This time without the formatting changes and with just the changed needed to add deliveries_delayed_1sec and deliveries_delayed_10sec to the /metrics output.
Also modified the test_http_metrics test to make sure the new stats are output.