### PR TITLE
DISPATCH-975: Implement max-message-size policy restrictions

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -201,6 +201,7 @@ extern const char * const QD_AMQP_COND_PRECONDITION_FAILED;
 extern const char * const QD_AMQP_COND_RESOURCE_DELETED;
 extern const char * const QD_AMQP_COND_ILLEGAL_STATE;
 extern const char * const QD_AMQP_COND_FRAME_SIZE_TOO_SMALL;
+extern const char * const QD_AMQP_COND_MESSAGE_SIZE_EXCEEDED;
 
 extern const char * const QD_AMQP_COND_CONNECTION_FORCED;
 /// @};

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -422,6 +422,19 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
  */
 uint8_t qd_message_get_priority(qd_message_t *msg);
 
+/**
+ * Sense if message exceeds maxMessageSize
+ * @param msg A pointer to the message
+ * @return true if the message has accumulated too many bytes
+ */
+bool qd_message_exceeds_max_message_size(const qd_message_t *msg);
+
+/**
+ * Message went oversize on last call to qd_message_receive
+ * @param msg A pointer to the message
+ * @return true if the message has accumulated too many bytes on last call to qd_message_receive
+ */
+bool qd_message_oversize_detected(const qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -423,18 +423,14 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
 uint8_t qd_message_get_priority(qd_message_t *msg);
 
 /**
- * Sense if message exceeds maxMessageSize
+ * Return numbr of times qd_message_receive detected that this message is oversize.
+ *  0 - message is not oversize
+ *  1 - message went oversize on last call to qd_message_receive
+ * >1 - message has been oversize and is being discarded
  * @param msg A pointer to the message
- * @return true if the message has accumulated too many bytes
+ * @return oversize detection count
  */
-bool qd_message_exceeds_max_message_size(const qd_message_t *msg);
-
-/**
- * Message went oversize on last call to qd_message_receive
- * @param msg A pointer to the message
- * @return true if the message has accumulated too many bytes on last call to qd_message_receive
- */
-bool qd_message_oversize_detected(const qd_message_t *msg);
+int qd_message_exceeded_max_message_size(const qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -604,6 +604,8 @@ bool qd_connection_strip_annotations_in(const qd_connection_t *c);
 
 void qd_connection_wake(qd_connection_t *ctx);
 
+int qd_connection_max_message_size(const qd_connection_t *c);
+
 /**
  * @}
  */

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1869,6 +1869,13 @@
                     "required": false,
                     "create": true
                 },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied only to transfers over user connections and is not applied to interrouter or edge router connections. This limit may be overridden by vhost or by vhost user group settings. A value of zero disables this limit.",
+                    "required": false,
+                    "create": true
+                },
                 "enableVhostPolicy": {
                     "type": "boolean",
                     "default": false,
@@ -1905,10 +1912,11 @@
                     "graph": true,
                     "description": "The sum of all vhost sender and receiver denials."
                 },
+                "maxMessageSizeDenied": {"type": "integer", "graph": true},
                 "totalDenials": {
                     "type": "integer",
                     "graph": true,
-                    "description": "The total number of connection and link denials."
+                    "description": "The total number of connection, link, and transfer denials."
                 }
             }
         },
@@ -1932,6 +1940,11 @@
                     "required": false,
                     "create": true,
                     "update": true
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections to this vhost. This limit overrides the policy maxMessageSize value and may be overridden by vhost user group settings. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxConnectionsPerUser": {
                     "type": "integer",
@@ -1992,6 +2005,11 @@
                     "description": "Optional maximum number of concurrent connections allowed for any remote host by users in this group. This value, if specified, overrides the vhost maxConnectionsPerHost value",
                     "required": false,
                     "create": false
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections created by users in this group. This limit overrides the policy and vhost maxMessageSize values. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxFrameSize": {
                     "type": "integer",
@@ -2130,7 +2148,8 @@
 
                 "sessionDenied": {"type": "integer", "graph": true},
                 "senderDenied": {"type": "integer", "graph": true},
-                "receiverDenied": {"type": "integer", "graph": true}
+                "receiverDenied": {"type": "integer", "graph": true},
+                "maxMessageSizeDenied": {"type": "integer", "graph": true}
             }
         },
 

--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -201,10 +201,12 @@ def configure_dispatch(dispatch, lib_handle, filename):
     policyDir           = config.by_type('policy')[0]['policyDir']
     policyDefaultVhost  = config.by_type('policy')[0]['defaultVhost']
     useHostnamePatterns = config.by_type('policy')[0]['enableVhostNamePatterns']
+    maxMessageSize      = config.by_type('policy')[0]['maxMessageSize']
     for a in config.by_type("policy"):
         configure(a)
     agent.policy.set_default_vhost(policyDefaultVhost)
     agent.policy.set_use_hostname_patterns(useHostnamePatterns)
+    agent.policy.set_max_message_size(maxMessageSize)
 
     # Remaining configuration
     for t in "sslProfile", "authServicePlugin", "listener", "connector", \

