### PR TITLE
DISPATCH-975: Enforce max message size on message ingress

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -201,6 +201,7 @@ extern const char * const QD_AMQP_COND_PRECONDITION_FAILED;
 extern const char * const QD_AMQP_COND_RESOURCE_DELETED;
 extern const char * const QD_AMQP_COND_ILLEGAL_STATE;
 extern const char * const QD_AMQP_COND_FRAME_SIZE_TOO_SMALL;
+extern const char * const QD_AMQP_COND_MESSAGE_SIZE_EXCEEDED;
 
 extern const char * const QD_AMQP_COND_CONNECTION_FORCED;
 /// @};

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -422,6 +422,15 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
  */
 uint8_t qd_message_get_priority(qd_message_t *msg);
 
+/**
+ * Return numbr of times qd_message_receive detected that this message is oversize.
+ *  0 - message is not oversize
+ *  1 - message went oversize on last call to qd_message_receive
+ * >1 - message has been oversize and is being discarded
+ * @param msg A pointer to the message
+ * @return oversize detection count
+ */
+int qd_message_exceeded_max_message_size(const qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -604,6 +604,8 @@ bool qd_connection_strip_annotations_in(const qd_connection_t *c);
 
 void qd_connection_wake(qd_connection_t *ctx);
 
+int qd_connection_max_message_size(const qd_connection_t *c);
+
 /**
  * @}
  */

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1869,6 +1869,13 @@
                     "required": false,
                     "create": true
                 },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied only to transfers over user connections and is not applied to interrouter or edge router connections. This limit may be overridden by vhost or by vhost user group settings. A value of zero disables this limit.",
+                    "required": false,
+                    "create": true
+                },
                 "enableVhostPolicy": {
                     "type": "boolean",
                     "default": false,
@@ -1905,10 +1912,11 @@
                     "graph": true,
                     "description": "The sum of all vhost sender and receiver denials."
                 },
+                "maxMessageSizeDenied": {"type": "integer", "graph": true},
                 "totalDenials": {
                     "type": "integer",
                     "graph": true,
-                    "description": "The total number of connection and link denials."
+                    "description": "The total number of connection, link, and transfer denials."
                 }
             }
         },
@@ -1932,6 +1940,11 @@
                     "required": false,
                     "create": true,
                     "update": true
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections to this vhost. This limit overrides the policy maxMessageSize value and may be overridden by vhost user group settings. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxConnectionsPerUser": {
                     "type": "integer",
@@ -1992,6 +2005,11 @@
                     "description": "Optional maximum number of concurrent connections allowed for any remote host by users in this group. This value, if specified, overrides the vhost maxConnectionsPerHost value",
                     "required": false,
                     "create": false
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections created by users in this group. This limit overrides the policy and vhost maxMessageSize values. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxFrameSize": {
                     "type": "integer",
@@ -2130,7 +2148,8 @@
 
                 "sessionDenied": {"type": "integer", "graph": true},
                 "senderDenied": {"type": "integer", "graph": true},
-                "receiverDenied": {"type": "integer", "graph": true}
+                "receiverDenied": {"type": "integer", "graph": true},
+                "maxMessageSizeDenied": {"type": "integer", "graph": true}
             }
         },
 

--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -201,10 +201,12 @@ def configure_dispatch(dispatch, lib_handle, filename):
     policyDir           = config.by_type('policy')[0]['policyDir']
     policyDefaultVhost  = config.by_type('policy')[0]['defaultVhost']
     useHostnamePatterns = config.by_type('policy')[0]['enableVhostNamePatterns']
+    maxMessageSize      = config.by_type('policy')[0]['maxMessageSize']
     for a in config.by_type("policy"):
         configure(a)
     agent.policy.set_default_vhost(policyDefaultVhost)
     agent.policy.set_use_hostname_patterns(useHostnamePatterns)
+    agent.policy.set_max_message_size(maxMessageSize)
 
     # Remaining configuration
     for t in "sslProfile", "authServicePlugin", "listener", "connector", \

