### PR TITLE
DISPATCH-1348 - Allocate qdr_error_t objects only when necessary. Pre…

### DIFF
--- a/src/router_core/error.c
+++ b/src/router_core/error.c
@@ -37,35 +37,25 @@ qdr_error_t *qdr_error_from_pn(pn_condition_t *pn)
     qdr_error_t *error = 0;
 
     const char *name = pn_condition_get_name(pn);
-
-    if (name && *name) {
-        if (!error) {
-            error = new_qdr_error_t();
-            ZERO(error);
-        }
-        error->name = qdr_field(name);
-    }
-
     const char *desc = pn_condition_get_description(pn);
-
-    if (desc && *desc) {
-        if (!error) {
-            error = new_qdr_error_t();
-            ZERO(error);
-        }
-        error->description = qdr_field(desc);
-    }
-
-
     pn_data_t *info = pn_condition_info(pn);
+    bool is_byt_size_gt_zero = false;
 
     if (info) {
         pn_bytes_t byt = pn_data_get_bytes(info);
-        if (byt.size > 0) {
-            if (!error) {
-                error = new_qdr_error_t();
-                ZERO(error);
-            }
+        if (byt.size > 0)
+            is_byt_size_gt_zero = true;
+    }
+
+    if ((name && *name) || (desc && *desc) || is_byt_size_gt_zero) {
+        error = new_qdr_error_t();
+        ZERO(error);
+        if (name && *name)
+            error->name = qdr_field(name);
+        if(desc && *desc)
+            error->description = qdr_field(desc);
+
+        if (is_byt_size_gt_zero) {
             error->info = pn_data(0);
             pn_data_copy(error->info, info);
         }

--- a/src/router_core/error.c
+++ b/src/router_core/error.c
@@ -34,19 +34,42 @@ qdr_error_t *qdr_error_from_pn(pn_condition_t *pn)
     if (!pn)
         return 0;
 
-    qdr_error_t *error = new_qdr_error_t();
-    ZERO(error);
+    qdr_error_t *error = 0;
 
     const char *name = pn_condition_get_name(pn);
-    if (name && *name)
+
+    if (name && *name) {
+        if (!error) {
+            error = new_qdr_error_t();
+            ZERO(error);
+        }
         error->name = qdr_field(name);
+    }
 
     const char *desc = pn_condition_get_description(pn);
-    if (desc && *desc)
-        error->description = qdr_field(desc);
 
-    error->info = pn_data(0);
-    pn_data_copy(error->info, pn_condition_info(pn));
+    if (desc && *desc) {
+        if (!error) {
+            error = new_qdr_error_t();
+            ZERO(error);
+        }
+        error->description = qdr_field(desc);
+    }
+
+
+    pn_data_t *info = pn_condition_info(pn);
+
+    if (info) {
+        pn_bytes_t byt = pn_data_get_bytes(info);
+        if (byt.size > 0) {
+            if (!error) {
+                error = new_qdr_error_t();
+                ZERO(error);
+            }
+            error->info = pn_data(0);
+            pn_data_copy(error->info, info);
+        }
+    }
 
     return error;
 }

--- a/src/router_core/error.c
+++ b/src/router_core/error.c
@@ -95,6 +95,9 @@ void qdr_error_free(qdr_error_t *error)
 
 void qdr_error_copy(qdr_error_t *from, pn_condition_t *to)
 {
+    if (from == 0)
+        return;
+
     if (from->name) {
         unsigned char *name = qd_iterator_copy(from->name->iterator);
         pn_condition_set_name(to, (char*) name);
@@ -137,6 +140,9 @@ char *qdr_error_name(const qdr_error_t *err)
 
 pn_data_t *qdr_error_info(const qdr_error_t *err)
 {
+    if (err == 0)
+        return 0;
+
     return err->info;
 }
 

--- a/src/router_core/error.c
+++ b/src/router_core/error.c
@@ -50,9 +50,11 @@ qdr_error_t *qdr_error_from_pn(pn_condition_t *pn)
     if ((name && *name) || (desc && *desc) || is_byt_size_gt_zero) {
         error = new_qdr_error_t();
         ZERO(error);
+
         if (name && *name)
             error->name = qdr_field(name);
-        if(desc && *desc)
+
+        if (desc && *desc)
             error->description = qdr_field(desc);
 
         if (is_byt_size_gt_zero) {


### PR DESCRIPTION
…viously, these objects were always getting created even in the absence of an error