### PR TITLE
DISPATCH-1513: add LWS flag to allow plain HTTP on an HTTPS listener.

### DIFF
--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -354,7 +354,7 @@ static void listener_start(qd_http_listener_t *hl, qd_http_server_t *hs) {
 
         info.options |=
             LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT |
-            (config->ssl_required ? 0 : LWS_SERVER_OPTION_ALLOW_NON_SSL_ON_SSL_PORT) |
+            (config->ssl_required ? 0 : LWS_SERVER_OPTION_ALLOW_NON_SSL_ON_SSL_PORT | LWS_SERVER_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER ) |
             ((config->requireAuthentication && info.ssl_ca_filepath) ? LWS_SERVER_OPTION_REQUIRE_VALID_OPENSSL_CLIENT_CERT : 0);
     }
     info.vhost_name = hl->listener->config.host_port;

--- a/tests/system_tests_http.py
+++ b/tests/system_tests_http.py
@@ -250,8 +250,7 @@ class RouterTestHttp(TestCase):
         self.assert_get("https://localhost:%s" % r.ports[0])
         # requireSsl=false Allows simple-ssl HTTP
 
-        # Commenting out the following assert until DISPATCH-1513 is fixed.
-        #self.assert_get("http://localhost:%s" % r.ports[0])
+        self.assert_get("http://localhost:%s" % r.ports[0])
 
         self.assert_get("https://localhost:%s" % r.ports[1])
         # requireSsl=True does not allow simple-ssl HTTP


### PR DESCRIPTION
One line fix -- we just need to tell Libwebsockets that we want it to do this, and it will let us.