--- a/python/qpid_dispatch_internal/policy/policy_manager.py
+++ b/python/qpid_dispatch_internal/policy/policy_manager.py
@@ -161,6 +161,14 @@ class PolicyManager(object):
         @return: none
         """
         self._policy_local.close_connection(conn_id)
+
+    def set_max_message_size(self, size):
+        """
+        Policy has set global maxMessageSize.
+        :param size:
+        :return: none
+        """
+        self._policy_local.set_max_message_size(size)
 #
 #
 #

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -86,6 +86,7 @@ const char * const QD_AMQP_COND_RESOURCE_DELETED = "amqp:resource-deleted";
 const char * const QD_AMQP_COND_ILLEGAL_STATE = "amqp:illegal-state";
 const char * const QD_AMQP_COND_FRAME_SIZE_TOO_SMALL = "amqp:frame-size-too-small";
 const char * const QD_AMQP_COND_CONNECTION_FORCED = "amqp:connection:forced";
+const char * const QD_AMQP_COND_MESSAGE_SIZE_EXCEEDED = "amqp:link:message-size-exceeded";
 
 const char * const QD_AMQP_PORT_STR = "5672";
 const char * const QD_AMQPS_PORT_STR = "5671";

--- a/src/container.c
+++ b/src/container.c
@@ -127,7 +127,7 @@ static void setup_outgoing_link(qd_container_t *container, pn_link_t *pn_link)
 }
 
 
-static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link)
+static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link, int max_size)
 {
     qd_node_t *node = container->default_node;
 
@@ -159,6 +159,9 @@ static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link)
     link->node       = node;
     link->remote_snd_settle_mode = pn_link_remote_snd_settle_mode(pn_link);
 
+    if (max_size) {
+        pn_link_set_max_message_size(pn_link, (uint64_t)max_size);
+    }
     pn_link_set_context(pn_link, link);
     node->ntype->incoming_handler(node->context, link);
 }
@@ -577,7 +580,7 @@ void qd_container_handle_event(qd_container_t *container, pn_event_t *event,
                         }
                         qd_conn->n_senders++;
                     }
-                    setup_incoming_link(container, pn_link);
+                    setup_incoming_link(container, pn_link, qd_connection_max_message_size(qd_conn));
                 }
             } else if (pn_link_state(pn_link) & PN_LOCAL_ACTIVE)
                 handle_link_open(container, pn_link);

--- a/src/message.c
+++ b/src/message.c
@@ -1244,7 +1244,9 @@ qd_message_t *discard_receive(pn_delivery_t *delivery,
                               qd_message_t  *msg_in)
 {
     qd_message_pvt_t *msg  = (qd_message_pvt_t*)msg_in;
-
+    if (msg->content->oversize) {
+        msg->content->oversize_detected++;
+    }
     while (1) {
 #define DISCARD_BUFFER_SIZE (128 * 1024)
         char dummy[DISCARD_BUFFER_SIZE];
@@ -1256,7 +1258,7 @@ qd_message_t *discard_receive(pn_delivery_t *delivery,
         } else if (rc == PN_EOS || rc < 0) {
             // end of message or error. Call the message complete
             msg->content->receive_complete = true;
-            msg->content->aborted = pn_delivery_aborted(delivery);
+            msg->content->aborted = pn_delivery_aborted(delivery) || msg->content->oversize;
             qd_nullify_safe_ptr(&msg->content->input_link_sp);
 
             pn_record_t *record = pn_delivery_attachments(delivery);
@@ -1301,6 +1303,7 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
         msg->strip_annotations_in  = qd_connection_strip_annotations_in(qdc);
         pn_record_def(record, PN_DELIVERY_CTX, PN_WEAKREF);
         pn_record_set(record, PN_DELIVERY_CTX, (void*) msg);
+        msg->content->max_message_size = qd_connection_max_message_size(qdc);
     }
 
     //
@@ -1409,10 +1412,23 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
             recv_error = true;
         } else if (rc > 0) {
             //
-            // We have received a positive number of bytes for the message.  Advance
-            // the cursor in the buffer.
+            // We have received a positive number of bytes for the message.  
+            // Advance the cursor in the buffer.
             //
             qd_buffer_insert(content->pending, rc);
+
+            // Handle maxMessageSize violations
+            if (content->max_message_size) {
+                content->bytes_received += rc;
+                if (content->bytes_received > content->max_message_size)
+                {
+                    content->oversize_detected += 1;
+                    content->oversize = true;
+                    content->discard = true;
+                    content->aborted = true;
+                    break;
+                }
+            }
         } else {
             //
             // We received zero bytes, and no PN_EOS.  This means that we've received
@@ -2222,4 +2238,10 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted)
         return;
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
     msg_pvt->content->aborted = aborted;
+}
+
+int qd_message_exceeded_max_message_size(const qd_message_t *msg)
+{
+    qd_message_content_t * mc = MSG_CONTENT(msg);
+    return mc->oversize_detected;
 }

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -109,6 +109,9 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
+    int                  max_message_size;               // configured max; 0 if no max to enforce
+    int                  bytes_received;                 // returned by pn_link_recv()
+    int                  oversize_detected;              // N times receive called for oversize message
     uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t_sp         input_link_sp;                  // message received on this link
 
@@ -120,6 +123,7 @@ typedef struct {
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
     bool                 priority_parsed;
     bool                 priority_present;
+    bool                 oversize;                       // policy oversize handling in effect
     uint8_t              priority;                       // The priority of this message
 } qd_message_content_t;
 

--- a/src/policy.c
+++ b/src/policy.c
@@ -46,6 +46,7 @@ static int n_connections = 0;
 static int n_denied = 0;
 static int n_processed = 0;
 static int n_links_denied = 0;
+static int n_maxsize_messages_denied = 0;
 static int n_total_denials = 0;
 
 //
@@ -83,6 +84,9 @@ static PyObject * module = 0;
 
 ALLOC_DEFINE(qd_policy_settings_t);
 
+// Policy log module used outside of policy proper
+qd_log_source_t* policy_log_source = 0;
+
 //
 // Policy configuration/statistics management interface
 //
@@ -116,6 +120,7 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->tree_lock            = sys_mutex();
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
     stats_lock                   = sys_mutex();
+    policy_log_source            = policy->log_source;
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");
     return policy;
@@ -206,7 +211,8 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
     qd_policy_denial_counts_t *dc = (qd_policy_denial_counts_t*)ccounts;
     if (!qd_entity_set_long(entity, "sessionDenied", dc->sessionDenied) &&
         !qd_entity_set_long(entity, "senderDenied", dc->senderDenied) &&
-        !qd_entity_set_long(entity, "receiverDenied", dc->receiverDenied)
+        !qd_entity_set_long(entity, "receiverDenied", dc->receiverDenied) &&
+        !qd_entity_set_long(entity, "maxMessageSizeDenied", dc->maxSizeMessagesDenied)
     )
         return QD_ERROR_NONE;
     return qd_error_code();
@@ -218,13 +224,14 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
  **/
 qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
     // Return global stats
-    int np, nd, nc, nl, nt;
+    int np, nd, nc, nl, nm, nt;
     sys_mutex_lock(stats_lock);
     {
         np = n_processed;
         nd = n_denied;
         nc = n_connections;
         nl = n_links_denied;
+        nm = n_maxsize_messages_denied;
         nt = n_total_denials;
     }
     sys_mutex_unlock(stats_lock);
@@ -232,6 +239,7 @@ qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
         !qd_entity_set_long(entity, "connectionsDenied", nd) &&
         !qd_entity_set_long(entity, "connectionsCurrent", nc) &&
         !qd_entity_set_long(entity, "linksDenied", nl) &&
+        !qd_entity_set_long(entity, "maxMessageSizeDenied", nm) &&
         !qd_entity_set_long(entity, "totalDenials", nt)
     )
         return QD_ERROR_NONE;
@@ -306,16 +314,18 @@ void qd_policy_socket_close(qd_policy_t *policy, const qd_connection_t *conn)
     int ssnDenied = 0;
     int sndDenied = 0;
     int rcvDenied = 0;
+    int sizDenied = 0;
     if (conn->policy_settings && conn->policy_settings->denialCounts) {
         ssnDenied = conn->policy_settings->denialCounts->sessionDenied;
         sndDenied = conn->policy_settings->denialCounts->senderDenied;
         rcvDenied = conn->policy_settings->denialCounts->receiverDenied;
+        sizDenied = conn->policy_settings->denialCounts->maxSizeMessagesDenied;
     }
     qd_log(policy->log_source, QD_LOG_DEBUG, 
            "Connection '%s' closed with resources n_sessions=%d, n_senders=%d, n_receivers=%d, "
-           "sessions_denied=%d, senders_denied=%d, receivers_denied=%d. nConnections= %d.",
+           "sessions_denied=%d, senders_denied=%d, receivers_denied=%d max_size_transfers_denied=%d. nConnections= %d.",
             hostname, conn->n_sessions, conn->n_senders, conn->n_receivers,
-            ssnDenied, sndDenied, rcvDenied, n_connections);
+            ssnDenied, sndDenied, rcvDenied, sizDenied, n_connections);
 }
 
 
@@ -502,6 +512,7 @@ bool qd_policy_open_fetch_settings(
                         settings->maxSessions          = qd_entity_opt_long((qd_entity_t*)upolicy, "maxSessions", 0);
                         settings->maxSenders           = qd_entity_opt_long((qd_entity_t*)upolicy, "maxSenders", 0);
                         settings->maxReceivers         = qd_entity_opt_long((qd_entity_t*)upolicy, "maxReceivers", 0);
+                        settings->maxMessageSize       = qd_entity_opt_long((qd_entity_t*)upolicy, "maxMessageSize", 0);
                         if (!settings->allowAnonymousSender) { //don't override if enabled by authz plugin
                             settings->allowAnonymousSender = qd_entity_opt_bool((qd_entity_t*)upolicy, "allowAnonymousSender", false);
                         }
@@ -665,6 +676,19 @@ void _qd_policy_deny_amqp_receiver_link(pn_link_t *pn_link, qd_connection_t *qd_
     }
 }
 
+
+//
+//
+void qd_policy_count_max_size_event(pn_link_t *link, qd_connection_t *qd_conn)
+{
+    sys_mutex_lock(stats_lock);
+    n_maxsize_messages_denied++;
+    n_total_denials++;
+    sys_mutex_unlock(stats_lock);
+    if (qd_conn->policy_settings && qd_conn->policy_settings->denialCounts) {
+        qd_conn->policy_settings->denialCounts->maxSizeMessagesDenied++;
+    }
+}
 
 /**
  * Given a char return true if it is a parse_tree token separater
@@ -1473,4 +1497,9 @@ char * qd_policy_compile_allowed_csv(char * csv)
     }
     free(dup);
     return result;
+}
+
+
+qd_log_source_t* qd_policy_log_source() {
+    return policy_log_source;
 }

--- a/src/policy.h
+++ b/src/policy.h
@@ -39,6 +39,7 @@ struct qd_policy_denial_counts_s {
     int sessionDenied;
     int senderDenied;
     int receiverDenied;
+    int maxSizeMessagesDenied;
 };
 
 typedef struct qd_policy_t qd_policy_t;
@@ -49,6 +50,7 @@ struct qd_policy__settings_s {
     int  maxSessions;
     int  maxSenders;
     int  maxReceivers;
+    int  maxMessageSize;
     bool allowDynamicSource;
     bool allowAnonymousSender;
     bool allowUserIdProxy;
@@ -231,6 +233,7 @@ char * qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPatter
  * @return the ruleset string to be used in policy settings.
  */
 char * qd_policy_compile_allowed_csv(char * csv);
+
 /**
  * Approve sending of message on anonymous link based on connection's policy.
  *
@@ -238,4 +241,19 @@ char * qd_policy_compile_allowed_csv(char * csv);
  * @param[in] qd_conn dispatch connection with policy settings
  */
 bool qd_policy_approve_message_target(qd_iterator_t *address, qd_connection_t *qd_conn);
+
+/**
+ * Tally counters for a link when policy maxMessageSize limit is exceeded.
+ *
+ * @param[in] pn_link proton link being closed
+ * @param[in] qd_conn dispatch connection with policy settings and counts
+ **/
+void qd_policy_count_max_size_event(pn_link_t *link,
+                                        qd_connection_t *qd_conn
+                                       );
+
+/**
+ * Return policy log source
+ */
+qd_log_source_t* qd_policy_log_source();
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -1646,3 +1646,7 @@ sys_mutex_t *qd_server_get_activation_lock(qd_server_t * server)
 {
     return server->conn_activation_lock;
 }
+
+int qd_connection_max_message_size(const qd_connection_t *c) {
+    return (c && c->policy_settings) ? c->policy_settings->maxMessageSize : 0;
+}


### PR DESCRIPTION
This commit has an updated implementation for further review.

Notes:

MaxMessageSize may be specified globally, per vhost, or per vhost user
group. The global setting applies to all vhosts for which maxMessageSize
is unspecified. The vhost setting applies to all vhost user groups for
which maxMessageSize is unspecified. The vhost user group setting
overrides all other settings. A maxMessageSize setting of zero disables
maxMessageSize enforcement.

Links over which maxMessageSize is being enforced will advertise the
size in the _max-message-size_ field of the Attach
frame. Qpid-dispatch ignores the _max-message-size_ field received in
incoming Attach frames.

Message size for maxMessageSize purposes is calculated to be the
number of AMQP octets in the Annotated Message. This includes the
header, delivery-annotations, message-annotations, properties,
application-properties, application-data, and footer
sections. Administrators and users must be aware that a "message"
consisting a single character string (the application-data) will be
much larger over the wire after properties and annotations have been
inserted.

Max message size is enforced on message/transfer ingress only. Once a
message has entered the router network it is free to go to any
destination.

When a message exceeds max size then:

 * Disposition of _rejected_ is returned to the sender for that delivery.
 * Ingress link to qpid-dispatch is closed with an error.
 * Copies of the message being delivered through the router network are aborted.

In message.c oversize messages are detected and then handled as
oversize, discarded, and aborted.

In router_node.c oversize messages are logged, links are closed, and
downstream deliveries are disconnected.

ToDo:

Fix issues in DISPATCH-1581 where policy settings and counters are
_int_ and not _uint64_. That will be a separate work stream.

Fix all resource leaks. Certain patterns of client activity leak
qd_message, qd_link, and qd_disposition resources. Sometimes. More
testing required.

Characterize some issues that AMQP clients suffer when oversize
messages are denied. Clients fail in mysterious ways and some hints on
what is happening and what to do about it will speed client
development.

Improve single-router test to cover multiple routers.