### PR TITLE
DISPATCH-1553: disallow problematic characters in router.id attribute

### DIFF
--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -374,7 +374,7 @@
             "singleton": true,
             "attributes": {
                 "id": {
-                    "description":"Router's unique identity. If not specified, a random identity will be assigned at startup.",
+                    "description":"Router's unique identity. This field may not contain whitespace or control characters. If not specified, a random identity will be assigned at startup.",
                     "type": "string",
                     "required": false,
                     "create": true

--- a/python/qpid_dispatch_internal/management/agent.py
+++ b/python/qpid_dispatch_internal/management/agent.py
@@ -259,13 +259,14 @@ class RouterEntity(EntityAdapter):
         return self.attributes.get('id')
 
     def create(self):
-        for ch in self.attributes[u"id"]:
-            try:
-                disallowed = unicodedata.category(ch)[0] in "CZ"
-            except TypeError:
-                disallowed = unicodedata.category(ch.decode('utf-8'))[0] in "CZ"
-            if disallowed:  # disallow control and whitespace characters
-                raise AttributeError("Router id attribute containing character '%s' in id '%s' is disallowed." % (ch, self.attributes[u"id"]))
+        if u"id" in self.attributes.keys():
+            for ch in self.attributes[u"id"]:
+                try:
+                    disallowed = unicodedata.category(ch)[0] in "CZ"
+                except TypeError:
+                    disallowed = unicodedata.category(ch.decode('utf-8'))[0] in "CZ"
+                if disallowed:  # disallow control and whitespace characters
+                    raise AttributeError("Router id attribute containing character '%s' in id '%s' is disallowed." % (ch, self.attributes[u"id"]))
         try:
             self.attributes[u"hostName"] = socket.gethostbyaddr(socket.gethostname())[0]
         except:

--- a/python/qpid_dispatch_internal/management/agent.py
+++ b/python/qpid_dispatch_internal/management/agent.py
@@ -68,6 +68,7 @@ from __future__ import print_function
 
 import traceback, json, pstats
 import socket
+import unicodedata
 from traceback import format_exc
 from threading import Lock
 from cProfile import Profile
@@ -258,6 +259,13 @@ class RouterEntity(EntityAdapter):
         return self.attributes.get('id')
 
     def create(self):
+        for ch in self.attributes[u"id"]:
+            try:
+                disallowed = unicodedata.category(ch)[0] in "CZ"
+            except TypeError:
+                disallowed = unicodedata.category(ch.decode('utf-8'))[0] in "CZ"
+            if disallowed:  # disallow control and whitespace characters
+                raise AttributeError("Router id attribute containing character '%s' in id '%s' is disallowed." % (ch, self.attributes[u"id"]))
         try:
             self.attributes[u"hostName"] = socket.gethostbyaddr(socket.gethostname())[0]
         except:

--- a/tests/system_tests_bad_configuration.py
+++ b/tests/system_tests_bad_configuration.py
@@ -160,3 +160,80 @@ class RouterTestBadConfiguration(TestCase):
         except Exception as e:
             raise Exception("%s\n%s" % (e, out))
         return out
+
+
+class RouterTestIdFailCtrlChar(TestCase):
+    """
+    This test case sets up a router using a configuration router id
+    that is illegal (control character). The router should not start.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(RouterTestIdFailCtrlChar, cls).setUpClass()
+        cls.name = "test-router-ctrl-char"
+
+    def __init__(self, test_method):
+        TestCase.__init__(self, test_method)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(RouterTestIdFailCtrlChar, cls).tearDownClass()
+
+    def test_verify_reject_id_with_ctrl_char(self):
+        """
+        Writes illegal config, runs router, examines console output
+        """
+        conf_path = "../setUpClass/test-router-ctrl-char.conf"
+        with open(conf_path, 'w') as router_conf:
+            router_conf.write("router { \n")
+            router_conf.write("    id: abc\\bdef \n")
+            router_conf.write("}")
+
+        p = self.popen(
+            ['qdrouterd', '-c', conf_path],
+            stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=Process.EXIT_FAIL,
+            universal_newlines=True)
+        out = p.communicate(timeout=5)[0]
+        try:
+            p.teardown()
+        except Exception as e:
+            raise Exception("%s\n%s" % (e, out))
+        self.assertTrue("AttributeError" in out)
+
+class RouterTestIdFailWhiteSpace(TestCase):
+    """
+    This test case sets up a router using a configuration router id
+    that is illegal (whitespace character). The router should not start.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(RouterTestIdFailWhiteSpace, cls).setUpClass()
+        cls.name = "test-router-ctrl-char"
+
+    def __init__(self, test_method):
+        TestCase.__init__(self, test_method)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(RouterTestIdFailWhiteSpace, cls).tearDownClass()
+
+    def test_verify_reject_id_with_whitespace(self):
+        """
+        Writes illegal config, runs router, examines console output
+        """
+        conf_path = "../setUpClass/test-router-whitespace.conf"
+        with open(conf_path, 'w') as router_conf:
+            router_conf.write("router { \n")
+            router_conf.write("    id: abc def \n")
+            router_conf.write("}")
+
+        p = self.popen(
+            ['qdrouterd', '-c', conf_path],
+            stdin=PIPE, stdout=PIPE, stderr=STDOUT, expect=Process.EXIT_FAIL,
+            universal_newlines=True)
+        out = p.communicate(timeout=5)[0]
+        try:
+            p.teardown()
+        except Exception as e:
+            raise Exception("%s\n%s" % (e, out))
+        self.assertTrue("AttributeError" in out)


### PR DESCRIPTION
Disallow control and whitespace characters as defined by
unicodedata.category C* and Z*.