### PR TITLE
DISPATCH-1300 - doc default httpRootDir as being stand-alone console install path

### DIFF
--- a/console/stand-alone/README.md
+++ b/console/stand-alone/README.md
@@ -43,7 +43,7 @@ The console will automatically connect to the router at localhost:5673
 
 ## To disable the console and still allow the router to respond to other http traffic
 
-- in the listener portion of the config file, add an httpRoot: None
+- in the listener portion of the config file, add an httpRootDir: None
 
 ```
 listener {
@@ -51,7 +51,7 @@ listener {
     host: 0.0.0.0
     port: 5673
     http: true
-    httpRoot: None
+    httpRootDir: None
     saslMechanisms: ANONYMOUS
 }
 ```

--- a/docs/books/user-guide/using-console.adoc
+++ b/docs/books/user-guide/using-console.adoc
@@ -53,7 +53,7 @@ listener {
 
 `http`:: Set this attribute to `true` to specify that this `listener` should accept HTTP connections instead of plain AMQP connections.
 
-`httpRootDir`:: Specify the absolute path to the directory that contains the web console HTML files. The default directory is `/usr/share/qpid-dispatch/console`.
+`httpRootDir`:: Specify the absolute path to the directory that contains the web console HTML files. The default directory is the stand-alone console installation directory, usually `/usr/share/qpid-dispatch/console`.
 --
 
 . If you want to secure access to the console, secure the `listener`.

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -869,7 +869,7 @@
                 },
                 "httpRootDir": {
                     "type": "path",
-                    "description": "Absolute path to a directory from which to serve static HTML files. Defaults to the stand-alone console installation directory, e.g. /usr/share/qpid-dispatch/console.",
+                    "description": "Absolute path to a directory from which to serve static HTML files. Defaults to the stand-alone console installation directory (typically /usr/share/qpid-dispatch/console).",
                     "deprecationName": "httpRoot",
                     "create": true
                 },

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -869,7 +869,7 @@
                 },
                 "httpRootDir": {
                     "type": "path",
-                    "description": "Absolute path to a directory from which to serve static HTML files. For example, /usr/share/qpid-dispatch/console.",
+                    "description": "Absolute path to a directory from which to serve static HTML files. Defaults to the stand-alone console installation directory, e.g. /usr/share/qpid-dispatch/console.",
                     "deprecationName": "httpRoot",
                     "create": true
                 },


### PR DESCRIPTION
I am intentionally not mentioning the CMAKE_INSTALL_PREFIX here. I hope
people who know of it can guess that it plays a role in determining the
console installation directory.