### PR TITLE
DISPATCH-1186: Add option to get CSV formatting for qdstat tables

### DIFF
--- a/python/qpid_dispatch_internal/tools/__init__.py
+++ b/python/qpid_dispatch_internal/tools/__init__.py
@@ -22,6 +22,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-from .display import Display, Header, Sorter, YN, Commas, TimeLong, TimeShort, Sortable
+from .display import Display, Header, Sorter, YN, Commas, TimeLong, TimeShort, Sortable, BodyFormat
 
-__all__ = ["Display", "Header", "Sorter", "YN", "Commas", "TimeLong", "TimeShort", "Sortable"]
+__all__ = ["Display", "Header", "Sorter", "YN", "Commas", "TimeLong", "TimeShort", "Sortable", "BodyFormat"]

--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -183,6 +183,7 @@ def _qdstat_parser(BusManager):
     # like -c, -l, -a, --autolinks, --linkroutes and --log.
     # By default, the limit is not set, which means the limit is unlimited.
     parser.add_argument("--limit", help="Limit number of output rows", type=int, default=None)
+    parser.add_argument("--csv", help="Render tabular output in csv format", action="store_true")
 
     add_connection_options(parser)
     return parser

--- a/python/qpid_dispatch_internal/tools/display.py
+++ b/python/qpid_dispatch_internal/tools/display.py
@@ -138,14 +138,33 @@ class Header:
     value /= 1000
     return self.numCell(value, 'g')
 
+class BodyFormat:
+  """
+  Display body format chooses between:
+   CLASSIC - original variable-width, unquoted, text delimited by white space
+   CSV     - quoted text delimited by commas
+  """
+  CLASSIC = 1
+  CSV = 2
+
+class CSV_CONFIG:
+  """ """
+  SEPERATOR = u','
+  STRING_QUOTE = u'"'
 
 class Display:
   """ Display formatting """
   
-  def __init__(self, spacing=2, prefix="    "):
+  def __init__(self, spacing=2, prefix="    ", bodyFormat=BodyFormat.CLASSIC):
     self.tableSpacing    = spacing
     self.tablePrefix     = prefix
     self.timestampFormat = "%X"
+    if bodyFormat == BodyFormat.CLASSIC:
+      self.printTable = self.table
+    elif bodyFormat == BodyFormat.CSV:
+      self.printTable = self.tableCsv
+    else:
+      raise Exception("Table body format must be CLASSIC or CSV.")
 
   def formattedTable(self, title, heads, rows):
     fRows = []
@@ -159,7 +178,7 @@ class Display:
     headtext = []
     for head in heads:
       headtext.append(head.text)
-    self.table(title, headtext, fRows)
+    self.printTable(title, headtext, fRows)
 
   def table(self, title, heads, rows):
     """ Print a table with autosized columns """
@@ -207,6 +226,31 @@ class Display:
             line = line + " "
         col = col + 1
       print(line)
+
+  def tableCsv(self, title, heads, rows):
+    """
+    Print a table with CSV format.
+    """
+
+    def csvEscape(text):
+      """
+      Given a unicode text field, return the quoted CSV format for it
+      :param text: a header field or a table row field
+      :return:
+      """
+      if len(text) == 0:
+        return ""
+      else:
+        text = text.replace(CSV_CONFIG.STRING_QUOTE, CSV_CONFIG.STRING_QUOTE*2)
+        return CSV_CONFIG.STRING_QUOTE + text + CSV_CONFIG.STRING_QUOTE
+
+    print("%s" % title)
+    if len (rows) == 0:
+      return
+
+    print(','.join([csvEscape(UNICODE(head)) for head in heads]))
+    for row in rows:
+      print(','.join([csvEscape(UNICODE(item)) for item in row]))
 
   def do_setTimeFormat (self, fmt):
     """ Select timestamp format """

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -73,8 +73,23 @@ class QdstatTest(system_test.TestCase):
         self.assertTrue("Mode                             standalone" in out)
         self.assertEqual(out.count("QDR.A"), 2)
 
+    def test_general_csv(self):
+        out = self.run_qdstat(['--general', '--csv'], r'(?s)Router Statistics.*Mode","Standalone')
+        self.assertTrue("Connections","1" in out)
+        self.assertTrue("Nodes","0" in out)
+        self.assertTrue("Auto Links","0" in out)
+        self.assertTrue("Link Routes","0" in out)
+        self.assertTrue("Router Id","QDR.A" in out)
+        self.assertTrue("Mode","standalone" in out)
+        self.assertEqual(out.count("QDR.A"), 2)
+
     def test_connections(self):
         self.run_qdstat(['--connections'], r'host.*container.*role')
