### PR TITLE
DISPATCH-1540: fix access to presettled flag in qdr_action_t

### DIFF
--- a/src/router_core/delivery.c
+++ b/src/router_core/delivery.c
@@ -210,10 +210,10 @@ qdr_delivery_t *qdr_deliver_continue(qdr_core_t *core,qdr_delivery_t *in_dlv, bo
 {
 
     qdr_action_t   *action = qdr_action(qdr_deliver_continue_CT, "deliver_continue");
-    action->args.connection.delivery = in_dlv;
+    action->args.delivery.delivery = in_dlv;
 
     qd_message_t *msg = qdr_delivery_message(in_dlv);
-    action->args.connection.more = !qd_message_receive_complete(msg);
+    action->args.delivery.more = !qd_message_receive_complete(msg);
     action->args.delivery.presettled = settled;
 
     // This incref is for the action reference
@@ -1084,8 +1084,8 @@ static void qdr_deliver_continue_CT(qdr_core_t *core, qdr_action_t *action, bool
     if (discard)
         return;
 
-    qdr_delivery_t *in_dlv  = action->args.connection.delivery;
-    bool more = action->args.connection.more;
+    qdr_delivery_t *in_dlv  = action->args.delivery.delivery;
+    bool more = action->args.delivery.more;
     bool presettled = action->args.delivery.presettled;
 
     //

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -129,18 +129,13 @@ struct qdr_action_t {
             qdr_field_t         *connection_label;
             qdr_field_t         *container_id;
             qdr_link_t_sp        link;
-            qdr_delivery_t      *delivery;
-            qd_message_t        *msg;
             qd_direction_t       dir;
             qdr_terminus_t      *source;
             qdr_terminus_t      *target;
             qdr_error_t         *error;
             qd_detach_type_t     dt;
             int                  credit;
-            bool                 more;  // true if there are more frames arriving, false otherwise
             bool                 drain;
-            uint8_t              tag[32];
-            int                  tag_length;
         } connection;
 
         //
@@ -148,10 +143,13 @@ struct qdr_action_t {
         //
         struct {
             qdr_delivery_t *delivery;
-            uint64_t        disposition;
-            bool            settled;
-            bool            presettled;
             qdr_error_t    *error;
+            uint64_t        disposition;
+            uint8_t         tag[32];
+            int             tag_length;
+            bool            settled;
+            bool            presettled;  // true if remote settles while msg is in flight
+            bool            more;  // true if there are more frames arriving, false otherwise
         } delivery;
 
         //

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -59,8 +59,8 @@ qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterato
     qdr_delivery_incref(dlv, "qdr_link_deliver - newly created delivery, add to action list");
     qdr_delivery_incref(dlv, "qdr_link_deliver - protect returned value");
 
-    action->args.connection.delivery = dlv;
-    action->args.connection.more = !qd_message_receive_complete(msg);
+    action->args.delivery.delivery = dlv;
+    action->args.delivery.more = !qd_message_receive_complete(msg);
     qdr_action_enqueue(link->core, action);
     return dlv;
 }
@@ -88,8 +88,8 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
     qdr_delivery_incref(dlv, "qdr_link_deliver_to - newly created delivery, add to action list");
     qdr_delivery_incref(dlv, "qdr_link_deliver_to - protect returned value");
 
-    action->args.connection.delivery = dlv;
-    action->args.connection.more = !qd_message_receive_complete(msg);
+    action->args.delivery.delivery = dlv;
+    action->args.delivery.more = !qd_message_receive_complete(msg);
     qdr_action_enqueue(link->core, action);
     return dlv;
 }
@@ -114,11 +114,11 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
     qdr_delivery_incref(dlv, "qdr_link_deliver_to_routed_link - newly created delivery, add to action list");
     qdr_delivery_incref(dlv, "qdr_link_deliver_to_routed_link - protect returned value");
 
-    action->args.connection.delivery = dlv;
-    action->args.connection.more = !qd_message_receive_complete(msg);
-    action->args.connection.tag_length = tag_length;
+    action->args.delivery.delivery = dlv;
+    action->args.delivery.more = !qd_message_receive_complete(msg);
+    action->args.delivery.tag_length = tag_length;
     assert(tag_length <= QDR_DELIVERY_TAG_MAX);
-    memcpy(action->args.connection.tag, tag, tag_length);
+    memcpy(action->args.delivery.tag, tag, tag_length);
     qdr_action_enqueue(link->core, action);
     return dlv;
 }
@@ -642,8 +642,8 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
     if (discard)
         return;
 
-    qdr_delivery_t *dlv  = action->args.connection.delivery;
-    bool            more = action->args.connection.more;
+    qdr_delivery_t *dlv  = action->args.delivery.delivery;
+    bool            more = action->args.delivery.more;
     qdr_link_t     *link = qdr_delivery_link(dlv);
 
     if (!link)
@@ -687,8 +687,8 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         //
         // Copy the delivery tag.  For link-routing, the delivery tag must be preserved.
         //
-        peer->tag_length = action->args.connection.tag_length;
-        memcpy(peer->tag, action->args.connection.tag, peer->tag_length);
+        peer->tag_length = action->args.delivery.tag_length;
+        memcpy(peer->tag, action->args.delivery.tag, peer->tag_length);
 
         qdr_forward_deliver_CT(core, link->connected_link, peer);
 


### PR DESCRIPTION
Clean up the qdr_action_t anonymous union layout by moving all
delivery related action data out of the connection sub-structure and
into the delivery sub-structure.