### PR TITLE
DISPATCH-1481: Multicast links should block until a consumer is present

### DIFF
--- a/docs/books/modules/user-guide/routing.adoc
+++ b/docs/books/modules/user-guide/routing.adoc
@@ -116,6 +116,14 @@ This involves configuring an address with a routing pattern. All messages sent t
 +
 This involves configuring a waypoint address to identify the broker queue and then connecting the router to the broker. All messages sent to the waypoint address will be routed to the broker queue.
 
+=== Message Routing Flow Control
+
+{RouterName} uses a _credit-based_ flow control mechanism to ensure that producers can only send messages to a router if at least one consumer is available to receive them. Because {RouterName} does not store messages, this credit-based flow control prevents producers from sending messages when there are no consumers present.
+
+A client wishing to send a message to the router must wait until the router has provided it with credit. Attempting to publish a message without credit available will cause the client to block. Once credit is made available, the client will unblock, and the message will be sent to the router.
+
+NOTE: Most AMQP client libraries enable you to determine the amount of credit available to a producer. For more information, consult your client's documentation.
+
 === Addresses
 
 Addresses determine how messages flow through your router network. An address designates an endpoint in your messaging network, such as:

--- a/src/router_core/modules/address_lookup_client/lookup_client.c
+++ b/src/router_core/modules/address_lookup_client/lookup_client.c
@@ -406,14 +406,12 @@ static void qdr_link_react_to_first_attach_CT(qdr_core_t       *core,
         // Issue the initial credit only if one of the following
         // holds:
         // - there are destinations for the address
-        // - if the address treatment is multicast
         // - the address is that of an exchange (no subscribers allowed)
         //
         if (dir == QD_INCOMING
             && (DEQ_SIZE(addr->subscriptions)
                 || DEQ_SIZE(addr->rlinks)
                 || qd_bitmask_cardinality(addr->rnodes)
-                || qdr_is_addr_treatment_multicast(addr)
                 || !!addr->exchange
                 || (!!addr->fallback
                     && (DEQ_SIZE(addr->fallback->subscriptions)

--- a/tests/system_tests_global_delivery_counts.py
+++ b/tests/system_tests_global_delivery_counts.py
@@ -784,13 +784,16 @@ class ReleasedDroppedPresettledCountTest(MessagingHandler):
         self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
         self.sender_conn = event.container.connect(self.sender_addr)
 
-        # Note that there are no receivers. All messages sent to this address will be dropped
-        self.sender = event.container.create_sender(self.sender_conn, self.dest)
+        # Note that this is an anonymous link which will be granted credit w/o
+        # blocking for consumers.  Therefore all messages sent to this address
+        # will be dropped
+        self.sender = event.container.create_sender(self.sender_conn)
 
     def on_sendable(self, event):
         # We are sending a total of 20 deliveries. 10 unsettled and 10 pre-settled to a multicast address
         if self.n_sent < self.num_messages:
             msg = Message(body={'number': self.n_sent})
+            msg.address = self.dest
             dlv = self.sender.send(msg)
             if self.n_sent < 10:
                 dlv.settle()

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -38,6 +38,7 @@ from proton import Message
 from proton import Delivery
 from qpid_dispatch.management.client import Node
 from system_test import AsyncTestSender
+from system_test import AsyncTestReceiver
 from system_test import TestCase
 from system_test import Qdrouterd
 from system_test import main_module
@@ -395,24 +396,50 @@ class MulticastLinearTest(TestCase):
         test.run()
         self.assertEqual(None, test.error)
 
-    def test_90_no_subscribers(self):
-        # DISPATCH-779: ensure credit is available even if there are no
-        # subscribers
-        tx = AsyncTestSender(address=self.EA1.listener,
-                             target='multicast/no/subscriber',
-                             count=LINK_CAPACITY * 2,
-                             presettle=True,
-                             container_id="test_90_presettled")
-        tx.wait()
-        self.assertEqual(None, tx.error)
+    def test_90_credit_no_subscribers(self):
+        """
+        Verify that multicast senders are blocked until a consumer is present.
+        """
+        test = MulticastCreditBlocked(address=self.EA1.listener,
+                                      target='multicast/no/subscriber1')
 
-        tx = AsyncTestSender(address=self.EA1.listener,
-                             target='multicast/no/subscriber',
-                             count=LINK_CAPACITY * 2,
-                             presettle=False,
-                             container_id="test_90_unsettled")
+        test.run()
+        self.assertEqual(None, test.error)
+
+        test = MulticastCreditBlocked(address=self.INT_A.listener,
+                                      target='multicast/no/subscriber2')
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_91_anonymous_sender(self):
+        """
+        Verify that senders over anonymous links do not block waiting for
+        consumers.
+        """
+
+        # no receiver - should not block, return RELEASED
+        msg = Message(body="test_100_anonymous_sender")
+        msg.address = "multicast/test_100_anonymous_sender"
+        tx = AsyncTestSender(address=self.INT_B.listener,
+                             count=5,
+                             target=None,
+                             message=msg,
+                             container_id="test_100_anonymous_sender")
         tx.wait()
-        self.assertEqual(500, tx.released)
+        self.assertEqual(5, tx.released)
+
+        # now add a receiver:
+        rx = AsyncTestReceiver(address=self.INT_A.listener,
+                               source=msg.address)
+        self.INT_B.wait_address(msg.address)
+        tx = AsyncTestSender(address=self.INT_B.listener,
+                             count=5,
+                             target=None,
+                             message=msg,
+                             container_id="test_100_anonymous_sender")
+        tx.wait()
+        self.assertEqual(5, tx.accepted)
+        rx.stop()
 
     def test_999_check_for_leaks(self):
         self._check_for_leaks()
@@ -909,6 +936,52 @@ class MulticastUnsettled3AckMA(MulticastUnsettled3Ack):
             self.done()
             return
         super(MulticastUnsettled3AckMA, self).on_message(event)
+
+
+class MulticastCreditBlocked(MessagingHandler):
+    """
+    Ensure that credit is not provided when there are no consumers present.
+    This client connects to 'address' and creates a sender to 'target'.  Once
+    the sending link has opened a short timer is started.  It is expected that
+    on_sendable() is NOT invoked before the timer expires.
+    """
+    def __init__(self, address, target=None, timeout=2, **handler_kwargs):
+        super(MulticastCreditBlocked, self).__init__(**handler_kwargs)
+        self.target = target
+        self.address = address
+        self.time_out = timeout
+
+        self.conn = None
+        self.sender = None
+        self.timer = None
+        self.error = "Timeout NOT triggered as expected!"
+
+    def done(self):
+        # stop the reactor and clean up the test
+        if self.timer:
+            self.timer.cancel()
+        if self.conn:
+            self.conn.close()
+
+    def timeout(self):
+        self.error = None
+        self.done()
+
+    def on_start(self, event):
+        self.conn = event.container.connect(self.address)
+        self.sender = event.container.create_sender(self.conn,
+                                                    target=self.target,
+                                                    name="McastBlocked")
+
+    def on_link_opened(self, event):
+        self.timer = event.reactor.schedule(self.time_out, TestTimeout(self))
+
+    def on_sendable(self, event):
+        self.error = "Unexpected call to on_sendable()!"
+        self.done()
+
+    def run(self):
+        Container(self).run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes an infinite loop bug which occurs when using multicast
addresses on inbound waypoint (broker) links.