--- a/python/qpid_dispatch_internal/policy/policy_manager.py
+++ b/python/qpid_dispatch_internal/policy/policy_manager.py
@@ -161,6 +161,14 @@ class PolicyManager(object):
         @return: none
         """
         self._policy_local.close_connection(conn_id)
+
+    def set_max_message_size(self, size):
+        """
+        Policy has set global maxMessageSize.
+        :param size:
+        :return: none
+        """
+        self._policy_local.set_max_message_size(size)
 #
 #
 #

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -86,6 +86,7 @@ const char * const QD_AMQP_COND_RESOURCE_DELETED = "amqp:resource-deleted";
 const char * const QD_AMQP_COND_ILLEGAL_STATE = "amqp:illegal-state";
 const char * const QD_AMQP_COND_FRAME_SIZE_TOO_SMALL = "amqp:frame-size-too-small";
 const char * const QD_AMQP_COND_CONNECTION_FORCED = "amqp:connection:forced";
+const char * const QD_AMQP_COND_MESSAGE_SIZE_EXCEEDED = "amqp:link:message-size-exceeded";
 
 const char * const QD_AMQP_PORT_STR = "5672";
 const char * const QD_AMQPS_PORT_STR = "5671";

--- a/src/message.c
+++ b/src/message.c
@@ -1256,7 +1256,7 @@ qd_message_t *discard_receive(pn_delivery_t *delivery,
         } else if (rc == PN_EOS || rc < 0) {
             // end of message or error. Call the message complete
             msg->content->receive_complete = true;
-            msg->content->aborted = pn_delivery_aborted(delivery);
+            msg->content->aborted = pn_delivery_aborted(delivery) || msg->content->oversize;;
             qd_nullify_safe_ptr(&msg->content->input_link_sp);
 
             pn_record_t *record = pn_delivery_attachments(delivery);
@@ -1301,6 +1301,10 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
         msg->strip_annotations_in  = qd_connection_strip_annotations_in(qdc);
         pn_record_def(record, PN_DELIVERY_CTX, PN_WEAKREF);
         pn_record_set(record, PN_DELIVERY_CTX, (void*) msg);
+        msg->content->max_message_size = qd_connection_max_message_size(qdc);
+    } else {
+        // existing messages may detect oversize transitions only once
+        msg->content->oversize_detected = false;
     }
 
     //
@@ -1409,10 +1413,23 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
             recv_error = true;
         } else if (rc > 0) {
             //
-            // We have received a positive number of bytes for the message.  Advance
-            // the cursor in the buffer.
+            // We have received a positive number of bytes for the message.  
+            // Advance the cursor in the buffer.
             //
             qd_buffer_insert(content->pending, rc);
+
+            // Handle maxMessageSize violations
+            if (content->max_message_size) {
+                content->bytes_received += rc;
+                if (content->bytes_received > content->max_message_size)
+                {
+                    content->oversize_detected = true;
+                    content->oversize = true;
+                    content->discard = true;
+                    content->aborted = true;
+                    break;
+                }
+            }
         } else {
             //
             // We received zero bytes, and no PN_EOS.  This means that we've received
@@ -2222,4 +2239,14 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted)
         return;
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
     msg_pvt->content->aborted = aborted;
+}
+
+bool qd_message_exceeds_max_message_size(const qd_message_t *msg)
+{
+    qd_message_content_t * mc = MSG_CONTENT(msg);
+    return mc->max_message_size && mc->bytes_received > mc->max_message_size;
+}
+
+bool qd_message_oversize_detected(const qd_message_t *msg) {
+    return (MSG_CONTENT(msg))->oversize_detected;
 }

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -109,6 +109,8 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
+    int                  max_message_size;               // configured max; 0 if no max to enforce
+    int                  bytes_received;                 // returned by pn_link_recv()
     uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t_sp         input_link_sp;                  // message received on this link
 
@@ -120,6 +122,8 @@ typedef struct {
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
     bool                 priority_parsed;
     bool                 priority_present;
+    bool                 oversize;                       // policy oversize handling in effect
+    bool                 oversize_detected;              // oversize happened on last receive
     uint8_t              priority;                       // The priority of this message
 } qd_message_content_t;
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -111,6 +111,7 @@ typedef struct {
     int                  ma_int_phase;
     int                  max_message_size;               // configured max; 0 if no max to enforce
     int                  bytes_received;                 // returned by pn_link_recv()
+    int                  oversize_detected;              // N times receive called for oversize message
     uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t_sp         input_link_sp;                  // message received on this link
 
@@ -123,7 +124,6 @@ typedef struct {
     bool                 priority_parsed;
     bool                 priority_present;
     bool                 oversize;                       // policy oversize handling in effect
-    bool                 oversize_detected;              // oversize happened on last receive
     uint8_t              priority;                       // The priority of this message
 } qd_message_content_t;
 

--- a/src/policy.h
+++ b/src/policy.h
@@ -39,6 +39,7 @@ struct qd_policy_denial_counts_s {
     int sessionDenied;
     int senderDenied;
     int receiverDenied;
+    int maxSizeMessagesDenied;
 };
 
 typedef struct qd_policy_t qd_policy_t;
@@ -49,6 +50,7 @@ struct qd_policy__settings_s {
     int  maxSessions;
     int  maxSenders;
     int  maxReceivers;
+    int  maxMessageSize;
     bool allowDynamicSource;
     bool allowAnonymousSender;
     bool allowUserIdProxy;
@@ -231,6 +233,7 @@ char * qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPatter
  * @return the ruleset string to be used in policy settings.
  */
 char * qd_policy_compile_allowed_csv(char * csv);
+
 /**
  * Approve sending of message on anonymous link based on connection's policy.
  *
@@ -238,4 +241,15 @@ char * qd_policy_compile_allowed_csv(char * csv);
  * @param[in] qd_conn dispatch connection with policy settings
  */
 bool qd_policy_approve_message_target(qd_iterator_t *address, qd_connection_t *qd_conn);
+
+/**
+ * Tally counters for a link when policy maxMessageSize limit is exceeded.
+ *
+ * @param[in] pn_link proton link being closed
+ * @param[in] qd_conn dispatch connection with policy settings and counts
+ **/
+void qd_policy_count_max_size_event(pn_link_t *link,
+                                        qd_connection_t *qd_conn
+                                       );
+
 #endif

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -332,10 +332,11 @@ static bool AMQP_rx_handler(void* context, qd_link_t *link)
 
     qd_message_t   *msg   = qd_message_receive(pnd);
     
-    bool is_oversize      = qd_message_exceeds_max_message_size(msg);
-    if (is_oversize) {
+    int oversize = qd_message_exceeded_max_message_size(msg);
+    if (oversize > 0) {
         // message is bigger than maxMessageSize
-        if (qd_message_oversize_detected(msg)) {
+        if (oversize == 1) {
+            // went oversize on this pass
             qdr_link_t *rlink = (qdr_link_t*) qd_link_get_context(link);
             qd_log(qd_log_source("POLICY"), QD_LOG_WARNING, "[C%"PRIu64"][L%"PRIu64"] maxMessageSize exceeded",
                     rlink->conn->identity, rlink->identity);

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -27,6 +27,7 @@
 #include "entity_cache.h"
 #include "router_private.h"
 #include "delivery.h"
+#include "policy.h"
 #include <qpid/dispatch/router_core.h>
 #include <qpid/dispatch/proton_utils.h>
 #include <proton/sasl.h>
@@ -329,12 +330,32 @@ static bool AMQP_rx_handler(void* context, qd_link_t *link)
     qdr_delivery_t *delivery = qdr_node_delivery_qdr_from_pn(pnd);
     bool       next_delivery = false;
 
-    //
-    // Receive the message into a local representation.
-    //
     qd_message_t   *msg   = qd_message_receive(pnd);
+    
+    bool is_oversize      = qd_message_exceeds_max_message_size(msg);
+    if (is_oversize) {
+        // message is bigger than maxMessageSize
+        if (qd_message_oversize_detected(msg)) {
+            qdr_link_t *rlink = (qdr_link_t*) qd_link_get_context(link);
+            qd_log(qd_log_source("POLICY"), QD_LOG_WARNING, "[C%"PRIu64"][L%"PRIu64"] maxMessageSize exceeded",
+                    rlink->conn->identity, rlink->identity);
+            // increment policy counters
+            qd_policy_count_max_size_event(pn_link, conn);
+            // Initiate link close with error.
+            // Do not settle delivery or issue new flow
+            pn_condition_t * cond = pn_link_condition(pn_link);
+            (void) pn_condition_set_name(cond, QD_AMQP_COND_MESSAGE_SIZE_EXCEEDED);
+            pn_link_close(pn_link);
+            // This link is now locally closed.
+            // Abort outbound deliveries that were receiving this incoming delivery
+            qdr_node_disconnect_deliveries(router->router_core, link, delivery, pnd);
+            // If more deliveries arrive for this transfer then they will be discarded.
+        }
+        // Link was not advanced
+        return false;
+    }
+    
     bool receive_complete = qd_message_receive_complete(msg);
-
     if (receive_complete) {
         log_link_message(conn, pn_link, msg);
 

--- a/src/server.c
+++ b/src/server.c
@@ -1611,3 +1611,7 @@ sys_mutex_t *qd_server_get_activation_lock(qd_server_t * server)
 {
     return server->conn_activation_lock;
 }
+
+int qd_connection_max_message_size(const qd_connection_t *c) {
+    return (c && c->policy_settings) ? c->policy_settings->maxMessageSize : 0;
+}


### PR DESCRIPTION
* This commit has the basics of the implementation for initial review.
* This commit has tests for the size settings in the schema but no tests
  checking run-time enforcement.

Notes:

* Max message size is enforced on message/transfer ingress only.
  Once a message has entered the router network it is free to go to any
  destination.

* When a message exceeds max size then the ingress link is closed with an error
  Delivery copies of oversize denied messages are aborted.

* In message.c oversize messages are detected and then handled as
  discarded and aborted.

* In router_node.c oversize messages are logged, links are closed,
  and downstream deliveries are disconnected.