### PR TITLE
DISPATCH-1384 - Fix unit_tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,9 +191,13 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-gnu-statement-expression)
 endif()
 
-if (NOT (APPLE OR USE_SANITIZERS OR USE_TSAN))
+if (APPLE)
+  set(CATCH_UNDEFINED "-Wl,-flat_namespace")
+elseif(NOT (USE_SANITIZERS OR USE_TSAN))
   set(CATCH_UNDEFINED "-Wl,-z,defs")
-endif ()
+else(APPLE)
+  set(CATCH_UNDEFINED "")
+endif(APPLE)
 
 ##
 ## Header file installation

--- a/src/server.c
+++ b/src/server.c
@@ -1524,6 +1524,7 @@ bool qd_connector_decref(qd_connector_t* ct)
     return false;
 }
 
+__attribute__((noinline)) // permit replacement by dummy implementation in unit_tests
 void qd_server_timeout(qd_server_t *server, qd_duration_t duration) {
     pn_proactor_set_timeout(server->proactor, duration);
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -114,6 +114,7 @@ void qd_timer_free(qd_timer_t *timer)
 }
 
 
+__attribute__((noinline)) // permit replacement by dummy implementation in unit_tests
 qd_timestamp_t qd_timer_now() {
     struct timespec tv;
     clock_gettime(CLOCK_MONOTONIC, &tv);


### PR DESCRIPTION
The inlining is not happening on Linux anyways, so disabling it should affect only macOS. I could not think of other way to make tests pass with the inlining, except doing some really crazy things that would have to affect what happens during normal execution too.

I have a StackOverflow question about it, btw ;)
https://stackoverflow.com/questions/56711149/how-do-i-replace-a-function-by-a-mock-implementation-when-unit-testing-a-shared

`-Wl,-export-dynamic` is Clangs equivalent of `-rdynamic` in GCC. I thought it should be used, but it does not appear to be necessary, so I am not adding that.