### PR TITLE
DISPATCH-1443: use python unittest library, fail back to unittest2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,23 +65,33 @@ elseif(PYTHON_VERSION_MAJOR STREQUAL 2)
     set(PY_STRING "python")
 endif()
 
-# Find python-unittest2
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import unittest2"
-			RESULT_VARIABLE UNITTEST2_MISSING
-			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 enable_testing()
-if(UNITTEST2_MISSING)
-  message(STATUS "WARNING: python-unittest2 is not installed. ***unit tests cannot be run***" )
-  # add bogus test for folk who may have missed the cmake warning
-  add_test(WARNING_python_unittest2_module_NOT_INSTALLED false)
-else(UNITTEST2_MISSING)
-  if    (NOT DEFINED DISPATCH_TEST_TIMEOUT)
-    set             (DISPATCH_TEST_TIMEOUT "360")
+
+# python unittest
+# For versions < 2.7 the developer needs to install the python-unittest2
+# module (available via 'pip install python-unittest2'
+#
+if(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
+  set(PYTHON_TEST_COMMAND "unit2")
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import unittest2"
+                  RESULT_VARIABLE UNITTEST_MISSING
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(UNITTEST_MISSING)
+    message(WARNING "python-unittest2 is not installed. ***unit tests cannot be run***\ntry 'pip install python-unittest2' to install python-unittest2")
+    # add bogus test for folk who may have missed the cmake warning
+    add_test(WARNING_python_unittest2_module_NOT_INSTALLED false)
+  endif(UNITTEST_MISSING)
+else(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
+  set(PYTHON_TEST_COMMAND "-m" "unittest")
+endif(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
+
+if(NOT UNITTEST_MISSING)
+  if (NOT DEFINED DISPATCH_TEST_TIMEOUT)
+    set(DISPATCH_TEST_TIMEOUT "360")
   endif (NOT DEFINED DISPATCH_TEST_TIMEOUT)
   SET(DART_TESTING_TIMEOUT ${DISPATCH_TEST_TIMEOUT} CACHE STRING "Default CTest timeout in seconds")
   include (CTest)
-endif(UNITTEST2_MISSING)
-
+endif(NOT UNITTEST_MISSING)
 
 set (SO_VERSION_MAJOR 2)
 set (SO_VERSION_MINOR 0)
@@ -216,11 +226,11 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/system_tests_authz_service_plug
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/system_tests_handle_failover.py.in ${CMAKE_CURRENT_SOURCE_DIR}/tests/system_tests_handle_failover.py)
 execute_process(COMMAND ${RUN} --sh OUTPUT_FILE config.sh)
 
-if (NOT UNITTEST2_MISSING)
+if (NOT UNITTEST_MISSING)
   file(GLOB SCRAPER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/tools/scraper/*.py)
   file(COPY ${SCRAPER_SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests/scraper/)
   add_subdirectory(tests)
-endif(NOT UNITTEST2_MISSING)
+endif(NOT UNITTEST_MISSING)
 add_subdirectory(python)
 add_subdirectory(router)
 add_subdirectory(docs)

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@
 ################# Begin code #######
 
 # Get the latest Centos version from dockerhub
-FROM centos:latest
+#FROM centos:latest  NEEDS JIRA DISPATCH-1444 FIXED!
+FROM centos:7
 
 MAINTAINER "dev@qpid.apache.org"
 
@@ -47,7 +48,7 @@ MAINTAINER "dev@qpid.apache.org"
 RUN yum -y install epel-release
 
 # now install the rest of the packages
-RUN yum -y install gcc cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 swig python-devel java-1.8.0-openjdk-devel git make doxygen valgrind emacs libuv libuv-devel libwebsockets-devel python-unittest2 && yum clean all -y
+RUN yum -y install gcc cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 swig python-devel java-1.8.0-openjdk-devel git make doxygen valgrind emacs libuv libuv-devel libwebsockets-devel && yum clean all -y
 
 # Create a main directory and clone the qpid-proton repo from github
 RUN mkdir /main && cd /main && git clone https://github.com/apache/qpid-proton.git  && cd /main/qpid-proton && mkdir /main/qpid-proton/build

--- a/README
+++ b/README
@@ -20,7 +20,15 @@ packages installed:
 - cyrus-sasl-devel
 - asciidoc (for building docs)
 - asciidoctor (for building docs)
-- python-unittest2 (python2-unittest2 on Fedora) (we use unittest2 for running python tests)
+
+The unit tests are implemented using Python's unittest library.
+Versions of Python versions prior to 2.7 do not have this library.  In
+order to run the unit tests using older versions of python the
+"python-unittest2" module must be installed.
+
+This may be available from your Linux distribution or via pip:
+
+  pip install python-unittest2
 
 Dispatch will not build on Windows.
 

--- a/dockerfiles/Dockerfile-fedora
+++ b/dockerfiles/Dockerfile-fedora
@@ -30,7 +30,7 @@ FROM fedora:latest
 MAINTAINER "dev@qpid.apache.org"
 
 # Install all the required packages. Some in this list were picked off from proton's INSTALL.md (https://github.com/apache/qpid-proton/blob/master/INSTALL.md) and the rest are from dispatch (https://github.com/apache/qpid-dispatch/blob/master/README)
-RUN dnf -y install gcc cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 swig python-devel java-1.8.0-openjdk-devel git make doxygen valgrind emacs libuv libuv-devel libwebsockets-devel python-unittest2 && dnf clean all -y
+RUN dnf -y install gcc cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 swig python-devel java-1.8.0-openjdk-devel git make doxygen valgrind emacs libuv libuv-devel libwebsockets-devel && dnf clean all -y
 
 # Create a main directory and clone the qpid-proton repo from github
 RUN mkdir /main && cd /main && git clone https://gitbox.apache.org/repos/asf/qpid-proton.git  && cd /main/qpid-proton && mkdir /main/qpid-proton/build

--- a/dockerfiles/Dockerfile-fedora-only-python3
+++ b/dockerfiles/Dockerfile-fedora-only-python3
@@ -34,7 +34,7 @@ RUN dnf -y install gcc cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-
 
 # Remove python2 if it is already there. We want this environment to contain only python3
 RUN dnf -y remove python2
-RUN dnf -y install  python3-devel python3-unittest2
+RUN dnf -y install  python3-devel
 RUN dnf clean all -y
 
 RUN alternatives --install /usr/bin/python python /usr/bin/python3 1

--- a/dockerfiles/Dockerfile-ubuntu
+++ b/dockerfiles/Dockerfile-ubuntu
@@ -26,7 +26,7 @@ MAINTAINER "dev@qpid.apache.org"
 
 # Install all the required packages. Some in this list were picked off from proton's INSTALL.md (https://github.com/apache/qpid-proton/blob/master/INSTALL.md) and the rest are from dispatch (https://github.com/apache/qpid-dispatch/blob/master/README)
 RUN apt-get update && \
-    apt-get install -y automake libtool zlib1g-dev cmake libsasl2-dev libssl-dev python python-dev libuv1-dev sasl2-bin swig maven git python-unittest2 && \
+    apt-get install -y automake libtool zlib1g-dev cmake libsasl2-dev libssl-dev python python-dev libuv1-dev sasl2-bin swig maven git && \
     apt-get -y clean
 
 RUN git clone https://gitbox.apache.org/repos/asf/qpid-dispatch.git && cd /qpid-dispatch && git submodule add -b v2.1-stable https://github.com/warmcat/libwebsockets && git submodule add https://gitbox.apache.org/repos/asf/qpid-proton.git && git submodule update --init

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,9 +72,9 @@ add_test(unit_tests_size_1     ${TEST_WRAP} unit_tests_size 1)
 add_test(unit_tests            ${TEST_WRAP} unit_tests ${CMAKE_CURRENT_SOURCE_DIR}/threads4.conf)
 
 # Unit test python modules
-add_test(router_engine_test    ${TEST_WRAP} unit2 -v router_engine_test)
-add_test(management_test       ${TEST_WRAP} unit2 -v management)
-add_test(router_policy_test    ${TEST_WRAP} unit2 -v router_policy_test)
+add_test(router_engine_test    ${TEST_WRAP} ${PYTHON_TEST_COMMAND} -v router_engine_test)
+add_test(management_test       ${TEST_WRAP} ${PYTHON_TEST_COMMAND} -v management)
+add_test(router_policy_test    ${TEST_WRAP} ${PYTHON_TEST_COMMAND} -v router_policy_test)
 
 if(USE_LIBWEBSOCKETS)
   set(SYSTEM_TESTS_HTTP system_tests_http)
@@ -137,7 +137,7 @@ foreach(py_test_module
     system_tests_router_mesh
     )
 
-  add_test(${py_test_module} ${TEST_WRAP} unit2 -v ${py_test_module})
+  add_test(${py_test_module} ${TEST_WRAP} ${PYTHON_TEST_COMMAND} -v ${py_test_module})
   list(APPEND SYSTEM_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${py_test_module}.py)
 endforeach()
 

--- a/tests/router_engine_test.py
+++ b/tests/router_engine_test.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 
 import os
 import sys
-import unittest2 as unittest
 import mock                     # Mock definitions for tests.
 
 sys.path.append(os.path.join(os.environ["SOURCE_DIR"], "python"))
@@ -33,6 +32,7 @@ from qpid_dispatch_internal.router.engine import HelloProtocol, PathEngine, Node
 from qpid_dispatch_internal.router.data import LinkState, MessageHELLO, ProtocolVersion
 from qpid_dispatch.management.entity import EntityBase
 from system_test import main_module
+from system_test import unittest
 
 class Adapter(object):
     def __init__(self, domain):

--- a/tests/router_policy_test.py
+++ b/tests/router_policy_test.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
+from system_test import unittest
 
 from qpid_dispatch_internal.policy.policy_util import HostAddr, is_ipv6_enabled
 from qpid_dispatch_internal.policy.policy_util import HostStruct

--- a/tests/run_system_tests.py
+++ b/tests/run_system_tests.py
@@ -32,8 +32,8 @@ from __future__ import print_function
 import os
 import sys
 from fnmatch import fnmatch
-import unittest2 as unittest
 import system_test
+from system_test import unittest
 
 # Collect all system_tests_*.py scripts in the same directory as this script.
 test_modules = [os.path.splitext(f)[0] for f in os.listdir(system_test.DIR)

--- a/tests/system_tests_address_lookup.py
+++ b/tests/system_tests_address_lookup.py
@@ -22,11 +22,11 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 import time
 
 from system_test import TestCase, Qdrouterd, TIMEOUT
 from system_test import AsyncTestReceiver
+from system_test import unittest
 from test_broker import FakeBroker
 
 from proton import Disposition

--- a/tests/system_tests_auth_service_plugin.py
+++ b/tests/system_tests_auth_service_plugin.py
@@ -23,10 +23,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 
-import unittest2 as unittest
 import os
 from subprocess import PIPE, Popen
 from system_test import TestCase, Qdrouterd, main_module, SkipIfNeeded
+from system_test import unittest
 from proton import SASL
 from proton.handlers import MessagingHandler
 from proton.reactor import Container

--- a/tests/system_tests_authz_service_plugin.py.in
+++ b/tests/system_tests_authz_service_plugin.py.in
@@ -22,10 +22,10 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 import os, json
 from subprocess import PIPE, Popen, STDOUT
 from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, Process, SkipIfNeeded
+from system_test import unittest
 from proton import Array, Data, Message, SASL, symbol, UNDESCRIBED
 from proton.handlers import MessagingHandler
 from proton.reactor import Container

--- a/tests/system_tests_autolinks.py
+++ b/tests/system_tests_autolinks.py
@@ -23,11 +23,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 
-import unittest2 as unittest
 import json
 from threading import Timer
 from proton import Message
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, Process
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from subprocess import PIPE, STDOUT

--- a/tests/system_tests_broker.py
+++ b/tests/system_tests_broker.py
@@ -28,9 +28,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 
-import unittest2 as unittest
 import system_test
 from system_test import Qdrouterd, message, MISSING_REQUIREMENTS
+from system_test import unittest
 from itertools import cycle
 
 
@@ -84,7 +84,7 @@ class DistributedQueueTest(system_test.TestCase): # pylint: disable=too-many-pub
             qs = [q.management.getQueue(self.testq) for q in self.qpidds]
             enq = sum(q.msgTotalEnqueues for q in qs)
             deq = sum(q.msgTotalDequeues for q in qs)
-            self.assertEquals((enq, deq), (len(r), len(r)))
+            self.assertEqual((enq, deq), (len(r), len(r)))
             # Verify each broker handled a reasonable share of the messages.
             self.assert_fair([q.msgTotalEnqueues for q in qs])
 

--- a/tests/system_tests_cmdline_parsing.py
+++ b/tests/system_tests_cmdline_parsing.py
@@ -32,8 +32,8 @@ from __future__ import print_function
 import os
 import signal
 from subprocess import PIPE, STDOUT
-import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, main_module, Process, wait_port
+from system_test import unittest
 
 class CommandLineTest(TestCase):
     """

--- a/tests/system_tests_core_endpoint.py
+++ b/tests/system_tests_core_endpoint.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, DynamicNodeProperties
 from qpid_dispatch_internal.compat import UNICODE

--- a/tests/system_tests_default_distribution.py
+++ b/tests/system_tests_default_distribution.py
@@ -22,10 +22,10 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 import re
 from subprocess import PIPE
 from system_test import TestCase, Qdrouterd, TIMEOUT, main_module
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from proton import Message

--- a/tests/system_tests_delivery_abort.py
+++ b/tests/system_tests_delivery_abort.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from qpid_dispatch_internal.compat import BINARY

--- a/tests/system_tests_disallow_link_resumable_link_route.py
+++ b/tests/system_tests_disallow_link_resumable_link_route.py
@@ -22,11 +22,11 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from time import sleep, time
 from subprocess import PIPE, STDOUT
 
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, Process
+from system_test import unittest
 
 from proton import Message, Terminus
 from proton.reactor import DurableSubscription, SenderOption

--- a/tests/system_tests_distribution.py
+++ b/tests/system_tests_distribution.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton          import Message, Timeout
 from system_test     import TestCase, Qdrouterd, main_module, TIMEOUT, SkipIfNeeded
+from system_test     import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor  import Container, LinkOption, ApplicationEvent, EventInjector
 

--- a/tests/system_tests_drain.py
+++ b/tests/system_tests_drain.py
@@ -22,8 +22,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, main_module
+from system_test import unittest
 from system_tests_drain_support import DrainMessagesHandler, DrainOneMessageHandler
 from system_tests_drain_support import DrainNoMessagesHandler, DrainNoMoreMessagesHandler
 from system_tests_drain_support import DrainMessagesMoreHandler

--- a/tests/system_tests_drain_support.py
+++ b/tests/system_tests_drain_support.py
@@ -22,11 +22,11 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from proton import Message, Endpoint
 from system_test import main_module, TIMEOUT
+from system_test import unittest
 
 class Timeout(object):
     def __init__(self, parent):

--- a/tests/system_tests_dynamic_terminus.py
+++ b/tests/system_tests_dynamic_terminus.py
@@ -22,11 +22,11 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, LinkOption
+from system_test import unittest
 
 
 class RouterTest(TestCase):

--- a/tests/system_tests_edge_router.py
+++ b/tests/system_tests_edge_router.py
@@ -27,12 +27,12 @@ from time import sleep
 from threading import Event
 from threading import Timer
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, MgmtMsgProxy
 from system_test import AsyncTestReceiver
 from system_test import AsyncTestSender
 from system_test import QdManager
+from system_test import unittest
 from system_tests_link_routes import ConnLinkRouteService
 from test_broker import FakeService
 from proton.handlers import MessagingHandler

--- a/tests/system_tests_exchange_bindings.py
+++ b/tests/system_tests_exchange_bindings.py
@@ -23,12 +23,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import ast
-import unittest2 as unittest
 from time import sleep
 from subprocess import PIPE, STDOUT
 
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, Process
 from system_test import AsyncTestReceiver
+from system_test import unittest
 from proton import Message, Timeout
 from proton.reactor import AtMostOnce, AtLeastOnce
 from proton.utils import BlockingConnection, SendException

--- a/tests/system_tests_failover_list.py
+++ b/tests/system_tests_failover_list.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 

--- a/tests/system_tests_fallback_dest.py
+++ b/tests/system_tests_fallback_dest.py
@@ -26,12 +26,12 @@ from time import sleep
 from threading import Event
 from threading import Timer
 
-import unittest2 as unittest
 from proton import Message, Timeout, symbol
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, MgmtMsgProxy
 from system_test import AsyncTestReceiver
 from system_test import AsyncTestSender
 from system_test import QdManager
+from system_test import unittest
 from system_tests_link_routes import ConnLinkRouteService
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, DynamicNodeProperties

--- a/tests/system_tests_handle_failover.py.in
+++ b/tests/system_tests_handle_failover.py.in
@@ -24,10 +24,10 @@ from __future__ import print_function
 
 import os
 from threading import Timer
-import unittest2 as unittest
 import json, re
 from system_test import main_module, TIMEOUT
 from system_test import TestCase, Qdrouterd, Process, TIMEOUT
+from system_test import unittest
 from subprocess import PIPE, STDOUT
 
 

--- a/tests/system_tests_http.py
+++ b/tests/system_tests_http.py
@@ -21,7 +21,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 import os
 import threading
 import sys
@@ -40,6 +39,7 @@ except ImportError:
 from system_test import TIMEOUT, Process
 from subprocess import PIPE, STDOUT
 from system_test import TestCase, Qdrouterd, main_module, DIR
+from system_test import unittest
 
 
 class RouterTestHttp(TestCase):

--- a/tests/system_tests_interior_sync_up.py
+++ b/tests/system_tests_interior_sync_up.py
@@ -25,11 +25,11 @@ from __future__ import print_function
 from time import sleep
 from threading import Timer
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, MgmtMsgProxy
 from system_test import AsyncTestReceiver
 from system_test import AsyncTestSender
+from system_test import unittest
 from system_tests_link_routes import ConnLinkRouteService
 from test_broker import FakeService
 from proton.handlers import MessagingHandler

--- a/tests/system_tests_link_route_credit.py
+++ b/tests/system_tests_link_route_credit.py
@@ -25,11 +25,11 @@ from __future__ import print_function
 from time import sleep
 from threading import Timer
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, MgmtMsgProxy
 from system_test import AsyncTestReceiver
 from system_test import AsyncTestSender
+from system_test import unittest
 from system_tests_link_routes import ConnLinkRouteService
 from test_broker import FakeService
 from proton.handlers import MessagingHandler

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -22,7 +22,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from time import sleep, time
 from threading import Event
 from subprocess import PIPE, STDOUT
@@ -32,6 +31,7 @@ from system_test import AsyncTestSender
 from system_test import AsyncTestReceiver
 from system_test import QdManager
 from system_test import MgmtMsgProxy
+from system_test import unittest
 from test_broker import FakeBroker
 
 from proton import Delivery
@@ -337,7 +337,7 @@ class LinkRouteTest(TestCase):
         # 3. inbound link to the $management
         # 4. outbound link to $management
         # self.assertEqual(4, len()
-        self.assertEquals(4, len(local_node.query(type='org.apache.qpid.dispatch.router.link').results))
+        self.assertEqual(4, len(local_node.query(type='org.apache.qpid.dispatch.router.link').results))
 
         blocking_connection.close()
 
@@ -610,7 +610,7 @@ class LinkRouteTest(TestCase):
 
         cmd = 'QUERY --type=linkRoute'
         out = self.run_qdmanage(cmd=cmd, address=self.routers[1].addresses[0])
-        self.assertEquals(out.rstrip(), '[]')
+        self.assertEqual(out.rstrip(), '[]')
 
         # linkRoutes now gone on QDR.B but remember that it still exist on QDR.C
         # We will now try to create a receiver on address org.apache.dev on QDR.C.
@@ -632,7 +632,7 @@ class LinkRouteTest(TestCase):
 
         cmd = 'QUERY --type=linkRoute'
         out = self.run_qdmanage(cmd=cmd, address=addr)
-        self.assertEquals(out.rstrip(), '[]')
+        self.assertEqual(out.rstrip(), '[]')
 
         res = local_node.query(type='org.apache.qpid.dispatch.router')
         results = res.results[0]

--- a/tests/system_tests_link_routes_add_external_prefix.py
+++ b/tests/system_tests_link_routes_add_external_prefix.py
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-import unittest2 as unittest
 from time import sleep, time
 from subprocess import PIPE, STDOUT
 
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, Process
+from system_test import unittest
 
 from proton import Message
 from proton.handlers import MessagingHandler

--- a/tests/system_tests_log_message_components.py
+++ b/tests/system_tests_log_message_components.py
@@ -22,10 +22,10 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 import json
 from proton import Message, symbol
 from system_test import TestCase, Qdrouterd, Process, TIMEOUT
+from system_test import unittest
 from subprocess import PIPE, STDOUT
 from proton.handlers import MessagingHandler
 from proton.reactor import Container

--- a/tests/system_tests_management.py
+++ b/tests/system_tests_management.py
@@ -24,7 +24,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 import system_test, re, os, json
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
@@ -34,6 +33,7 @@ from qpid_dispatch_internal.management.qdrouter import QdSchema
 from qpid_dispatch_internal.compat import dictify
 from qpid_dispatch_internal.compat import BINARY
 from system_test import Qdrouterd, message, Process
+from system_test import unittest
 from itertools import chain
 
 PREFIX = u'org.apache.qpid.dispatch.'
@@ -470,9 +470,9 @@ class ManagementTest(system_test.TestCase):
     def test_get_schema(self):
         schema = dictify(QdSchema().dump())
         got = self.node.call(self.node.request(operation="GET-JSON-SCHEMA", identity="self")).body
-        self.assertEquals(schema, dictify(json.loads(got)))
+        self.assertEqual(schema, dictify(json.loads(got)))
         got = self.node.call(self.node.request(operation="GET-SCHEMA", identity="self")).body
-        self.assertEquals(schema, got)
+        self.assertEqual(schema, got)
 
 
 class SimpleSndRecv(MessagingHandler):

--- a/tests/system_tests_multi_phase.py
+++ b/tests/system_tests_multi_phase.py
@@ -26,12 +26,12 @@ from time import sleep
 from threading import Event
 from threading import Timer
 
-import unittest2 as unittest
 from proton import Message, Timeout, symbol
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, MgmtMsgProxy
 from system_test import AsyncTestReceiver
 from system_test import AsyncTestSender
 from system_test import QdManager
+from system_test import unittest
 from system_tests_link_routes import ConnLinkRouteService
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, DynamicNodeProperties

--- a/tests/system_tests_multi_tenancy.py
+++ b/tests/system_tests_multi_tenancy.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, DynamicNodeProperties
 from qpid_dispatch_internal.compat import UNICODE

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -28,7 +28,6 @@ from __future__ import print_function
 
 import sys
 from time import sleep
-import unittest2 as unittest
 
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
@@ -44,6 +43,7 @@ from system_test import Qdrouterd
 from system_test import main_module
 from system_test import TIMEOUT
 from system_test import TestTimeout
+from system_test import unittest
 
 
 MAX_FRAME=1023

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Condition, Message, Delivery, Url, symbol, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, DIR, Process
+from system_test import unittest
 from proton.handlers import MessagingHandler, TransactionHandler
 from proton.reactor import Container, AtMostOnce, AtLeastOnce, DynamicNodeProperties, LinkOption, ApplicationEvent, EventInjector
 from proton.utils import BlockingConnection, SyncRequestResponse

--- a/tests/system_tests_priority.py
+++ b/tests/system_tests_priority.py
@@ -23,9 +23,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton          import Message, Timeout
 from system_test     import TestCase, Qdrouterd, main_module, Process
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor  import Container
 

--- a/tests/system_tests_protocol_family.py
+++ b/tests/system_tests_protocol_family.py
@@ -22,11 +22,11 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton import Message
 from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from system_test import TestCase, Qdrouterd, main_module
+from system_test import unittest
 from qpid_dispatch_internal.policy.policy_util import is_ipv6_enabled
 
 class ProtocolFamilyTest(TestCase):

--- a/tests/system_tests_protocol_settings.py
+++ b/tests/system_tests_protocol_settings.py
@@ -22,8 +22,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, main_module
+from system_test import unittest
 from proton.utils import BlockingConnection
 import subprocess
 X86_64_ARCH = "x86_64"

--- a/tests/system_tests_qdmanage.py
+++ b/tests/system_tests_qdmanage.py
@@ -22,9 +22,11 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import json, unittest2 as unittest, os
+import json
+import os
 
 from system_test import TestCase, Process, Qdrouterd, main_module, TIMEOUT, DIR
+from system_test import unittest
 from subprocess import PIPE, STDOUT
 from qpid_dispatch_internal.compat import dictify
 from qpid_dispatch_internal.management.qdrouter import QdSchema
@@ -178,9 +180,9 @@ class QdmanageTest(TestCase):
     def test_get_schema(self):
         schema = dictify(QdSchema().dump())
         actual = self.run_qdmanage("get-json-schema")
-        self.assertEquals(schema, dictify(json.loads(actual)))
+        self.assertEqual(schema, dictify(json.loads(actual)))
         actual = self.run_qdmanage("get-schema")
-        self.assertEquals(schema, dictify(json.loads(actual)))
+        self.assertEqual(schema, dictify(json.loads(actual)))
 
     def test_get_annotations(self):
         """
@@ -267,7 +269,7 @@ class QdmanageTest(TestCase):
             if log_levels_present == n_log_levels:
                 good_logs += 1
 
-        self.assertEquals ( good_logs, len(logs) )
+        self.assertEqual ( good_logs, len(logs) )
 
     def test_update(self):
         exception = False
@@ -409,8 +411,8 @@ class QdmanageTest(TestCase):
         listener_port = self.get_port()
 
         listener = self.create(long_type, name, str(listener_port))
-        self.assertEquals(listener['type'], long_type)
-        self.assertEquals(listener['name'], name)
+        self.assertEqual(listener['type'], long_type)
+        self.assertEqual(listener['name'], name)
 
         exception_occurred = False
 

--- a/tests/system_tests_router_mesh.py
+++ b/tests/system_tests_router_mesh.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 import os
 import sys
 from time import sleep
-import unittest2 as unittest
 from signal import SIGINT
 from subprocess import PIPE
 
@@ -38,6 +37,7 @@ from system_test import main_module
 from system_test import TIMEOUT
 from system_test import Process
 from system_test import AsyncTestSender
+from system_test import unittest
 
 
 class ThreeRouterTest(TestCase):

--- a/tests/system_tests_sasl_plain.py
+++ b/tests/system_tests_sasl_plain.py
@@ -22,9 +22,10 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest, os
+import os
 from subprocess import PIPE, Popen
 from system_test import TestCase, Qdrouterd, main_module, DIR, TIMEOUT, SkipIfNeeded
+from system_test import unittest
 from qpid_dispatch.management.client import Node
 from proton import SASL
 

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -27,12 +27,12 @@ import re
 from subprocess import Popen, PIPE
 from qpid_dispatch.management.client import Node
 from system_test import TestCase, main_module, Qdrouterd, DIR, SkipIfNeeded
+from system_test import unittest
 from proton import SASL, Url, SSLDomain, SSLUnavailable
 from proton.utils import BlockingConnection
 from distutils.version import StrictVersion
 import proton
 import cproton
-import unittest2 as unittest
 
 
 class RouterTestSslBase(TestCase):
@@ -456,7 +456,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1 only is allowed
         """
-        self.assertEquals(self.get_expected_tls_result([True, False, False, False]),
+        self.assertEqual(self.get_expected_tls_result([True, False, False, False]),
                           self.get_allowed_protocols(self.PORT_TLS1))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -464,7 +464,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1.1 only is allowed
         """
-        self.assertEquals(self.get_expected_tls_result([False, True, False, False]),
+        self.assertEqual(self.get_expected_tls_result([False, True, False, False]),
                           self.get_allowed_protocols(self.PORT_TLS11))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -472,7 +472,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1.2 only is allowed
         """
-        self.assertEquals(self.get_expected_tls_result([False, False, True, False]),
+        self.assertEqual(self.get_expected_tls_result([False, False, True, False]),
                           self.get_allowed_protocols(self.PORT_TLS12))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -480,7 +480,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1.3 only is allowed
         """
-        self.assertEquals(self.get_expected_tls_result([False, False, False, True]),
+        self.assertEqual(self.get_expected_tls_result([False, False, False, True]),
                           self.get_allowed_protocols(self.PORT_TLS13))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -488,7 +488,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1 and TLSv1.1 only are allowed
         """
-        self.assertEquals(self.get_expected_tls_result([True, True, False, False]),
+        self.assertEqual(self.get_expected_tls_result([True, True, False, False]),
                           self.get_allowed_protocols(self.PORT_TLS1_TLS11))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -496,7 +496,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1 and TLSv1.2 only are allowed
         """
-        self.assertEquals(self.get_expected_tls_result([True, False, True, False]),
+        self.assertEqual(self.get_expected_tls_result([True, False, True, False]),
                           self.get_allowed_protocols(self.PORT_TLS1_TLS12))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -504,7 +504,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects TLSv1.1 and TLSv1.2 only are allowed
         """
-        self.assertEquals(self.get_expected_tls_result([False, True, True, False]),
+        self.assertEqual(self.get_expected_tls_result([False, True, True, False]),
                           self.get_allowed_protocols(self.PORT_TLS11_TLS12))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
@@ -512,7 +512,7 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         Expects all supported versions: TLSv1, TLSv1.1, TLSv1.2 and TLSv1.3 to be allowed
         """
-        self.assertEquals(self.get_expected_tls_result([True, True, True, True]),
+        self.assertEqual(self.get_expected_tls_result([True, True, True, True]),
                           self.get_allowed_protocols(self.PORT_TLS_ALL))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)

--- a/tests/system_tests_topology.py
+++ b/tests/system_tests_topology.py
@@ -22,9 +22,9 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-import unittest2 as unittest
 from proton          import Message, Timeout
 from system_test     import TestCase, Qdrouterd, main_module
+from system_test import unittest
 from proton.handlers import MessagingHandler
 from proton.reactor  import Container
 

--- a/tests/system_tests_two_routers.py
+++ b/tests/system_tests_two_routers.py
@@ -24,13 +24,13 @@ from __future__ import print_function
 
 from time import sleep
 import json, os
-import unittest2 as unittest
 import logging
 from threading import Timer
 from subprocess import PIPE, STDOUT
 from proton import Message, Timeout, Delivery
 from system_test import TestCase, Process, Qdrouterd, main_module, TIMEOUT, DIR
 from system_test import AsyncTestReceiver
+from system_test import unittest
 
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, AtLeastOnce

--- a/tests/system_tests_user_id.py
+++ b/tests/system_tests_user_id.py
@@ -23,8 +23,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, DIR, main_module
+from system_test import unittest
 from qpid_dispatch.management.client import Node
 from proton import SSLDomain
 

--- a/tests/system_tests_user_id_proxy.py
+++ b/tests/system_tests_user_id_proxy.py
@@ -23,8 +23,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
-import unittest2 as unittest
 from system_test import TestCase, Qdrouterd, DIR, main_module
+from system_test import unittest
 import proton
 from proton import SSLDomain, Delivery
 from proton.utils import BlockingConnection


### PR DESCRIPTION
unittest is part of the standard library for Python.  unittest in
versions of Python prior to 2.7 does not have all the features needed
by our unit tests.  Use 3rd party python-unittest2 module if Python <
2.7, otherwise use the standard library unittest.