### PR TITLE
DISPATCH-975: Enforce max message size on message ingress

### DIFF
--- a/include/qpid/dispatch/container.h
+++ b/include/qpid/dispatch/container.h
@@ -200,6 +200,7 @@ void qd_link_detach(qd_link_t *link);
 void qd_link_free(qd_link_t *link);
 void *qd_link_get_node_context(const qd_link_t *link);
 void qd_link_restart_rx(qd_link_t *link);
+void qd_connection_log_policy_denial(qd_link_t *link, const char *text);
 
 ///@}
 #endif

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -422,6 +422,12 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
  */
 uint8_t qd_message_get_priority(qd_message_t *msg);
 
+/**
+ * True if message is larger that maxMessageSize
+ * @param msg A pointer to the message
+ * @return 
+ */
+bool qd_message_oversize(const qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -604,6 +604,8 @@ bool qd_connection_strip_annotations_in(const qd_connection_t *c);
 
 void qd_connection_wake(qd_connection_t *ctx);
 
+int qd_connection_max_message_size(const qd_connection_t *c);
+
 /**
  * @}
  */

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1869,6 +1869,13 @@
                     "required": false,
                     "create": true
                 },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied only to transfers over user connections and is not applied to interrouter or edge router connections. This limit may be overridden by vhost or by vhost user group settings. A value of zero disables this limit.",
+                    "required": false,
+                    "create": true
+                },
                 "enableVhostPolicy": {
                     "type": "boolean",
                     "default": false,
@@ -1905,10 +1912,11 @@
                     "graph": true,
                     "description": "The sum of all vhost sender and receiver denials."
                 },
+                "maxMessageSizeDenied": {"type": "integer", "graph": true},
                 "totalDenials": {
                     "type": "integer",
                     "graph": true,
-                    "description": "The total number of connection and link denials."
+                    "description": "The total number of connection, link, and transfer denials."
                 }
             }
         },
@@ -1932,6 +1940,11 @@
                     "required": false,
                     "create": true,
                     "update": true
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections to this vhost. This limit overrides the policy maxMessageSize value and may be overridden by vhost user group settings. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxConnectionsPerUser": {
                     "type": "integer",
@@ -1992,6 +2005,11 @@
                     "description": "Optional maximum number of concurrent connections allowed for any remote host by users in this group. This value, if specified, overrides the vhost maxConnectionsPerHost value",
                     "required": false,
                     "create": false
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections created by users in this group. This limit overrides the policy and vhost maxMessageSize values. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxFrameSize": {
                     "type": "integer",
@@ -2130,7 +2148,8 @@
 
                 "sessionDenied": {"type": "integer", "graph": true},
                 "senderDenied": {"type": "integer", "graph": true},
-                "receiverDenied": {"type": "integer", "graph": true}
+                "receiverDenied": {"type": "integer", "graph": true},
+                "maxMessageSizeDenied": {"type": "integer", "graph": true}
             }
         },
 

--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -201,10 +201,12 @@ def configure_dispatch(dispatch, lib_handle, filename):
     policyDir           = config.by_type('policy')[0]['policyDir']
     policyDefaultVhost  = config.by_type('policy')[0]['defaultVhost']
     useHostnamePatterns = config.by_type('policy')[0]['enableVhostNamePatterns']
+    maxMessageSize      = config.by_type('policy')[0]['maxMessageSize']
     for a in config.by_type("policy"):
         configure(a)
     agent.policy.set_default_vhost(policyDefaultVhost)
     agent.policy.set_use_hostname_patterns(useHostnamePatterns)
+    agent.policy.set_max_message_size(maxMessageSize)
 
     # Remaining configuration
     for t in "sslProfile", "authServicePlugin", "listener", "connector", \

