### PR TITLE
DISPATCH-1485 - Setting limit=0 on qdstat means setting the limit to …

### DIFF
--- a/python/qpid_dispatch/management/client.py
+++ b/python/qpid_dispatch/management/client.py
@@ -244,7 +244,7 @@ class Node(object):
         if offset is None:
             offset = 0
 
-        if count is None:
+        if count is None or count==0:
             # count has not been specified. For each request the
             # maximum number of rows we can get without proton
             # failing is MAX_ALLOWED_COUNT_PER_REQUEST

--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -182,7 +182,7 @@ def _qdstat_parser(BusManager):
     # can be used in conjunction with options
     # like -c, -l, -a, --autolinks, --linkroutes and --log.
     # By default, the limit is not set, which means the limit is unlimited.
-    parser.add_argument("--limit", help="Limit number of output rows", type=int, default=None)
+    parser.add_argument("--limit", help="Limit number of output rows. Unlimited if limit is zero or if limit not specified", type=int, default=None)
 
     add_connection_options(parser)
     return parser

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -241,6 +241,17 @@ class QdstatTest(system_test.TestCase):
 
         self.assertEqual(links, 500)
 
+        # DISPATCH-1485. Try to run qdstat with a limit=0. Without the fix for DISPATCH-1485
+        # this following command will hang and the test will fail.
+        outs = self.run_qdstat(['--links', '--limit=0'])
+        out_list = outs.split("\n")
+
+        links = 0
+        for out in out_list:
+            if "endpoint" in out and "examples" in out:
+                links += 1
+        self.assertEqual(links, COUNT*2)
+
 
         # This test would fail without the fix for DISPATCH-974
         outs = self.run_qdstat(['--address'])


### PR DESCRIPTION
…unlimited. Fixed infinite loop