### PR TITLE
DISPATCH-1471: print strings that fail assert

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -659,6 +659,7 @@ class TestCase(unittest.TestCase, Tester): # pylint: disable=too-many-public-met
 
     @classmethod
     def setUpClass(cls):
+        cls.maxDiff = None
         cls.tester = Tester('.'.join([cls.__module__, cls.__name__, 'setUpClass']))
         cls.tester.rmtree()
         cls.tester.setup()


### PR DESCRIPTION
This patch disables string truncation in all tests in the python suite derived from system_test/TestCase.
There's not a great way to write a test to see if this works.