--- a/python/qpid_dispatch_internal/policy/policy_manager.py
+++ b/python/qpid_dispatch_internal/policy/policy_manager.py
@@ -161,6 +161,14 @@ class PolicyManager(object):
         @return: none
         """
         self._policy_local.close_connection(conn_id)
+
+    def set_max_message_size(self, size):
+        """
+        Policy has set global maxMessageSize.
+        :param size:
+        :return: none
+        """
+        self._policy_local.set_max_message_size(size)
 #
 #
 #

--- a/src/container.c
+++ b/src/container.c
@@ -127,7 +127,7 @@ static void setup_outgoing_link(qd_container_t *container, pn_link_t *pn_link)
 }
 
 
-static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link)
+static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link, int max_size)
 {
     qd_node_t *node = container->default_node;
 
@@ -159,6 +159,9 @@ static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link)
     link->node       = node;
     link->remote_snd_settle_mode = pn_link_remote_snd_settle_mode(pn_link);
 
+    if (max_size) {
+        pn_link_set_max_message_size(pn_link, (uint64_t)max_size);
+    }
     pn_link_set_context(pn_link, link);
     node->ntype->incoming_handler(node->context, link);
 }
@@ -577,7 +580,7 @@ void qd_container_handle_event(qd_container_t *container, pn_event_t *event,
                         }
                         qd_conn->n_senders++;
                     }
-                    setup_incoming_link(container, pn_link);
+                    setup_incoming_link(container, pn_link, qd_connection_max_message_size(qd_conn));
                 }
             } else if (pn_link_state(pn_link) & PN_LOCAL_ACTIVE)
                 handle_link_open(container, pn_link);

--- a/src/message.c
+++ b/src/message.c
@@ -29,6 +29,7 @@
 #include "compose_private.h"
 #include "connection_manager_private.h"
 #include "aprintf.h"
+#include "policy.h"
 #include <string.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -1237,14 +1238,13 @@ void qd_message_set_tag_sent(qd_message_t *in_msg, bool tag_sent)
 /**
  * Receive and discard large messages for which there is no destination.
  * Don't waste resources by putting the message into internal buffers.
- * Don't fiddle with locking as no sender is competing with reception.
+ * Message locking is not required since the message content buffers are untouched.
  */
 qd_message_t *discard_receive(pn_delivery_t *delivery,
                               pn_link_t     *link,
                               qd_message_t  *msg_in)
 {
     qd_message_pvt_t *msg  = (qd_message_pvt_t*)msg_in;
-
     while (1) {
 #define DISCARD_BUFFER_SIZE (128 * 1024)
         char dummy[DISCARD_BUFFER_SIZE];
@@ -1255,12 +1255,18 @@ qd_message_t *discard_receive(pn_delivery_t *delivery,
             break;
         } else if (rc == PN_EOS || rc < 0) {
             // end of message or error. Call the message complete
-            msg->content->receive_complete = true;
             msg->content->aborted = pn_delivery_aborted(delivery);
             qd_nullify_safe_ptr(&msg->content->input_link_sp);
-
             pn_record_t *record = pn_delivery_attachments(delivery);
             pn_record_set(record, PN_DELIVERY_CTX, 0);
+            if (msg->content->oversize) {
+                pn_delivery_update(delivery, PN_REJECTED);
+                pn_delivery_settle(delivery);
+                // Oversize messages are also marked as aborted
+                // so that downstream copies to remote receivers get aborted.
+                msg->content->aborted = true;
+            }
+            msg->content->receive_complete = true;
             break;
         } else {
             // rc was > 0. bytes were read and discarded.
@@ -1301,13 +1307,15 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
         msg->strip_annotations_in  = qd_connection_strip_annotations_in(qdc);
         pn_record_def(record, PN_DELIVERY_CTX, PN_WEAKREF);
         pn_record_set(record, PN_DELIVERY_CTX, (void*) msg);
+        msg->content->max_message_size = qd_connection_max_message_size(qdc);
     }
 
     //
     // The discard flag indicates we should keep reading the input stream
     // but not process the message for delivery.
+    // Messages already marked oversize are also discarded.
     //
-    if (msg->content->discard) {
+    if (msg->content->discard || msg->content->oversize) {
         return discard_receive(delivery, link, (qd_message_t *)msg);
     }
 
@@ -1409,10 +1417,25 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
             recv_error = true;
         } else if (rc > 0) {
             //
-            // We have received a positive number of bytes for the message.  Advance
-            // the cursor in the buffer.
+            // We have received a positive number of bytes for the message.  
+            // Advance the cursor in the buffer.
             //
             qd_buffer_insert(content->pending, rc);
+
+            // Handle maxMessageSize violations
+            if (content->max_message_size) {
+                content->bytes_received += rc;
+                if (content->bytes_received > content->max_message_size)
+                {
+                    qd_connection_t *conn = qd_link_connection(qdl);
+                    qd_connection_log_policy_denial(qdl, "DENY AMQP Transfer maxMessageSize exceeded");
+                    // increment policy counters
+                    qd_policy_count_max_size_event(link, conn);
+
+                    content->oversize = true;
+                    return discard_receive(delivery, link, (qd_message_t*)msg);
+                }
+            }
         } else {
             //
             // We received zero bytes, and no PN_EOS.  This means that we've received
@@ -2222,4 +2245,10 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted)
         return;
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
     msg_pvt->content->aborted = aborted;
+}
+
+bool qd_message_oversize(const qd_message_t *msg)
+{
+    qd_message_content_t * mc = MSG_CONTENT(msg);
+    return mc->oversize;
 }

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -109,6 +109,8 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
+    int                  max_message_size;               // configured max; 0 if no max to enforce
+    int                  bytes_received;                 // returned by pn_link_recv()
     uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t_sp         input_link_sp;                  // message received on this link
 
@@ -120,6 +122,7 @@ typedef struct {
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
     bool                 priority_parsed;
     bool                 priority_present;
+    bool                 oversize;                       // policy oversize handling in effect
     uint8_t              priority;                       // The priority of this message
 } qd_message_content_t;
 

--- a/src/policy.c
+++ b/src/policy.c
@@ -46,6 +46,7 @@ static int n_connections = 0;
 static int n_denied = 0;
 static int n_processed = 0;
 static int n_links_denied = 0;
+static int n_maxsize_messages_denied = 0;
 static int n_total_denials = 0;
 
 //
@@ -83,6 +84,9 @@ static PyObject * module = 0;
 
 ALLOC_DEFINE(qd_policy_settings_t);
 
+// Policy log module used outside of policy proper
+qd_log_source_t* policy_log_source = 0;
+
 //
 // Policy configuration/statistics management interface
 //
@@ -116,6 +120,7 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->tree_lock            = sys_mutex();
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
     stats_lock                   = sys_mutex();
+    policy_log_source            = policy->log_source;
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");
     return policy;
@@ -206,7 +211,8 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
     qd_policy_denial_counts_t *dc = (qd_policy_denial_counts_t*)ccounts;
     if (!qd_entity_set_long(entity, "sessionDenied", dc->sessionDenied) &&
         !qd_entity_set_long(entity, "senderDenied", dc->senderDenied) &&
-        !qd_entity_set_long(entity, "receiverDenied", dc->receiverDenied)
+        !qd_entity_set_long(entity, "receiverDenied", dc->receiverDenied) &&
+        !qd_entity_set_long(entity, "maxMessageSizeDenied", dc->maxSizeMessagesDenied)
     )
         return QD_ERROR_NONE;
     return qd_error_code();
@@ -218,13 +224,14 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
  **/
 qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
     // Return global stats
-    int np, nd, nc, nl, nt;
+    int np, nd, nc, nl, nm, nt;
     sys_mutex_lock(stats_lock);
     {
         np = n_processed;
         nd = n_denied;
         nc = n_connections;
         nl = n_links_denied;
+        nm = n_maxsize_messages_denied;
         nt = n_total_denials;
     }
     sys_mutex_unlock(stats_lock);
@@ -232,6 +239,7 @@ qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
         !qd_entity_set_long(entity, "connectionsDenied", nd) &&
         !qd_entity_set_long(entity, "connectionsCurrent", nc) &&
         !qd_entity_set_long(entity, "linksDenied", nl) &&
+        !qd_entity_set_long(entity, "maxMessageSizeDenied", nm) &&
         !qd_entity_set_long(entity, "totalDenials", nt)
     )
         return QD_ERROR_NONE;
@@ -306,16 +314,18 @@ void qd_policy_socket_close(qd_policy_t *policy, const qd_connection_t *conn)
     int ssnDenied = 0;
     int sndDenied = 0;
     int rcvDenied = 0;
+    int sizDenied = 0;
     if (conn->policy_settings && conn->policy_settings->denialCounts) {
         ssnDenied = conn->policy_settings->denialCounts->sessionDenied;
         sndDenied = conn->policy_settings->denialCounts->senderDenied;
         rcvDenied = conn->policy_settings->denialCounts->receiverDenied;
+        sizDenied = conn->policy_settings->denialCounts->maxSizeMessagesDenied;
     }
     qd_log(policy->log_source, QD_LOG_DEBUG, 
            "Connection '%s' closed with resources n_sessions=%d, n_senders=%d, n_receivers=%d, "
-           "sessions_denied=%d, senders_denied=%d, receivers_denied=%d. nConnections= %d.",
+           "sessions_denied=%d, senders_denied=%d, receivers_denied=%d max_size_transfers_denied=%d. nConnections= %d.",
             hostname, conn->n_sessions, conn->n_senders, conn->n_receivers,
-            ssnDenied, sndDenied, rcvDenied, n_connections);
+            ssnDenied, sndDenied, rcvDenied, sizDenied, n_connections);
 }
 
 
@@ -502,6 +512,7 @@ bool qd_policy_open_fetch_settings(
                         settings->maxSessions          = qd_entity_opt_long((qd_entity_t*)upolicy, "maxSessions", 0);
                         settings->maxSenders           = qd_entity_opt_long((qd_entity_t*)upolicy, "maxSenders", 0);
                         settings->maxReceivers         = qd_entity_opt_long((qd_entity_t*)upolicy, "maxReceivers", 0);
+                        settings->maxMessageSize       = qd_entity_opt_long((qd_entity_t*)upolicy, "maxMessageSize", 0);
                         if (!settings->allowAnonymousSender) { //don't override if enabled by authz plugin
                             settings->allowAnonymousSender = qd_entity_opt_bool((qd_entity_t*)upolicy, "allowAnonymousSender", false);
                         }
@@ -665,6 +676,19 @@ void _qd_policy_deny_amqp_receiver_link(pn_link_t *pn_link, qd_connection_t *qd_
     }
 }
 
+
+//
+//
+void qd_policy_count_max_size_event(pn_link_t *link, qd_connection_t *qd_conn)
+{
+    sys_mutex_lock(stats_lock);
+    n_maxsize_messages_denied++;
+    n_total_denials++;
+    sys_mutex_unlock(stats_lock);
+    if (qd_conn->policy_settings && qd_conn->policy_settings->denialCounts) {
+        qd_conn->policy_settings->denialCounts->maxSizeMessagesDenied++;
+    }
+}
 
 /**
  * Given a char return true if it is a parse_tree token separater
@@ -1473,4 +1497,9 @@ char * qd_policy_compile_allowed_csv(char * csv)
     }
     free(dup);
     return result;
+}
+
+
+qd_log_source_t* qd_policy_log_source() {
+    return policy_log_source;
 }

--- a/src/policy.h
+++ b/src/policy.h
@@ -39,6 +39,7 @@ struct qd_policy_denial_counts_s {
     int sessionDenied;
     int senderDenied;
     int receiverDenied;
+    int maxSizeMessagesDenied;
 };
 
 typedef struct qd_policy_t qd_policy_t;
@@ -49,6 +50,7 @@ struct qd_policy__settings_s {
     int  maxSessions;
     int  maxSenders;
     int  maxReceivers;
+    int  maxMessageSize;
     bool allowDynamicSource;
     bool allowAnonymousSender;
     bool allowUserIdProxy;
@@ -231,6 +233,7 @@ char * qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPatter
  * @return the ruleset string to be used in policy settings.
  */
 char * qd_policy_compile_allowed_csv(char * csv);
+
 /**
  * Approve sending of message on anonymous link based on connection's policy.
  *
@@ -238,4 +241,19 @@ char * qd_policy_compile_allowed_csv(char * csv);
  * @param[in] qd_conn dispatch connection with policy settings
  */
 bool qd_policy_approve_message_target(qd_iterator_t *address, qd_connection_t *qd_conn);
+
+/**
+ * Tally counters for a link when policy maxMessageSize limit is exceeded.
+ *
+ * @param[in] pn_link proton link being closed
+ * @param[in] qd_conn dispatch connection with policy settings and counts
+ **/
+void qd_policy_count_max_size_event(pn_link_t *link,
+                                        qd_connection_t *qd_conn
+                                       );
+
+/**
+ * Return policy log source
+ */
+qd_log_source_t* qd_policy_log_source();
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -1646,3 +1646,7 @@ sys_mutex_t *qd_server_get_activation_lock(qd_server_t * server)
 {
     return server->conn_activation_lock;
 }
+
+int qd_connection_max_message_size(const qd_connection_t *c) {
+    return (c && c->policy_settings) ? c->policy_settings->maxMessageSize : 0;
+}


### PR DESCRIPTION
This commit has an updated implementation for final review.

MaxMessageSize may be specified globally, per vhost, or per vhost user
group. The global setting applies to all vhosts for which maxMessageSize
is unspecified. The vhost setting applies to all vhost user groups for
which maxMessageSize is unspecified. The vhost user group setting
overrides all other settings. A maxMessageSize setting of zero disables
maxMessageSize enforcement.

Links over which maxMessageSize is being enforced will advertise the
size in the _max-message-size_ field of the Attach
frame. Qpid-dispatch ignores the _max-message-size_ field received in
incoming Attach frames.

Message size for maxMessageSize purposes is calculated to be the
number of AMQP octets in the Annotated Message. This includes the
header, delivery-annotations, message-annotations, properties,
application-properties, application-data, and footer
sections. Administrators and users must be aware that a "message"
consisting a single character string (the application-data) will be
much larger over the wire after properties and annotations have been
inserted.

Max message size is enforced on message/transfer ingress only. Once a
message has entered the router network it is free to go to any
destination.

When a message exceeds max size then:

 * Disposition of _rejected_ is returned to the sender for that delivery.
 * Copies of the message being delivered through the router network are aborted.
 * Previous versions of this patch closed the sender's ingress link
   with an error. This ensured that a sender would know that the
   message did not get through and would clearly know why. However,
   spontaneous link closures cause a wide variety of serious problems
   for many clients. Link closure should not be enforced until, at a
   minimum, qpid-proton clients handle the closure cleanly.

Self test includes a four-router linear network with two interior and two
edge routers. Tests try oversize messages with a variety of sender and
receiver attachment points in that network.