### PR TITLE
DISPATCH-1422: Create global policy denial count

### DIFF
--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1831,7 +1831,17 @@
                 },
                 "connectionsProcessed": {"type": "integer", "graph": true},
                 "connectionsDenied": {"type": "integer", "graph": true},
-                "connectionsCurrent": {"type": "integer", "graph": true}
+                "connectionsCurrent": {"type": "integer", "graph": true},
+                "linksDenied": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The sum of all vhost sender and receiver denials."
+                },
+                "totalDenials": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The total number of connection and link denials."
+                }
             }
         },
 

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -83,6 +83,8 @@ class PolicyKeys(object):
     KW_CONNECTIONS_APPROVED     = "connectionsApproved"
     KW_CONNECTIONS_DENIED       = "connectionsDenied"
     KW_CONNECTIONS_CURRENT      = "connectionsCurrent"
+    KW_LINKS_DENIED             = "linksDenied"
+    KW_TOTAL_DENIALS            = "totalDenials"
     KW_PER_USER_STATE           = "perUserState"
     KW_PER_HOST_STATE           = "perHostState"
 

--- a/src/policy.c
+++ b/src/policy.c
@@ -40,9 +40,13 @@
 // The current statistics maintained globally through multiple
 // reconfiguration of policy settings.
 //
+static sys_mutex_t *stats_lock = 0;
+
 static int n_connections = 0;
 static int n_denied = 0;
 static int n_processed = 0;
+static int n_links_denied = 0;
+static int n_total_denials = 0;
 
 //
 // error conditions signaled to effect denial
@@ -106,6 +110,7 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->max_connection_limit = 65535;
     policy->tree_lock            = sys_mutex();
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
+    stats_lock                   = sys_mutex();
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");
     return policy;
@@ -123,6 +128,8 @@ void qd_policy_free(qd_policy_t *policy)
         sys_mutex_free(policy->tree_lock);
     hostname_tree_free(policy->hostname_tree);
     free(policy);
+    if (stats_lock)
+        sys_mutex_free(stats_lock);
 }
 
 //
@@ -200,9 +207,21 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
  **/
 qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
     // Return global stats
-    if (!qd_entity_set_long(entity, "connectionsProcessed", n_processed) &&
-        !qd_entity_set_long(entity, "connectionsDenied", n_denied) &&
-        !qd_entity_set_long(entity, "connectionsCurrent", n_connections)
+    int np, nd, nc, nl, nt;
+    sys_mutex_lock(stats_lock);
+    {
+        np = n_processed;
+        nd = n_denied;
+        nc = n_connections;
+        nl = n_links_denied;
+        nt = n_total_denials;
+    }
+    sys_mutex_unlock(stats_lock);
+    if (!qd_entity_set_long(entity, "connectionsProcessed", np) &&
+        !qd_entity_set_long(entity, "connectionsDenied", nd) &&
+        !qd_entity_set_long(entity, "connectionsCurrent", nc) &&
+        !qd_entity_set_long(entity, "linksDenied", nl) &&
+        !qd_entity_set_long(entity, "totalDenials", nt)
     )
         return QD_ERROR_NONE;
     return qd_error_code();
@@ -220,17 +239,25 @@ qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
 bool qd_policy_socket_accept(qd_policy_t *policy, const char *hostname)
 {
     bool result = true;
+    int nc;
+    sys_mutex_lock(stats_lock);
     if (n_connections < policy->max_connection_limit) {
         // connection counted and allowed
-        n_connections += 1;
-        qd_log(policy->log_source, QD_LOG_TRACE, "ALLOW Connection '%s' based on global connection count. nConnections= %d", hostname, n_connections);
+        n_connections++;
+        n_processed++;
+        nc = n_connections;
+        sys_mutex_unlock(stats_lock);
+        qd_log(policy->log_source, QD_LOG_TRACE, "ALLOW Connection '%s' based on global connection count. nConnections= %d", hostname, nc);
     } else {
         // connection denied
         result = false;
-        n_denied += 1;
-        qd_log(policy->log_source, QD_LOG_INFO, "DENY Connection '%s' based on global connection count. nConnections= %d", hostname, n_connections);
+        n_denied++;
+        n_total_denials++;
+        n_processed++;
+        nc = n_connections;
+        sys_mutex_unlock(stats_lock);
+        qd_log(policy->log_source, QD_LOG_INFO, "DENY Connection '%s' based on global connection count. nConnections= %d", hostname, nc);
     }
-    n_processed += 1;
     return result;
 }
 
@@ -239,8 +266,10 @@ bool qd_policy_socket_accept(qd_policy_t *policy, const char *hostname)
 //
 void qd_policy_socket_close(qd_policy_t *policy, const qd_connection_t *conn)
 {
-    n_connections -= 1;
+    sys_mutex_lock(stats_lock);
+    n_connections--;
     assert (n_connections >= 0);
+    sys_mutex_unlock(stats_lock);
     if (policy->enableVhostPolicy) {
         // HACK ALERT: TODO: This should be deferred to a Python thread
         qd_python_lock_state_t lock_state = qd_python_lock();
@@ -529,6 +558,9 @@ void qd_policy_deny_amqp_session(pn_session_t *ssn, qd_connection_t *qd_conn)
     (void) pn_condition_set_name(       cond, QD_AMQP_COND_RESOURCE_LIMIT_EXCEEDED);
     (void) pn_condition_set_description(cond, SESSION_DISALLOWED);
     pn_session_close(ssn);
+    sys_mutex_lock(stats_lock);
+    n_total_denials++;
+    sys_mutex_unlock(stats_lock);
     if (qd_conn->policy_settings->denialCounts) {
         qd_conn->policy_settings->denialCounts->sessionDenied++;
     }
@@ -591,6 +623,10 @@ void _qd_policy_deny_amqp_link(pn_link_t *link, qd_connection_t *qd_conn, const 
     (void) pn_condition_set_name(       cond, condition);
     (void) pn_condition_set_description(cond, LINK_DISALLOWED);
     pn_link_close(link);
+    sys_mutex_lock(stats_lock);
+    n_links_denied++;
+    n_total_denials++;
+    sys_mutex_unlock(stats_lock);
 }
 
 


### PR DESCRIPTION
Policy status creates two global counts that get aggregated for
all links and connections:

* linksDenied - sum of all vhost sender and receiver denials
* totalDenials - sum of linksDenied, connectionsDenied, and
                 sessionsDenied

Implementation adds locks around changing shared static and
generating statistic reports for management.

Self test is added on to the PolicyVhostOverride as that test puts
its statistics into a known vhost. Otherwise stats could go into
system-specific vhosts like '0.0.0.0', '::0', 'localhost', etc.
adding unneeded complexity to the analysis.