### PR TITLE
DISPATCH-1384 - Fix assert in system_tests_bad_configuration

### DIFF
--- a/tests/system_tests_bad_configuration.py
+++ b/tests/system_tests_bad_configuration.py
@@ -34,6 +34,7 @@ import re
 from subprocess import PIPE, STDOUT
 from system_test import TestCase, Qdrouterd, TIMEOUT, Process
 
+
 class RouterTestBadConfiguration(TestCase):
 
     """
@@ -109,10 +110,14 @@ class RouterTestBadConfiguration(TestCase):
         """
         with open('../setUpClass/test-router.log', 'r') as router_log:
             log_lines = router_log.read().split("\n")
-            regex = ".*(getaddrinfo|proton:io Name or service not known).*"
-            errors_caught = [line for line in log_lines if re.match(regex, line)]
+            expected_errors = [
+                "proton:io Name or service not known",  # Linux
+                "proton:io unknown node or service",  # macOS
+            ]
+            errors_caught = [line for line in log_lines
+                             if any([expected_error in line for expected_error in expected_errors])]
 
-            self.error_caught = len(errors_caught) > 0
+            self.error_caught = any(errors_caught)
 
             # If condition not yet satisfied and not exhausted max attempts,
             # re-schedule the verification.
@@ -137,7 +142,7 @@ class RouterTestBadConfiguration(TestCase):
         It expects that the error can be caught in the logs.
         :return:
         """
-        self.assertEqual(True, self.error_caught)
+        self.assertTrue(self.error_caught)
 
     def test_qdmanage_query(self):
         """


### PR DESCRIPTION
The expected Linux error is

    2019-10-17 10:14:09.319632 +0200 SERVER (info) [C1] Connection to unresolvable.host.name:amqp failed: proton:io Name or service not known - connect to  unresolvable.host.name:5672 (../src/server.c:974)

The expected macOS error is

    2019-06-21 21:00:34.125714 -0700 SERVER (info) [C4] Connection to unresolvable.host.name:amqp failed: proton:io unknown node or service - on connect resolving unresolvable.host.name:5672 (/Users/cloud-user/projects/qpid-dispatch/src/server.c:965)

The macOS error did not match the Linux specific regex used before.