### PR TITLE
DISPATCH-1350 - Update logging and management doc

### DIFF
--- a/docs/books/user-guide/logging.adoc
+++ b/docs/books/user-guide/logging.adoc
@@ -48,8 +48,8 @@ In this example, `ROUTER` logs show the lifecycle of a connection and a link tha
 2019-04-05 14:54:38.041103 -0400 ROUTER (info) [C1][L6] Link lost: del=1 presett=0 psdrop=0 acc=1 rej=0 rel=0 mod=0 delay1=0 delay10=0 // <3>
 2019-04-05 14:54:38.041154 -0400 ROUTER (info) [C1] Connection Closed // <4>
 ----
-<1> The connection is opened. Each connection is identified with a unique ID (`C1`). The log also shows some information about the connection.
-<2> A link is attached over the connection. The link is identified with a unique ID (`L1`). The log also shows the direction of the link, and the source and target addresses.
+<1> The connection is opened. Each connection has a unique ID (`C1`). The log also shows some information about the connection.
+<2> A link is attached over the connection. The link is identified with a unique ID (`L6`). The log also shows the direction of the link, and the source and target addresses.
 <3> The link is detached. The log shows the link's terminal statistics.
 <4> The connection is closed.
 ====
@@ -156,7 +156,7 @@ Tue Jun  7 14:36:54 2016 MESSAGE (trace) Sending Message{to='amqp:/_topo/0/Route
 
 === The `SERVER` Logging Module
 
-This module provides information about how the router is listening for and connecting to other containers in the network (such as clients, routers, and brokers). This includes the state of AMQP messages sent and received by the broker (open, begin, attach, transfer, flow, and so on), and the related content of those messages.
+This module provides information about how the router is listening for and connecting to other containers in the network (such as clients, routers, and brokers). This information includes the state of AMQP messages sent and received by the broker (open, begin, attach, transfer, flow, and so on), and the related content of those messages.
 
 For example, this log shows details about how the router handled a link attachment:
 

--- a/docs/books/user-guide/logging.adoc
+++ b/docs/books/user-guide/logging.adoc
@@ -37,28 +37,22 @@ The default module. This module applies defaults to all of the other logging mod
 
 This module provides information and statistics about the local router. This includes how the router connects to other routers in the network, and information about the remote destinations that are directly reachable from the router (link routes, waypoints, autolinks, and so on).
 
-In this example, on `Router.A`, the `ROUTER` log shows that `Router.B` is the next hop. It also shows the cost for `Router.A` to reach the other routers on the network:
+.Using the `ROUTER` log to trace connections and links
+====
+In this example, `ROUTER` logs show the lifecycle of a connection and a link that is associated with it.
 
 [options="nowrap"]
 ----
-Tue Jun  7 13:28:27 2016 ROUTER (trace) Node Router.C next hop set: Router.B
-Tue Jun  7 13:28:27 2016 ROUTER (trace) Node Router.C valid origins: []
-Tue Jun  7 13:28:27 2016 ROUTER (trace) Node Router.C cost: 2
-Tue Jun  7 13:28:27 2016 ROUTER (trace) Node Router.B valid origins: []
-Tue Jun  7 13:28:27 2016 ROUTER (trace) Node Router.B cost: 1
+2019-04-05 14:54:38.037248 -0400 ROUTER (info) [C1] Connection Opened: dir=in host=127.0.0.1:55440 vhost= encrypted=no auth=no user=anonymous container_id=95e55424-6c0a-4a5c-8848-65a3ea5cc25a props= // <1>
+2019-04-05 14:54:38.038137 -0400 ROUTER (info) [C1][L6] Link attached: dir=in source={<none> expire:sess} target={$management expire:sess} // <2>
+2019-04-05 14:54:38.041103 -0400 ROUTER (info) [C1][L6] Link lost: del=1 presett=0 psdrop=0 acc=1 rej=0 rel=0 mod=0 delay1=0 delay10=0 // <3>
+2019-04-05 14:54:38.041154 -0400 ROUTER (info) [C1] Connection Closed // <4>
 ----
-
-On `Router.B`, the `ROUTER` log provides more information about valid origins:
-
-[options="nowrap"]
-----
-Tue Jun  7 13:28:25 2016 ROUTER (trace) Node Router.C cost: 1
-Tue Jun  7 13:28:26 2016 ROUTER (trace) Node Router.A created: maskbit=2
-Tue Jun  7 13:28:26 2016 ROUTER (trace) Node Router.A link set: link_id=1
-Tue Jun  7 13:28:26 2016 ROUTER (trace) Node Router.A valid origins: ['Router.C']
-Tue Jun  7 13:28:26 2016 ROUTER (trace) Node Router.A cost: 1
-Tue Jun  7 13:28:27 2016 ROUTER (trace) Node Router.C valid origins: ['Router.A']
-----
+<1> The connection is opened. Each connection is identified with a unique ID (`C1`). The log also shows some information about the connection.
+<2> A link is attached over the connection. The link is identified with a unique ID (`L1`). The log also shows the direction of the link, and the source and target addresses.
+<3> The link is detached. The log shows the link's terminal statistics.
+<4> The connection is closed.
+====
 
 === The `ROUTER_HELLO` Logging Module
 
@@ -90,9 +84,9 @@ Tue Jun  7 13:50:19 2016 ROUTER_HELLO (trace) RCVD: HELLO(id=Router.C area=0 ins
 <2> `Router.B` received a Hello message from `Router.A`, which can only see `Router.B`.
 <3> `Router.B` received a Hello message from `Router.C`, which can only see `Router.B`.
 
-=== The `ROUTER_LS` Logging Module 
+=== The `ROUTER_LS` Logging Module
 
-This module provides information about link-state data between routers, including Router Advertisement (RA), Link State Request (LSR), and Link State Update (LSU) messages. 
+This module provides information about link-state data between routers, including Router Advertisement (RA), Link State Request (LSR), and Link State Update (LSU) messages.
 
 Periodically, each router sends an LSR to the other routers and receives an LSU with the requested information. Exchanging the above information, each router can compute the next hops in the topology, and the related costs.
 
@@ -100,8 +94,8 @@ This example shows the RA, LSR, and LSU messages sent between three routers:
 
 [options="nowrap"]
 ----
-Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSR(id=Router.A area=0) to: Router.C //
-Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSR(id=Router.A area=0) to: Router.B //
+Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSR(id=Router.A area=0) to: Router.C
+Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSR(id=Router.A area=0) to: Router.B
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: RA(id=Router.A area=0 inst=1465308600 ls_seq=1 mobile_seq=1) // <1>
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) RCVD: LSU(id=Router.B area=0 inst=1465308595 ls_seq=2 ls=LS(id=Router.B area=0 ls_seq=2 peers={'Router.A': 1L, 'Router.C': 1L})) // <2>
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) RCVD: LSR(id=Router.B area=0)
@@ -109,7 +103,7 @@ Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSU(id=Router.A area=0 inst=146
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) RCVD: RA(id=Router.C area=0 inst=1465308592 ls_seq=1 mobile_seq=0)
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSR(id=Router.A area=0) to: Router.C
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) RCVD: LSR(id=Router.C area=0) // <3>
-Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSU(id=Router.A area=0 // inst=1465308600 ls_seq=1 ls=LS(id=Router.A area=0 ls_seq=1 peers={'Router.B': 1}))
+Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) SENT: LSU(id=Router.A area=0 inst=1465308600 ls_seq=1 ls=LS(id=Router.A area=0 ls_seq=1 peers={'Router.B': 1}))
 Tue Jun  7 14:10:02 2016 ROUTER_LS (trace) RCVD: LSU(id=Router.C area=0 inst=1465308592 ls_seq=1 ls=LS(id=Router.C area=0 ls_seq=1 peers={'Router.B': 1L})) // <4>
 Tue Jun  7 14:10:03 2016 ROUTER_LS (trace) Computed next hops: {'Router.C': 'Router.B', 'Router.B': 'Router.B'} // <5>
 Tue Jun  7 14:10:03 2016 ROUTER_LS (trace) Computed costs: {'Router.C': 2L, 'Router.B': 1}
