### PR TITLE
DISPATCH-1536: Microsecond timestamp utility for self-tests

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import errno, os, time, socket, random, subprocess, shutil, unittest, __main__, re, sys
+from datetime import datetime
 from subprocess import PIPE, STDOUT
 from copy import copy
 try:
@@ -1218,3 +1219,46 @@ def get_inter_router_links(address):
 
     return inter_router_links
 
+
+class Timestamp(object):
+    """
+    Time stamps for logging.
+    """
+    def __init__(self):
+        self.ts = datetime.now()
+
+    def __str__(self):
+        return self.ts.strftime("%Y-%m-%d %H:%M:%S:%f")
+
+
+class Logger(object):
+    """
+    Record an event log for a self test.
+    May print per-event or save events to be printed later.
+    """
+
+    def __init__(self, title="Logger", print_to_console=False, save_for_dump=True):
+        self.title = title
+        self.print_to_console = print_to_console
+        self.save_for_dump = save_for_dump
+        self.logs = []
+
+    def log(self, msg):
+        ts = Timestamp()
+        if self.save_for_dump:
+            self.logs.append( (ts, msg) )
+        if self.print_to_console:
+            print("%s %s" % (ts, msg))
+            sys.stdout.flush()
+
+    def dump(self):
+        print(self)
+        sys.stdout.flush()
+
+    def __str__(self):
+        lines = []
+        lines.append(self.title)
+        for ts, msg in self.logs:
+            lines.append("%s %s" % (ts, msg))
+        res = str('\n'.join(lines))
+        return res

--- a/tests/system_tests_edge_router.py
+++ b/tests/system_tests_edge_router.py
@@ -22,7 +22,6 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-from datetime import datetime
 from time import sleep
 from threading import Event
 from threading import Timer
@@ -31,6 +30,7 @@ from proton import Message, Timeout
 from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, MgmtMsgProxy
 from system_test import AsyncTestReceiver
 from system_test import AsyncTestSender
+from system_test import Logger
 from system_test import QdManager
 from system_test import unittest
 from system_tests_link_routes import ConnLinkRouteService
@@ -471,7 +471,7 @@ class RouterTest(TestCase):
                                  "test_12")
         test.run()
         if test.error is not None:
-            print(str(test.logger))
+            test.logger.dump()
         self.assertEqual(None, test.error)
 
     def test_13_mobile_address_edge_to_edge_one_interior(self):
@@ -1892,26 +1892,6 @@ class DynamicAddressTest(MessagingHandler):
 
     def run(self):
         Container(self).run()
-
-class Logger(object):
-    """
-    Keep an in-memory list of timestamped messages.
-    Print only on request successful tests are not encumbered
-    with print detail.
-    """
-    PRINT_TO_CONSOLE = False
-    def __init__(self):
-        self.msgs = []
-
-    def log(self, msg):
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S:%f")
-        m = "%s %s" % (ts, msg)
-        self.msgs.append(m)
-        if Logger.PRINT_TO_CONSOLE:
-            print(m)
-
-    def __str__(self):
-        return '\n'.join(self.msgs)
 
 
 class CustomTimeout(object):


### PR DESCRIPTION
This commit pulls the Logger class out of system_tests_edge_router and
places it into system_tests for easy access.

An example consumer of Logger is the MobileAddressTest. That test creates
a logger and loads it with facts as the test progresses but it doesn't print
anything unless there is a test failure.

By default Logger does not print to the console and it saves each log
line as it goes. When Logger is initialized either of these defaults
may be overridden.

How to print to the console with a timestamp:

    from system_test import Logger
    ...
    self.log2 = Logger(print_to_console=True, save_for_dump=False)
    self.log2.log("Help I'm a Rock")