+        outs = self.run_qdstat(['--connections'], 'no-auth')
+        outs = self.run_qdstat(['--connections'], 'QDR.A')
+
+    def test_connections_csv(self):
+        self.run_qdstat(['--connections', "--csv"], r'host.*container.*role')
         outs = self.run_qdstat(['--connections'], 'no-auth')
         outs = self.run_qdstat(['--connections'], 'QDR.A')
 
@@ -84,13 +99,27 @@ class QdstatTest(system_test.TestCase):
         parts = out.split("\n")
         self.assertEqual(len(parts), 9)
 
+    def test_links_csv(self):
+        self.run_qdstat(['--links', "--csv"], r'QDR.A')
+        out = self.run_qdstat(['--links'], r'endpoint.*out.*local.*temp.')
+        parts = out.split("\n")
+        self.assertEqual(len(parts), 9)
+
     def test_links_with_limit(self):
         out = self.run_qdstat(['--links', '--limit=1'])
         parts = out.split("\n")
         self.assertEqual(len(parts), 8)
 
+    def test_links_with_limit_csv(self):
+        out = self.run_qdstat(['--links', '--limit=1', "--csv"])
+        parts = out.split("\n")
+        self.assertEqual(len(parts), 7)
+
     def test_nodes(self):
         self.run_qdstat(['--nodes'], r'No Router List')
+
+    def test_nodes_csv(self):
+        self.run_qdstat(['--nodes', "--csv"], r'No Router List')
 
     def test_address(self):
         out = self.run_qdstat(['--address'], r'QDR.A')

--- a/tools/qdstat.in
+++ b/tools/qdstat.in
@@ -34,7 +34,7 @@ from time import ctime, strftime, gmtime
 import qpid_dispatch_site
 from qpid_dispatch.management.client import Url, Node, Entity
 from qpid_dispatch_internal.management.qdrouter import QdSchema
-from qpid_dispatch_internal.tools import Display, Header, Sorter, YN, Commas, TimeLong, TimeShort
+from qpid_dispatch_internal.tools import Display, Header, Sorter, YN, Commas, TimeLong, TimeShort, BodyFormat
 from qpid_dispatch_internal.tools.command import (parse_args_qdstat, main,
                                                   opts_ssl_domain, opts_sasl,
                                                   opts_url)
@@ -55,6 +55,7 @@ class BusManager(Node):
                             ssl_domain=opts_ssl_domain(opts),
                             sasl=opts_sasl(opts)))
         self.show = getattr(self, opts.show)
+        self.bodyFormat = BodyFormat.CSV if opts.csv else BodyFormat.CLASSIC
 
     def query(self, entity_type, attribute_names=None, limit=None):
         if attribute_names:
@@ -120,7 +121,7 @@ class BusManager(Node):
 
 
     def displayEdges(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("id"))
         heads.append(Header("host"))
@@ -183,7 +184,7 @@ class BusManager(Node):
         disp.formattedTable(title, heads, dispRows)            
         
     def displayConnections(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("id"))
         heads.append(Header("host"))
@@ -305,7 +306,7 @@ class BusManager(Node):
         return outlist
 
     def displayGeneral(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("attr"))
         heads.append(Header("value"))
@@ -366,7 +367,7 @@ class BusManager(Node):
         disp.formattedTable(title, heads, dispRows)
 
     def displayRouterLinks(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("type"))
         heads.append(Header("dir"))
@@ -483,7 +484,7 @@ class BusManager(Node):
         disp.formattedTable(title, heads, dispRows)
 
     def displayRouterNodes(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("router-id"))
         heads.append(Header("next-hop"))
@@ -534,7 +535,7 @@ class BusManager(Node):
             print("Router is Standalone - No Router List")
 
     def displayAddresses(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("class"))
         heads.append(Header("addr"))
@@ -602,7 +603,7 @@ class BusManager(Node):
         disp.formattedTable(title, heads, dispRows)
 
     def displayAutolinks(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("addr"))
         heads.append(Header("dir"))
@@ -641,7 +642,7 @@ class BusManager(Node):
         disp.formattedTable(title, heads, dispRows)
 
     def displayLinkRoutes(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("address"))
         heads.append(Header("dir"))
@@ -687,7 +688,7 @@ class BusManager(Node):
         disp.formattedTable(title, heads, dispRows)
 
     def displayMemory(self, show_date_id=True):
-        disp = Display(prefix="  ")
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
         heads = []
         heads.append(Header("type"))
         heads.append(Header("size", Header.COMMAS))


### PR DESCRIPTION
Add a "--csv" switch to qdstat command line to apply to display tables.

The CSV format is controlled with a separator of ',' and a string quote
of '"'.

This option removes ambiguity for certain tables (like 'qdstat -l') where
columns (like peer and phs) have no entry, and headers (like 'conn id') have
spaces in their names. These ambiguities make user reconstruction of the
original tables difficult after the table content has been through a
jira or email paste.

This commit has the code implementation but no docs.