### PR TITLE
DISPATCH-1525: raise AttributeError if accessing invalid Entity attri…

### DIFF
--- a/python/qpid_dispatch/management/entity.py
+++ b/python/qpid_dispatch/management/entity.py
@@ -81,7 +81,9 @@ class EntityBase(object):
         return self.attributes[name]
 
     def __getattr__(self, name):
-        return self.attributes[name]
+        if name in self.attributes:
+            return self.attributes[name]
+        raise AttributeError
 
     def __contains__(self, name):
         return name in self.attributes


### PR DESCRIPTION
…bute

Using 'hasattr' against the Entity class will not work properly unless
the Entity's __getattr__ method raises an AttributeError when the
attribute is not present.