### PR TITLE
DISPATCH-1363 - Move RAT licence check from travis builds into a sub build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,23 @@ matrix:
   allow_failures:
     - os: osx
   include:
+  - name: "apache-rat:check"
+    os: linux
+    sudo: false
+    env: []
+    language: java
+    addons:
+      apt:
+        packages: []
+    cache:
+      directories:
+        - $HOME/.m2/repository
+      before_cache:
+        - rm -rf $HOME/.m2/repository/org/apache/qpid/*
+    install: []
+    before_script: []
+    script:
+    - mvn apache-rat:check
   # prepending /usr/bin to PATH to avoid mismatched python interpreters in /opt
   - os: linux
     env:
@@ -61,8 +78,6 @@ addons:
     - python2.7-dev
     - sasl2-bin
     - swig
-    # For apache RAT tool
-    - maven
     # documentation
     - asciidoc
     - asciidoctor
@@ -98,15 +113,7 @@ script:
 # Workaround on macOS for PROTON-808 Binaries have their library locations stripped
 - if [[ "${OSTYPE}" == "darwin"* ]]; then install_name_tool -add_rpath $PREFIX/lib/. $PREFIX/lib/proton/bindings/python/_cproton.so; fi
 - ctest -V && if [ "$BUILD_TYPE" = "Coverage" ]; then cmake --build . --target coverage; fi
-- popd
-- mvn apache-rat:check
 
 after_success:
-- pushd build
+- cd ${TRAVIS_BUILD_DIR}/build
 - if [ "$BUILD_TYPE" = "Coverage" ]; then bash <(curl -s https://codecov.io/bash); fi
-
-cache:
-  directories:
-  - $HOME/.m2/repository
-  before_cache:
-  - rm -rf $HOME/.m2/repository/org/apache/qpid/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ endif()
 enable_testing()
 
 # python unittest
-# For versions < 2.7 the developer needs to install the python-unittest2
-# module (available via 'pip install python-unittest2'
+# For versions < 2.7 the developer needs to install the unittest2
+# module (available via 'yum install python-unittest2' or 'pip install unittest2'
 #
 if(PYTHON_VERSION_MAJOR EQUAL 2 AND PYTHON_VERSION_MINOR LESS 7)
   set(PYTHON_TEST_COMMAND "unit2")


### PR DESCRIPTION
Now easier to do when the `matrix` key is in place in `.travis.yml`.

Doing this also fixes the duplicated top level `cache` key in `.travis.yml` we had.

It appears that `matrix` is outdated syntax, and `jobs` should be preferred, https://github.com/travis-ci/docs-travis-ci-com/issues/1500. The doc page https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix uses `matrix.include` in the text and `jobs.include` in the yaml samples. Task for another time.