### PR TITLE
DISPATCH-1455: not testing mutually exclusive groups on rhel6.

### DIFF
--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -34,6 +34,9 @@ from qpid_dispatch_site import VERSION
 from proton import SSLDomain, Url
 from proton.utils import SyncRequestResponse, BlockingConnection
 
+def version_supports_mutually_exclusive_arguments():
+    return sys.version_info >= (2,7)
+
 class UsageError(Exception):
     """
     Raise this exception to indicate the usage message should be printed.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-import unittest, argparse, sys
+import argparse, sys
 from itertools import combinations
 
 from qpid_dispatch_internal.tools.command import (main,
@@ -25,7 +25,10 @@ from qpid_dispatch_internal.tools.command import (main,
                                                   parse_args_qdstat,
                                                   parse_args_qdmanage,
                                                   _qdmanage_parser,
-                                                  _qdstat_parser)
+                                                  _qdstat_parser,
+                                                  version_supports_mutually_exclusive_arguments)
+
+from system_test import unittest
 
 def mock_error(self, message):
     raise ValueError(message)
@@ -57,6 +60,11 @@ class TestParseArgsQdstat(unittest.TestCase):
         self.parser.print_help()
 
     def test_parse_args_qdstat_mutually_exclusive(self):
+        if not version_supports_mutually_exclusive_arguments():
+            #unittest.skip also not supported
+            print("skipping: Mutually_exclusive options not working on python 2.6")
+            return
+
         options1 = ["-g", "-c",
                     "-l","-n","-e","-a","-m","--autolinks","--linkroutes","--log",
                     "--all-entities"]


### PR DESCRIPTION
So, here I am just skipping the tests on rhel6 (python version < 2.7), Because the behaviour on rhel6 is just using the last option, and no error is raised.