### PR TITLE
DISPATCH-1363 - Move Rat licence check from travis builds into GitHub Action

### DIFF
--- a/.github/workflows/apache-rat:check.yml
+++ b/.github/workflows/apache-rat:check.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  'apache-rat:check':
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn apache-rat:check

--- a/.github/workflows/apache-rat:check.yml
+++ b/.github/workflows/apache-rat:check.yml
@@ -3,8 +3,8 @@ name: Java CI
 on: [push, pull_request]
 
 jobs:
-  'apache-rat:check':
-
+  'apache-rat_check':
+    name: 'apache-rat:check'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/apache-rat:check.yml
+++ b/.github/workflows/apache-rat:check.yml
@@ -15,5 +15,6 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: mvn --no-transfer-progress apache-rat:check
-    - name: Print Rat report
+    - name: Print Rat report if Rat failed
+      if: failure()
       run: cat target/rat.txt

--- a/.github/workflows/apache-rat:check.yml
+++ b/.github/workflows/apache-rat:check.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 11
     - name: Build with Maven
-      run: mvn apache-rat:check
+      run: mvn --no-transfer-progress apache-rat:check

--- a/.github/workflows/apache-rat:check.yml
+++ b/.github/workflows/apache-rat:check.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn apache-rat:check

--- a/.github/workflows/apache-rat:check.yml
+++ b/.github/workflows/apache-rat:check.yml
@@ -15,3 +15,5 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: mvn --no-transfer-progress apache-rat:check
+    - name: Print Rat report
+      run: cat target/rat.txt


### PR DESCRIPTION
Just an idea for further improvement. This should save one click when investigating CI results on a PR, as GitHub Actions get a different entry in the CI result summary on the PR page.