### PR TITLE
DISPATCH-1310: refactor delivery peer handling

### DIFF
--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -130,11 +130,9 @@ void qdrc_endpoint_send_CT(qdr_core_t *core, qdrc_endpoint_t *ep, qdr_delivery_t
 
 qdr_delivery_t *qdrc_endpoint_delivery_CT(qdr_core_t *core, qdrc_endpoint_t *endpoint, qd_message_t *message)
 {
-    qdr_delivery_t *dlv = new_qdr_delivery_t();
+    qdr_delivery_t *dlv = qdr_delivery(endpoint->link);
     uint64_t       *tag = (uint64_t*) dlv->tag;
 
-    ZERO(dlv);
-    set_safe_ptr_qdr_link_t(endpoint->link, &dlv->link_sp);
     dlv->msg            = message;
     *tag                = core->next_tag++;
     dlv->tag_length = 8;

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -57,7 +57,8 @@ W_THREADS=2
 # check for leaks of the following entities
 ALLOC_STATS=["qd_message_t",
              "qd_buffer_t",
-             "qdr_delivery_t"]
+             "qdr_delivery_in_t",
+             "qdr_delivery_out_t"]
 
 class MulticastLinearTest(TestCase):
     """


### PR DESCRIPTION
Moves as much of the incoming delivery --> outgoing deliveries logic
to the delivery.c module.