### PR TITLE
DISPATCH-1354: Annotation processing performance improvements

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -112,6 +112,14 @@ extern const char * const QD_MA_TRACE;    ///< Trace
 extern const char * const QD_MA_TO;       ///< To-Override
 extern const char * const QD_MA_PHASE;    ///< Phase for override address
 extern const char * const QD_MA_CLASS;    ///< Message-Class
+
+#define QD_MA_PREFIX_LEN  (9)
+#define QD_MA_INGRESS_LEN (16)
+#define QD_MA_TRACE_LEN   (14)
+#define QD_MA_TO_LEN      (11)
+#define QD_MA_PHASE_LEN   (14)
+#define QD_MA_CLASS_LEN   (14)
+
 extern const int          QD_MA_MAX_KEY_LEN;  ///< strlen of longest key name
 extern const int          QD_MA_N_KEYS;       ///< number of router annotation keys
 extern const int          QD_MA_FILTER_LEN;   ///< size of annotation filter buffer

--- a/include/qpid/dispatch/parse.h
+++ b/include/qpid/dispatch/parse.h
@@ -301,6 +301,17 @@ void qd_parse_annotations(
     qd_iterator_pointer_t *blob_pointer,
     uint32_t              *blob_item_count);
 
+/**
+ * Identify which annotation is being parsed
+ */
+typedef enum {
+    QD_MAE_INGRESS,
+    QD_MAE_TRACE,
+    QD_MAE_TO,
+    QD_MAE_PHASE,
+    QD_MAE_NONE
+} qd_ma_enum_t;
+
 ///@}
 
 #endif


### PR DESCRIPTION
Message annotation processing on received messages stages key names
byte by byte into a flat buffer and then uses strcmp to check them.

Easy improvements are:

 * Use name in raw buffer if it does not cross a buffer boundary
 * If name crosses a boundary then use memmoves to get the name in chunks
 * Check the name prefix only once and then check variable parts of name strings
 * Don't create unnecessary qd_iterators and qd_parsed_fields
 * Don't check names whose lengths differ from the given keys