### PR TITLE
DISPATCH-1362 - Remove recursive call to qdr_check_addr_CT during cor…

### DIFF
--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -1173,7 +1173,15 @@ void qdr_check_addr_CT(qdr_core_t *core, qdr_address_t *addr)
         && addr->tracked_deliveries == 0
         && addr->core_endpoint == 0
         && addr->fallback_for == 0) {
+        qdr_address_t *fallback = addr->fallback;
         qdr_core_remove_address(core, addr);
+
+        //
+        // If the address being removed had a fallback address, check to see if that
+        // address should now also be removed.
+        //
+        if (!!fallback)
+            qdr_check_addr_CT(core, fallback);
     }
 }
 

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -519,10 +519,13 @@ void qdr_core_remove_address(qdr_core_t *core, qdr_address_t *addr)
         cr = DEQ_HEAD(addr->conns);
     }
 
-    if (!!addr->fallback) {
+    //
+    // If there are any fallback-related linkages, disconnect them.
+    //
+    if (!!addr->fallback)
         addr->fallback->fallback_for = 0;
-        qdr_check_addr_CT(core, addr->fallback);
-    }
+    if (!!addr->fallback_for)
+        addr->fallback_for->fallback = 0;
 
     free(addr->add_prefix);
     free(addr->del_prefix);


### PR DESCRIPTION
…e shutdown.  This removes a window of opportunity for an invalid free during shutdown.