@@ -162,7 +156,7 @@ Tue Jun  7 14:36:54 2016 MESSAGE (trace) Sending Message{to='amqp:/_topo/0/Route
 
 === The `SERVER` Logging Module
 
-This module provides information about how the router is listening for and connecting to other containers in the network (such as clients, routers, and brokers). This includes the state of AMQP messages sent and received by the broker (open, begin, attach, transfer, flow, and so on), and the related content of those messages. 
+This module provides information about how the router is listening for and connecting to other containers in the network (such as clients, routers, and brokers). This includes the state of AMQP messages sent and received by the broker (open, begin, attach, transfer, flow, and so on), and the related content of those messages.
 
 For example, this log shows details about how the router handled a link attachment:
 

--- a/docs/books/user-guide/managing-using-qdmanage.adoc
+++ b/docs/books/user-guide/managing-using-qdmanage.adoc
@@ -53,29 +53,61 @@ For example, the following command executes a query operation on a router, and t
 $ qdmanage query --type listener
 [
   {
-    "stripAnnotations": "both", 
-    "addr": "127.0.0.1", 
-    "multiTenant": false, 
-    "requireSsl": false, 
-    "idleTimeoutSeconds": 16, 
-    "saslMechanisms": "ANONYMOUS", 
-    "maxFrameSize": 16384, 
-    "requireEncryption": false, 
-    "host": "0.0.0.0", 
-    "cost": 1, 
-    "role": "normal", 
-    "http": false, 
-    "maxSessions": 32768, 
-    "authenticatePeer": false, 
-    "type": "org.apache.qpid.dispatch.listener", 
-    "port": "amqp", 
-    "identity": "listener/0.0.0.0:amqp", 
+    "stripAnnotations": "both",
+    "addr": "127.0.0.1",
+    "multiTenant": false,
+    "requireSsl": false,
+    "idleTimeoutSeconds": 16,
+    "saslMechanisms": "ANONYMOUS",
+    "maxFrameSize": 16384,
+    "requireEncryption": false,
+    "host": "0.0.0.0",
+    "cost": 1,
+    "role": "normal",
+    "http": false,
+    "maxSessions": 32768,
+    "authenticatePeer": false,
+    "type": "org.apache.qpid.dispatch.listener",
+    "port": "amqp",
+    "identity": "listener/0.0.0.0:amqp",
     "name": "listener/0.0.0.0:amqp"
   }
 ]
 ----
 
 For more information about `qdmanage`, see the {qdmanageManPageLink}.
+
+== Closing a connection
+
+If a consumer is processing messages too slowly, or has stopped processing messages without settling their deliveries, you can close the connection. By closing the connection, the "stuck" deliveries will be released, and they can be redelivered to a different consumer.
+
+.Procedure
+
+. Find the ID of the connection with the slow consumer.
++
+--
+This command lists the connections for a router in the router network:
+
+[options="nowrap"]
+----
+$ qdstat -c -r Router.A
+Connections
+id    host                        container                              role             dir  security     authentication  tenant
+==================================================================================================================================
+  2   127.0.0.1:5672                                                     route-container  out  no-security  anonymous-user
+  10  127.0.0.1:5001               Router.B                              inter-router     out  no-security  anonymous-user
+  12  localhost.localdomain:42972  161211fe-ba9e-4726-9996-52d6962d1276  normal           in   no-security  anonymous-user
+  14  localhost.localdomain:42980  a35fcc78-63d9-4bed-b57c-053969c38fda  normal           in   no-security  anonymous-user
+  15  localhost.localdomain:42982  0a03aa5b-7c45-4500-8b38-db81d01ce651  normal           in   no-security  anonymous-user
+----
+--
+
+. Close the connection by setting its `adminStatus` to `deleted`.
++
+[options="nowrap"]
+----
+$ qdmanage update --type=connection --id=12 adminStatus=deleted
+----
 
 == Managing Network Connections
 
@@ -132,7 +164,7 @@ a|
 +
 [options="nowrap"]
 ----
-qdmanage create --stdin 
+qdmanage create --stdin
 ----
 . Configure the listeners using a JSON map:
 +
@@ -156,7 +188,7 @@ a|
 +
 [options="nowrap"]
 ----
-qdmanage update --stdin 
+qdmanage update --stdin
 ----
 . Configure the listeners using a JSON map:
 +
@@ -238,7 +270,7 @@ a|
 +
 [options="nowrap"]
 ----
-qdmanage create --stdin 
+qdmanage create --stdin
 ----
 . Configure the connectors using a JSON map:
 +
@@ -262,7 +294,7 @@ a|
 +
 [options="nowrap"]
 ----
-qdmanage update --stdin 
+qdmanage update --stdin
 ----
 . Configure the connectors using a JSON map:
 +

--- a/docs/books/user-guide/managing-using-qdmanage.adoc
+++ b/docs/books/user-guide/managing-using-qdmanage.adoc
@@ -79,7 +79,7 @@ For more information about `qdmanage`, see the {qdmanageManPageLink}.
 
 == Closing a connection
 
-If a consumer is processing messages too slowly, or has stopped processing messages without settling their deliveries, you can close the connection. By closing the connection, the "stuck" deliveries will be released, and they can be redelivered to a different consumer.
+If a consumer is processing messages too slowly, or has stopped processing messages without settling its deliveries, you can close the connection. When you close the connection, the "stuck" deliveries are released.
 
 .Procedure
 


### PR DESCRIPTION
Replaced the example in the ROUTER log doc with a new example that demonstrates how to use the log to trace a connection and its link.

Added a new procedure for closing a connection.