### PR TITLE
DISPATCH-1467: enable AddressSanitizer build option (ASAN)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
   - os: linux
     env:
     - PATH="/usr/bin:$PATH" PROTON_VERSION=0.29.0 BUILD_TYPE=RelWithDebInfo
+    - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
   - os: osx
     osx_image: xcode10.1
     env:
@@ -103,7 +104,7 @@ before_script:
 - source qpid-proton/build/config.sh
 - mkdir build
 - pushd build
-- cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DUSE_VALGRIND=NO -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDISPATCH_TEST_TIMEOUT=600
+- cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DDISPATCH_TEST_TIMEOUT=600 ${DISPATCH_CMAKE_ARGS}
 - cmake --build . --target install -- -j $NPROC
 
 script:

--- a/README
+++ b/README
@@ -144,7 +144,7 @@ GCC/Clang Thread Sanitizer (TSAN)
 ---------------------------------
 This option turns on extra run time threading verification.
 
-Applicable only to GCC versions >= 4.8 and Clang versions >= 4.1.
+Applicable only to GCC versions >= 7.4 and Clang versions >= 6.0.
 
 To enable the thread sanitizer set the RUNTIME_CHECK build flag to "tsan":
 
@@ -159,3 +159,23 @@ displayed in the CTest output. For example:
 
 RuntimeError: Errors during teardown:
 Process XXXX error: exit code 66, expected 0
+
+False positives can be suppressed via the tsan.supp file in the tests
+directory.
+
+GCC/Clang Address Sanitizer (ASAN)
+----------------------------------
+This option turns on extra run time memory verification, including
+leak checks.
+
+Applicable only to GCC versions >= 5.4 and Clang versions >= 6.0.
+
+To enable the address sanitizer set the RUNTIME_CHECK build flag to "asan":
+
+cmake .. -DRUNTIME_CHECK=asan
+
+The ASAN (libasan) and UBSAN (libubsan) libraries must be installed in
+order to use this option.
+
+False positive leak errors can be suppressed via the lsan.supp file in
+the tests directory.

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,8 @@
                       <exclude>**/MANIFEST.in</exclude>
                       <exclude>**/valgrind.supp</exclude>
                       <exclude>**/tsan.supp</exclude>
+                      <exclude>**/asan.supp</exclude>
+                      <exclude>**/lsan.supp</exclude>
                       <exclude>**/*.json.in</exclude>
                       <exclude>**/*.json</exclude>
                       <exclude>**/*.svg</exclude>

--- a/run.py.in
+++ b/run.py.in
@@ -84,7 +84,9 @@ env_vars = {
     'QPID_DISPATCH_RUNNER': qdrouterd_runner,
     'MALLOC_CHECK_': "3",      # 3 = print error and abort
     'MALLOC_PERTURB_': "153",  # 153 = 0x99 freed memory pattern
-    'TSAN_OPTIONS': "${RUNTIME_TSAN_ENV_OPTIONS}"
+    'TSAN_OPTIONS': "${RUNTIME_TSAN_ENV_OPTIONS}",
+    'ASAN_OPTIONS': "${RUNTIME_ASAN_ENV_OPTIONS}",
+    'LSAN_OPTIONS': "${RUNTIME_LSAN_ENV_OPTIONS}",
 }
 os.environ.update(env_vars)
 

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -46,7 +46,7 @@ DEQ_DECLARE(qd_alloc_type_t, qd_alloc_type_list_t);
 #define PATTERN_BACK  0xbabecafe
 
 struct qd_alloc_item_t {
-    uint32_t              sequence;
+    uintmax_t             sequence;  // uintmax_t ensures proper alignment of following data
 #ifdef QD_MEMORY_DEBUG
     qd_alloc_type_desc_t *desc;
     uint32_t              header;

--- a/tests/asan.supp
+++ b/tests/asan.supp
@@ -1,0 +1,3 @@
+# Suppression file for address issues found by AddressSanitizer (ASAN)
+# Note: memory leaks should not be suppressed here - update lsan.supp
+# instead.

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -1,0 +1,64 @@
+# Suppression file for memory leaks
+# found by AddressSanitizer (ASAN)
+#
+leak:_flush_send_queue_CT
+leak:add_session_to_free_list
+leak:compose_message_annotations
+leak:qd_parse_annotations
+leak:qd_compose_insert_string_n
+leak:qd_core_agent_query_handler
+leak:qd_dispatch_configure_connector
+leak:qd_dispatch_configure_listener
+leak:qd_dispatch_configure_ssl_profile
+leak:qd_manage_response_handler
+leak:qd_message_receive
+leak:qd_policy_amqp_open
+leak:qd_policy_amqp_open_connector
+leak:qd_policy_c_counts_alloc
+leak:qd_policy_open_fetch_settings
+leak:qdi_router_configure_body
+leak:qdr_action
+leak:qdr_add_local_address_CT
+leak:qdr_connection_opened
+leak:qdr_core_subscribe
+leak:qdr_error_description
+leak:qdr_forward_balanced_CT
+leak:qdr_forward_closest_CT
+leak:qdr_forward_multicast_CT
+leak:qdr_link_deliver
+leak:qdr_link_deliver_to_routed_link
+leak:qdr_link_deliver_to_routed_link
+leak:qdr_link_outbound_detach_CT
+leak:qdr_manage_advance_address_CT
+leak:qdr_node_connect_deliveries
+leak:qdr_route_add_auto_link_CT
+leak:qdr_route_add_link_route_CT
+leak:qdr_route_connection_opened_CT
+leak:qdr_subscribe_CT
+leak:qdr_terminus
+leak:router_annotate_message
+leak:qd_container_register_node_type
+
+# Ubuntu 18.04 (Bionic)
+leak:qdr_link_issue_credit_CT
+leak:qdr_delivery_push_CT
+
+# Ubuntu 16.04 (Xenial)
+leak:_ctypes_alloc_format_string
+leak:__strdup
+leak:add_link_to_free_list
+leak:qd_parse_internal
+
+
+####
+#### Miscellaneous 3rd party libraries, test code, etc:
+####
+
+leak:*libpython*
+leak:*libwebsockets*
+
+# We should be able to uncomment these once all known dispatch leaks have been fixed
+leak:*libqpid-proton*
+
+# Ignore test code
+leak:run_unit_tests.c


### PR DESCRIPTION
To run the AddressSanitizer, define RUNTIME_CHECK=asan via CMake:

  cmake .. -DRUNTIME_CHECK=asan

This patch includes minor code tweaks to issues found when running
with the sanitizer enabled.