### PR TITLE
DISPATCH-975: Enforce max message size on message ingress v3

### DIFF
--- a/include/qpid/dispatch/container.h
+++ b/include/qpid/dispatch/container.h
@@ -238,6 +238,8 @@ void qd_session_free(qd_session_t *qd_ssn);
 bool qd_session_is_q3_blocked(const qd_session_t *qd_ssn);
 qd_link_list_t *qd_session_q3_blocked_links(qd_session_t *qd_ssn);
 
+void qd_connection_log_policy_denial(qd_link_t *link, const char *text);
+
 
 // handy macros to get around PROTON-2184: pn_session_set_context aborts if
 // context==0  (can remove this once qdrouter requires >= proton 0.31.x)

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -432,6 +432,12 @@ void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
  */
 uint8_t qd_message_get_priority(qd_message_t *msg);
 
+/**
+ * True if message is larger that maxMessageSize
+ * @param msg A pointer to the message
+ * @return 
+ */
+bool qd_message_oversize(const qd_message_t *msg);
 
 ///@}
 

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -604,6 +604,8 @@ bool qd_connection_strip_annotations_in(const qd_connection_t *c);
 
 void qd_connection_wake(qd_connection_t *ctx);
 
+int qd_connection_max_message_size(const qd_connection_t *c);
+
 /**
  * @}
  */

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1869,6 +1869,13 @@
                     "required": false,
                     "create": true
                 },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied only to transfers over user connections and is not applied to interrouter or edge router connections. This limit may be overridden by vhost or by vhost user group settings. A value of zero disables this limit.",
+                    "required": false,
+                    "create": true
+                },
                 "enableVhostPolicy": {
                     "type": "boolean",
                     "default": false,
@@ -1905,10 +1912,11 @@
                     "graph": true,
                     "description": "The sum of all vhost sender and receiver denials."
                 },
+                "maxMessageSizeDenied": {"type": "integer", "graph": true},
                 "totalDenials": {
                     "type": "integer",
                     "graph": true,
-                    "description": "The total number of connection and link denials."
+                    "description": "The total number of connection, link, and transfer denials."
                 }
             }
         },
@@ -1932,6 +1940,11 @@
                     "required": false,
                     "create": true,
                     "update": true
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections to this vhost. This limit overrides the policy maxMessageSize value and may be overridden by vhost user group settings. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxConnectionsPerUser": {
                     "type": "integer",
@@ -1992,6 +2005,11 @@
                     "description": "Optional maximum number of concurrent connections allowed for any remote host by users in this group. This value, if specified, overrides the vhost maxConnectionsPerHost value",
                     "required": false,
                     "create": false
+                },
+                "maxMessageSize": {
+                    "type": "integer",
+                    "description": "Optional maximum size in bytes of AMQP message transfers allowed for connections created by users in this group. This limit overrides the policy and vhost maxMessageSize values. A value of zero disables this limit.",
+                    "required": false
                 },
                 "maxFrameSize": {
                     "type": "integer",
@@ -2130,7 +2148,8 @@
 
                 "sessionDenied": {"type": "integer", "graph": true},
                 "senderDenied": {"type": "integer", "graph": true},
-                "receiverDenied": {"type": "integer", "graph": true}
+                "receiverDenied": {"type": "integer", "graph": true},
+                "maxMessageSizeDenied": {"type": "integer", "graph": true}
             }
         },
 

--- a/python/qpid_dispatch_internal/management/config.py
+++ b/python/qpid_dispatch_internal/management/config.py
@@ -201,10 +201,12 @@ def configure_dispatch(dispatch, lib_handle, filename):
     policyDir           = config.by_type('policy')[0]['policyDir']
     policyDefaultVhost  = config.by_type('policy')[0]['defaultVhost']
     useHostnamePatterns = config.by_type('policy')[0]['enableVhostNamePatterns']
+    maxMessageSize      = config.by_type('policy')[0]['maxMessageSize']
     for a in config.by_type("policy"):
         configure(a)
     agent.policy.set_default_vhost(policyDefaultVhost)
     agent.policy.set_use_hostname_patterns(useHostnamePatterns)
+    agent.policy.set_max_message_size(maxMessageSize)
 
     # Remaining configuration
     for t in "sslProfile", "authServicePlugin", "listener", "connector", \

--- a/python/qpid_dispatch_internal/policy/policy_manager.py
+++ b/python/qpid_dispatch_internal/policy/policy_manager.py
@@ -161,6 +161,14 @@ class PolicyManager(object):
         @return: none
         """
         self._policy_local.close_connection(conn_id)
+
+    def set_max_message_size(self, size):
+        """
+        Policy has set global maxMessageSize.
+        :param size:
+        :return: none
+        """
+        self._policy_local.set_max_message_size(size)
 #
 #
 #

--- a/src/container.c
+++ b/src/container.c
@@ -159,7 +159,7 @@ static void setup_outgoing_link(qd_container_t *container, pn_link_t *pn_link)
 }
 
 
-static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link)
+static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link, int max_size)
 {
     qd_node_t *node = container->default_node;
 
@@ -191,6 +191,9 @@ static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link)
     link->node       = node;
     link->remote_snd_settle_mode = pn_link_remote_snd_settle_mode(pn_link);
 
+    if (max_size) {
+        pn_link_set_max_message_size(pn_link, (uint64_t)max_size);
+    }
     pn_link_set_context(pn_link, link);
     node->ntype->incoming_handler(node->context, link);
 }
@@ -652,7 +655,7 @@ void qd_container_handle_event(qd_container_t *container, pn_event_t *event,
                         }
                         qd_conn->n_senders++;
                     }
-                    setup_incoming_link(container, pn_link);
+                    setup_incoming_link(container, pn_link, qd_connection_max_message_size(qd_conn));
                 }
             } else if (pn_link_state(pn_link) & PN_LOCAL_ACTIVE)
                 handle_link_open(container, pn_link);

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -109,6 +109,8 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
+    int                  max_message_size;               // configured max; 0 if no max to enforce
+    int                  bytes_received;                 // bytes returned by pn_link_recv() when enforcing max_message_size
     uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t_sp         input_link_sp;                  // message received on this link
 
@@ -120,6 +122,7 @@ typedef struct {
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
     bool                 priority_parsed;
     bool                 priority_present;
+    bool                 oversize;                       // policy oversize handling in effect
     uint8_t              priority;                       // The priority of this message
 } qd_message_content_t;
 

--- a/src/policy.c
+++ b/src/policy.c
@@ -46,6 +46,7 @@ static int n_connections = 0;
 static int n_denied = 0;
 static int n_processed = 0;
 static int n_links_denied = 0;
+static int n_maxsize_messages_denied = 0;
 static int n_total_denials = 0;
 
 //
@@ -83,6 +84,9 @@ static PyObject * module = 0;
 
 ALLOC_DEFINE(qd_policy_settings_t);
 
+// Policy log module used outside of policy proper
+qd_log_source_t* policy_log_source = 0;
+
 //
 // Policy configuration/statistics management interface
 //
@@ -116,6 +120,7 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->tree_lock            = sys_mutex();
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
     stats_lock                   = sys_mutex();
+    policy_log_source            = policy->log_source;
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");
     return policy;
@@ -206,7 +211,8 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
     qd_policy_denial_counts_t *dc = (qd_policy_denial_counts_t*)ccounts;
     if (!qd_entity_set_long(entity, "sessionDenied", dc->sessionDenied) &&
         !qd_entity_set_long(entity, "senderDenied", dc->senderDenied) &&
-        !qd_entity_set_long(entity, "receiverDenied", dc->receiverDenied)
+        !qd_entity_set_long(entity, "receiverDenied", dc->receiverDenied) &&
+        !qd_entity_set_long(entity, "maxMessageSizeDenied", dc->maxSizeMessagesDenied)
     )
         return QD_ERROR_NONE;
     return qd_error_code();
@@ -218,13 +224,14 @@ qd_error_t qd_policy_c_counts_refresh(long ccounts, qd_entity_t *entity)
  **/
 qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
     // Return global stats
-    int np, nd, nc, nl, nt;
+    int np, nd, nc, nl, nm, nt;
     sys_mutex_lock(stats_lock);
     {
         np = n_processed;
         nd = n_denied;
         nc = n_connections;
         nl = n_links_denied;
+        nm = n_maxsize_messages_denied;
         nt = n_total_denials;
     }
     sys_mutex_unlock(stats_lock);
@@ -232,6 +239,7 @@ qd_error_t qd_entity_refresh_policy(qd_entity_t* entity, void *unused) {
         !qd_entity_set_long(entity, "connectionsDenied", nd) &&
         !qd_entity_set_long(entity, "connectionsCurrent", nc) &&
         !qd_entity_set_long(entity, "linksDenied", nl) &&
+        !qd_entity_set_long(entity, "maxMessageSizeDenied", nm) &&
         !qd_entity_set_long(entity, "totalDenials", nt)
     )
         return QD_ERROR_NONE;
@@ -306,16 +314,18 @@ void qd_policy_socket_close(qd_policy_t *policy, const qd_connection_t *conn)
     int ssnDenied = 0;
     int sndDenied = 0;
     int rcvDenied = 0;
+    int sizDenied = 0;
     if (conn->policy_settings && conn->policy_settings->denialCounts) {
         ssnDenied = conn->policy_settings->denialCounts->sessionDenied;
         sndDenied = conn->policy_settings->denialCounts->senderDenied;
         rcvDenied = conn->policy_settings->denialCounts->receiverDenied;
+        sizDenied = conn->policy_settings->denialCounts->maxSizeMessagesDenied;
     }
     qd_log(policy->log_source, QD_LOG_DEBUG, 
            "Connection '%s' closed with resources n_sessions=%d, n_senders=%d, n_receivers=%d, "
-           "sessions_denied=%d, senders_denied=%d, receivers_denied=%d. nConnections= %d.",
+           "sessions_denied=%d, senders_denied=%d, receivers_denied=%d max_size_transfers_denied=%d. nConnections= %d.",
             hostname, conn->n_sessions, conn->n_senders, conn->n_receivers,
-            ssnDenied, sndDenied, rcvDenied, n_connections);
+            ssnDenied, sndDenied, rcvDenied, sizDenied, n_connections);
 }
 
 
@@ -502,6 +512,7 @@ bool qd_policy_open_fetch_settings(
                         settings->maxSessions          = qd_entity_opt_long((qd_entity_t*)upolicy, "maxSessions", 0);
                         settings->maxSenders           = qd_entity_opt_long((qd_entity_t*)upolicy, "maxSenders", 0);
                         settings->maxReceivers         = qd_entity_opt_long((qd_entity_t*)upolicy, "maxReceivers", 0);
+                        settings->maxMessageSize       = qd_entity_opt_long((qd_entity_t*)upolicy, "maxMessageSize", 0);
                         if (!settings->allowAnonymousSender) { //don't override if enabled by authz plugin
                             settings->allowAnonymousSender = qd_entity_opt_bool((qd_entity_t*)upolicy, "allowAnonymousSender", false);
                         }
@@ -665,6 +676,20 @@ void _qd_policy_deny_amqp_receiver_link(pn_link_t *pn_link, qd_connection_t *qd_
     }
 }
 
+
+//
+//
+void qd_policy_count_max_size_event(pn_link_t *link, qd_connection_t *qd_conn)
+{
+    sys_mutex_lock(stats_lock);
+    n_maxsize_messages_denied++;
+    n_total_denials++;
+    sys_mutex_unlock(stats_lock);
+    // TODO: denialCounts is shared among connections and should be protected also
+    if (qd_conn->policy_settings && qd_conn->policy_settings->denialCounts) {
+        qd_conn->policy_settings->denialCounts->maxSizeMessagesDenied++;
+    }
+}
 
 /**
  * Given a char return true if it is a parse_tree token separater
@@ -1473,4 +1498,9 @@ char * qd_policy_compile_allowed_csv(char * csv)
     }
     free(dup);
     return result;
+}
+
+
+qd_log_source_t* qd_policy_log_source() {
+    return policy_log_source;
 }

--- a/src/policy.h
+++ b/src/policy.h
@@ -39,6 +39,7 @@ struct qd_policy_denial_counts_s {
     int sessionDenied;
     int senderDenied;
     int receiverDenied;
+    int maxSizeMessagesDenied;
 };
 
 typedef struct qd_policy_t qd_policy_t;
@@ -49,6 +50,7 @@ struct qd_policy__settings_s {
     int  maxSessions;
     int  maxSenders;
     int  maxReceivers;
+    int  maxMessageSize;
     bool allowDynamicSource;
     bool allowAnonymousSender;
     bool allowUserIdProxy;
@@ -231,6 +233,7 @@ char * qd_policy_host_pattern_lookup(qd_policy_t *policy, const char *hostPatter
  * @return the ruleset string to be used in policy settings.
  */
 char * qd_policy_compile_allowed_csv(char * csv);
+
 /**
  * Approve sending of message on anonymous link based on connection's policy.
  *
@@ -238,4 +241,17 @@ char * qd_policy_compile_allowed_csv(char * csv);
  * @param[in] qd_conn dispatch connection with policy settings
  */
 bool qd_policy_approve_message_target(qd_iterator_t *address, qd_connection_t *qd_conn);
+
+/**
+ * Increment counters for a link when policy maxMessageSize limit is exceeded.
+ *
+ * @param[in] pn_link proton link being with delivery/transfer being rejected
+ * @param[in] qd_conn dispatch connection with policy settings and counts
+ **/
+void qd_policy_count_max_size_event(pn_link_t *link, qd_connection_t *qd_conn);
+
+/**
+ * Return POLICY log_source to log policy 
+ */
+qd_log_source_t* qd_policy_log_source();
 #endif

--- a/src/server.c
+++ b/src/server.c
@@ -1662,3 +1662,7 @@ sys_mutex_t *qd_server_get_activation_lock(qd_server_t * server)
 {
     return server->conn_activation_lock;
 }
+
+int qd_connection_max_message_size(const qd_connection_t *c) {
+    return (c && c->policy_settings) ? c->policy_settings->maxMessageSize : 0;
+}

--- a/tests/system_tests_policy.py
+++ b/tests/system_tests_policy.py
@@ -27,15 +27,17 @@ import os, json, re, signal
 import sys
 import time
 
-from system_test import TestCase, Qdrouterd, main_module, Process, TIMEOUT, DIR
+from system_test import TestCase, Qdrouterd, main_module, Process, TIMEOUT, DIR, QdManager, Logger
 from subprocess import PIPE, STDOUT
-from proton import ConnectionException, Timeout, Url, symbol
+from proton import ConnectionException, Timeout, Url, symbol, Message
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, ReceiverOption
 from proton.utils import BlockingConnection, LinkDetached, SyncRequestResponse
 from qpid_dispatch_internal.policy.policy_util import is_ipv6_enabled
 from qpid_dispatch_internal.compat import dict_iteritems
 from test_broker import FakeBroker
+
+W_THREADS = 2
 
 class AbsoluteConnectionCountLimit(TestCase):
     """
@@ -1383,7 +1385,7 @@ class ConnectorPolicyMisconfiguredClient(FakeBroker):
             self._thread.join(timeout=5)
 
     def on_start(self, event):
-        self.timer          = event.reactor.schedule(10.0, Timeout(self))        
+        self.timer          = event.reactor.schedule(10.0, Timeout(self))
         self.acceptor = event.container.listen(self.url)
 
     def timeout(self):
@@ -1392,7 +1394,7 @@ class ConnectorPolicyMisconfiguredClient(FakeBroker):
     def on_connection_opening(self, event):
         self.connection_opening += 1
         super(ConnectorPolicyMisconfiguredClient, self).on_connection_opening(event)
-        
+
     def on_connection_opened(self, event):
         self.connection_opened += 1
         super(ConnectorPolicyMisconfiguredClient, self).on_connection_opened(event)
@@ -1407,7 +1409,7 @@ class ConnectorPolicyMisconfigured(TestCase):
     to open the connection if the policy is not defined
     """
     remoteListenerPort = None
-    
+
     @classmethod
     def setUpClass(cls):
         """Start the router"""
@@ -1456,7 +1458,7 @@ class ConnectorPolicyMisconfigured(TestCase):
             time.sleep(0.1)
         tc.join()
         self.assertTrue(tc.connection_error == 1)
-        
+
 #
 
 class ConnectorPolicyClient(FakeBroker):
@@ -1529,7 +1531,7 @@ class ConnectorPolicyClient(FakeBroker):
             self._thread.join(timeout=5)
 
     def on_start(self, event):
-        self.timer    = event.reactor.schedule(60, Timeout(self))        
+        self.timer    = event.reactor.schedule(60, Timeout(self))
         self.acceptor = event.container.listen(self.url)
 
     def timeout(self):
@@ -1824,6 +1826,816 @@ class ConnectorPolicyNSndrRcvr(TestCase):
             except:
                 res = False
             self.assertFalse(res)
+
+class MaxMessageSize1(TestCase):
+    """
+    verify that maxMessageSize propagates from policy->vhost->vhostGroup
+    """
+    policy_type = "org.apache.qpid.dispatch.policy"
+    vhost_type = "org.apache.qpid.dispatch.vhost"
+    groups_type = "org.apache.qpid.dispatch.vhostUserGroupSettings"
+
+    @classmethod
+    def setUpClass(cls):
+        """Start the router"""
+        super(MaxMessageSize1, cls).setUpClass()
+        config = Qdrouterd.Config([
+            ('router', {'mode': 'standalone', 'id': 'MaxMessageSize1'}),
+            ('listener', {'port': cls.tester.get_port()}),
+            ('policy', {'maxConnections': 100, 'enableVhostPolicy': 'true', 'maxMessageSize': 1000000, 'defaultVhost': '$default'}),
+            ('vhost', {
+                'hostname': '$default',
+                'allowUnknownUser': 'true',
+                'groups': [(
+                    '$default', {
+                        'users': '*',
+                        'maxConnections': 100,
+                        'remoteHosts': '*',
+                        'sources': '*',
+                        'targets': '*',
+                        'allowAnonymousSender': 'true',
+                        'allowWaypointLinks': 'true',
+                        'allowDynamicSource': 'true'
+                    }
+                )]
+            }),
+            ('vhost', {
+                'hostname': 'vhostMaxMsgSize',
+                'allowUnknownUser': 'true',
+                'maxMessageSize': 2000000,
+                'groups': [(
+                    '$default', {
+                        'users': '*',
+                        'maxConnections': 100,
+                        'remoteHosts': '*',
+                        'sources': '*',
+                        'targets': '*',
+                        'allowAnonymousSender': 'true',
+                        'allowWaypointLinks': 'true',
+                        'allowDynamicSource': 'true'
+                    }
+                )]
+            }),
+            ('vhost', {
+                'hostname': 'vhostUserMaxMsgSize',
+                'allowUnknownUser': 'true',
+                'groups': [(
+                    '$default', {
+                        'users': '*',
+                        'maxConnections': 100,
+                        'remoteHosts': '*',
+                        'sources': '*',
+                        'targets': '*',
+                        'allowAnonymousSender': 'true',
+                        'allowWaypointLinks': 'true',
+                        'allowDynamicSource': 'true',
+                        'maxMessageSize': 3000000
+                    }
+                )]
+            })
+
+        ])
+
+        cls.router = cls.tester.qdrouterd('MaxMessageSize1', config, wait=True)
+
+    def address(self):
+        return self.router.addresses[0]
+
+    def test_39_verify_max_message_size_policy_settings(self):
+        # Verify that max message sizes get instantiated in policy
+        qd_manager = QdManager(self, self.address())
+        policy = qd_manager.query(self.policy_type)
+        self.assertTrue(policy[0]['maxMessageSize'] == 1000000)
+
+        vhost = qd_manager.query(self.vhost_type)
+
+        # vhost with no max size defs
+        ddef = vhost[0]
+        self.assertTrue(ddef['hostname'] == '$default')
+
+        ddefmax = int(ddef.get('maxMessageSize', -1))
+        self.assertTrue(ddefmax == -1)
+
+        groups = ddef.get('groups', None)
+        gsettings = groups.get('$default', None)
+        self.assertTrue(gsettings is not None)
+
+        ddefgmax = int(gsettings.get('maxMessageSize', -1))
+        self.assertTrue(ddefgmax == -1)
+
+        # vhost with max size defined in vhost but not in group
+        ddef = vhost[1]
+        self.assertTrue(ddef['hostname'] == 'vhostMaxMsgSize')
+
+        ddefmax = int(ddef.get('maxMessageSize', -1))
+        self.assertTrue(ddefmax == 2000000)
+
+        groups = ddef.get('groups', None)
+        gsettings = groups.get('$default', None)
+        self.assertTrue(gsettings is not None)
+
+        ddefgmax = int(gsettings.get('maxMessageSize', -1))
+        self.assertTrue(ddefgmax == -1)
+
+        # vhost with max size defined in group but not in vhost
+        ddef = vhost[2]
+        self.assertTrue(ddef['hostname'] == 'vhostUserMaxMsgSize')
+
+        ddefmax = int(ddef.get('maxMessageSize', -1))
+        self.assertTrue(ddefmax == -1)
+
+        groups = ddef.get('groups', None)
+        gsettings = groups.get('$default', None)
+        self.assertTrue(gsettings is not None)
+
+        ddefgmax = int(gsettings.get('maxMessageSize', -1))
+        self.assertTrue(ddefgmax == 3000000)
+
+#
+# DISPATCH-975 Detect that an oversize message was blocked by qdr
+#
+class OversizeMessageTransferTest(MessagingHandler):
+    """
+    This test connects a sender and a receiver. Then it sends _count_ number  of messages
+    of the given size optionally expecting that the messages will be rejected by the router.
+
+    With expect_block=True sender messages should be rejected.
+    The receiver may receive aborted indications but that is not guaranteed.
+    The test is a success when n_rejected == count.
+
+    With expect_block=False sender messages should be received normally.
+    The test is a success when n_accepted == count.
+    """
+    def __init__(self, sender_host, receiver_host, test_address,
+                 message_size=100000, count=10, expect_block=True):
+        super(OversizeMessageTransferTest, self).__init__()
+        self.sender_host = sender_host
+        self.receiver_host = receiver_host
+        self.test_address = test_address
+        self.msg_size = message_size
+        self.count = count
+        self.expect_block = expect_block
+
+        self.sender_conn = None
+        self.receiver_conn = None
+        self.error = None
+        self.sender = None
+        self.receiver = None
+        self.proxy = None
+
+        self.n_sent = 0
+        self.n_rcvd = 0
+        self.n_accepted = 0
+        self.n_rejected = 0
+        self.n_aborted = 0
+
+        self.logger = Logger(title=("OversizeMessageTransferTest - %s" % (self.test_address))) # , print_to_console=True)
+        self.log_unhandled = not self.expect_block
+
+    def timeout(self):
+        self.error = "Timeout Expired: n_sent=%d n_rcvd=%d n_rejected=%d n_aborted=%d" % \
+                     (self.n_sent, self.n_rcvd, self.n_rejected, self.n_aborted)
+        self.logger.log("self.timeout " + self.error)
+        self._shut_down_test()
+
+    def on_start(self, event):
+        self.logger.log("on_start")
+        self.timer = event.reactor.schedule(TIMEOUT, Timeout(self))
+        self.logger.log("on_start: opening receiver connection to %s" % (self.receiver_host.addresses[0]))
+        self.receiver_conn = event.container.connect(self.receiver_host.addresses[0])
+        self.logger.log("on_start: opening   sender connection to %s" % (self.sender_host.addresses[0]))
+        self.sender_conn = event.container.connect(self.sender_host.addresses[0])
+        self.logger.log("on_start: Creating receiver")
+        self.receiver = event.container.create_receiver(self.receiver_conn, self.test_address)
+        self.logger.log("on_start: Creating sender")
+        self.sender = event.container.create_sender(self.sender_conn, self.test_address)
+        self.logger.log("on_start: done")
+
+    def send(self):
+        while self.sender.credit > 0 and self.n_sent < self.count:
+            # construct message in indentifiable chunks
+            body_msg = ""
+            padchar = "abcdefghijklmnopqrstuvwxyz@#$%"[self.n_sent % 30]
+            while len(body_msg) < self.msg_size:
+                chunk = "[%s:%d:%d" % (self.test_address, self.n_sent, len(body_msg))
+                padlen = 50 - len(chunk)
+                chunk += padchar * padlen
+                body_msg += chunk
+            if len(body_msg) > self.msg_size:
+                body_msg = body_msg[:self.msg_size]
+            self.logger.log("send. address:%s message:%d of %s length=%d" %
+                            (self.test_address, self.n_sent, self.count, self.msg_size))
+            m = Message(body=body_msg)
+            self.sender.send(m)
+            self.n_sent += 1
+
+    def on_sendable(self, event):
+        if event.sender == self.sender:
+            self.logger.log("on_sendable")
+            self.send()
+
+    def on_message(self, event):
+        if self.expect_block:
+            # All messages should violate maxMessageSize.
+            # Receiving any is an error.
+            self.error = "Received a message. Expected to receive no messages."
+            self.logger.log(self.error)
+            self._shut_down_test()
+        else:
+            self.n_rcvd += 1
+            self.accept(event.delivery)
+            self._check_done()
+
+    def _shut_down_test(self):
+        if self.timer:
+            self.timer.cancel()
+            self.timer = None
+        if self.sender:
+            self.sender.close()
+            self.sender = None
+        if self.receiver:
+            self.receiver.close()
+            self.receiver = None
+        if self.sender_conn:
+            self.sender_conn.close()
+            self.sender_conn = None
+        if self.receiver_conn:
+            self.receiver_conn.close()
+            self.receiver_conn = None
+
+    def _check_done(self):
+        current = ("check_done: sent=%d rcvd=%d rejected=%d aborted=%d" %
+                   (self.n_sent, self.n_rcvd, self.n_rejected, self.n_aborted))
+        self.logger.log(current)
+        done = (self.n_sent == self.count and self.n_rejected == self.count) \
+                if self.expect_block else \
+                (self.n_sent == self.count and self.n_rcvd == self.count)
+
+        if done:
+            self.logger.log("TEST DONE!!!")
+            # self.log_unhandled = True # verbose debugging
+            self._shut_down_test()
+
+    def on_rejected(self, event):
+        self.logger.log("on_rejected: entry")
+        self.n_rejected += 1
+        self._check_done()
+
+    def on_aborted(self, event):
+        self.logger.log("on_aborted")
+        self.n_aborted += 1
+        self._check_done()
+
+    def on_error(self, event):
+        self.error = "Container error"
+        self.logger.log(self.error)
+        self.sender_conn.close()
+        self.receiver_conn.close()
+        self.timer.cancel()
+
+    def on_link_error(self, event):
+        self.error = event.link.remote_condition.name
+        self.logger.log("on_link_error: %s" % (self.error))
+        #
+        # qpid-proton master @ 6abb4ce
+        # At this point the container is wedged and closing the connections does
+        # not get the container to exit.
+        # Instead, raise an exception that bypasses normal container exit.
+        # This class then returns something for the main test to evaluate.
+        #
+        raise Exception(self.error)
+
+    def on_unhandled(self, method, *args):
+        if self.log_unhandled:
+            self.logger.log("on_unhandled: method: %s, args: %s" % (method, args))
+
+    def run(self):
+        try:
+            Container(self).run()
+        except Exception as e:
+            self.error = "Container run exception: %s" % (e)
+            self.logger.log(self.error)
+            self.logger.dump()
+
+
+# For the next test case define max sizes for each router
+EA1_MAX_SIZE = 50000
+INTA_MAX_SIZE = 100000
+INTB_MAX_SIZE = 150000
+EB1_MAX_SIZE = 200000
+
+# The bytes-over and bytes-under max that should trigger allow or deny.
+# Messages with content this much over should be blocked while
+# messages with content this much under should be allowed.
+OVER_UNDER = 20
+
+
+class MaxMessageSizeBlockOversize(TestCase):
+    """
+    verify that maxMessageSize blocks oversize messages
+    """
+    @classmethod
+    def setUpClass(cls):
+        """Start the router"""
+        super(MaxMessageSizeBlockOversize, cls).setUpClass()
+
+        def router(name, mode, max_size, extra):
+            config = [
+                ('router', {'mode': mode,
+                            'id': name,
+                            'allowUnsettledMulticast': 'yes',
+                            'workerThreads': W_THREADS}),
+                ('listener', {'role': 'normal',
+                              'port': cls.tester.get_port()}),
+                ('address', {'prefix': 'multicast', 'distribution': 'multicast'}),
+                ('policy', {'maxConnections': 100, 'enableVhostPolicy': 'true', 'maxMessageSize': max_size, 'defaultVhost': '$default'}),
+                ('vhost', {'hostname': '$default', 'allowUnknownUser': 'true',
+                    'groups': [(
+                        '$default', {
+                            'users': '*',
+                            'maxConnections': 100,
+                            'remoteHosts': '*',
+                            'sources': '*',
+                            'targets': '*',
+                            'allowAnonymousSender': 'true',
+                            'allowWaypointLinks': 'true',
+                            'allowDynamicSource': 'true'
+                        }
+                    )]}
+                )
+            ]
+
+            if extra:
+                config.extend(extra)
+            config = Qdrouterd.Config(config)
+            cls.routers.append(cls.tester.qdrouterd(name, config, wait=True))
+            return cls.routers[-1]
+
+        # configuration:
+        # two edge routers connected via 2 interior routers.
+        #
+        #  +-------+    +---------+    +---------+    +-------+
+        #  |  EA1  |<==>|  INT.A  |<==>|  INT.B  |<==>|  EB1  |
+        #  +-------+    +---------+    +---------+    +-------+
+        #
+        # Note:
+        #  * Messages whose senders connect to INT.A or INT.B are subject to max message size
+        #    defined for the ingress router only.
+        #  * Message whose senders connect to EA1 or EA2 are subject to max message size
+        #    defined for the ingress router. If the message is forwarded through the
+        #    connected interior router then the message is subject to another max message size
+        #    defined by the interior router.
+
+        cls.routers = []
+
+        interrouter_port = cls.tester.get_port()
+        cls.INTA_edge_port   = cls.tester.get_port()
+        cls.INTB_edge_port   = cls.tester.get_port()
+
+        router('INT.A', 'interior', INTA_MAX_SIZE,
+               [('listener', {'role': 'inter-router',
+                              'port': interrouter_port}),
+                ('listener', {'role': 'edge', 'port': cls.INTA_edge_port})])
+        cls.INT_A = cls.routers[0]
+        cls.INT_A.listener = cls.INT_A.addresses[0]
+
+        router('INT.B', 'interior', INTB_MAX_SIZE,
+               [('connector', {'name': 'connectorToA',
+                               'role': 'inter-router',
+                               'port': interrouter_port}),
+                ('listener', {'role': 'edge',
+                              'port': cls.INTB_edge_port})])
+        cls.INT_B = cls.routers[1]
+        cls.INT_B.listener = cls.INT_B.addresses[0]
+
+        router('EA1', 'edge', EA1_MAX_SIZE,
+               [('listener', {'name': 'rc', 'role': 'route-container',
+                              'port': cls.tester.get_port()}),
+                ('connector', {'name': 'uplink', 'role': 'edge',
+                               'port': cls.INTA_edge_port})])
+        cls.EA1 = cls.routers[2]
+        cls.EA1.listener = cls.EA1.addresses[0]
+
+        router('EB1', 'edge', EB1_MAX_SIZE,
+               [('connector', {'name': 'uplink',
+                               'role': 'edge',
+                               'port': cls.INTB_edge_port,
+                               'maxFrameSize': 1024}),
+                ('listener', {'name': 'rc', 'role': 'route-container',
+                              'port': cls.tester.get_port()})])
+        cls.EB1 = cls.routers[3]
+        cls.EB1.listener = cls.EB1.addresses[0]
+
+        cls.INT_A.wait_router_connected('INT.B')
+        cls.INT_B.wait_router_connected('INT.A')
+        cls.EA1.wait_connectors()
+        cls.EB1.wait_connectors()
+
+    def test_40_block_oversize_INTA_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e40",
+                                           message_size=INTA_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_40 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_41_block_oversize_INTA_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e41",
+                                           message_size=INTA_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_41 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_42_block_oversize_INTA_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e42",
+                                           message_size=INTA_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_42 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_43_block_oversize_INTA_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e43",
+                                           message_size=INTA_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_43 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_44_block_oversize_INTB_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e44",
+                                           message_size=INTB_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_44 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_45_block_oversize_INTB_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e45",
+                                           message_size=INTB_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_45 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_46_block_oversize_INTB_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e46",
+                                           message_size=INTB_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_46 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_47_block_oversize_INTB_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e47",
+                                           message_size=INTB_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_47 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_48_block_oversize_EA1_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e48",
+                                           message_size=EA1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_48 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_49_block_oversize_EA1_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e49",
+                                           message_size=EA1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_49 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4a_block_oversize_EA1_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e4a",
+                                           message_size=EA1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4a test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4b_block_oversize_EA1_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e4b",
+                                           message_size=EA1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4b test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4c_block_oversize_EB1_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e4c",
+                                           message_size=EB1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4c test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4d_block_oversize_EB1_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e4d",
+                                           message_size=EB1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4d test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4e_block_oversize_EB1_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e4e",
+                                           message_size=EB1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4e test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4f_block_oversize_EB1_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e4f",
+                                           message_size=EB1_MAX_SIZE + OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4f test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_4g_block_oversize_EB1_INTA(self):
+        # allowed by EB1 but blocked by INT.A
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e4g",
+                                           message_size=EB1_MAX_SIZE - OVER_UNDER,
+                                           expect_block=True)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_4g test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    #
+    # tests under maxMessageSize should not block
+    #
+    def test_50_allow_undersize_INTA_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e50",
+                                           message_size=INTA_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_50 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_51_allow_undersize_INTA_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e51",
+                                           message_size=INTA_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_51 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_52_allow_undersize_INTA_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e52",
+                                           message_size=INTA_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_52 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_53_allow_undersize_INTA_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_A,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e53",
+                                           message_size=INTA_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_53 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_54_allow_undersize_INTB_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e54",
+                                           message_size=INTB_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_54 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_55_allow_undersize_INTB_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e55",
+                                           message_size=INTB_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_55 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_56_allow_undersize_INTB_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e56",
+                                           message_size=INTB_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_56 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_57_allow_undersize_INTB_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.INT_B,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e57",
+                                           message_size=INTB_MAX_SIZE - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_57 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_58_allow_undersize_EA1_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e58",
+                                           message_size=min(EA1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_58 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+
+    def test_59_allow_undersize_EA1_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e59",
+                                           message_size=min(EA1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_59 test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+
+    def test_5a_allow_undersize_EA1_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e5a",
+                                           message_size=min(EA1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_5a test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+
+    def test_5b_allow_undersize_EA1_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EA1,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e5b",
+                                           message_size=min(EA1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_5b test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+    def test_5c_allow_undersize_EB1_INTA(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.INT_A,
+                                           "e5c",
+                                           message_size=min(EB1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_5c test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+
+    def test_5d_allow_undersize_EB1_INTB(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.INT_B,
+                                           "e5d",
+                                           message_size=min(EB1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_5d test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+
+    def test_5e_allow_undersize_EB1_EA1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.EA1,
+                                           "e5e",
+                                           message_size=min(EB1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_5e test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
+
+
+    def test_5f_allow_undersize_EB1_EB1(self):
+        test = OversizeMessageTransferTest(MaxMessageSizeBlockOversize.EB1,
+                                           MaxMessageSizeBlockOversize.EB1,
+                                           "e5f",
+                                           message_size=min(EB1_MAX_SIZE, INTA_MAX_SIZE) - OVER_UNDER,
+                                           expect_block=False)
+        test.run()
+        if test.error is not None:
+            test.logger.log("test_5f test error: %s" % (test.error))
+            test.logger.dump()
+        self.assertTrue(test.error is None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This update incorporates review comments and a number of new features:

* All pn_delivery work is moved out of message.c and into router_node.c
* log_link_message identifies oversize messages
* Oversize message handling in router_node.c is separated into an
  isolated section of code making it easier to reason about how
  oversize messages are handled.
* Self tests are improved
** Each router has a different maxMessagesize
** Sixteen tests connect to each of four routers with senders and
   receivers.
** Oversize and Undersize messages are checked to prove that routers
   with smaller limits will successfully pass through larger messages.
** Interior routers with smaller limits than attached edge routers
   will block messages that the edge routers allow but are over the
   interior router limit.

TODO:

* This version still leaks resource (iterator, buffer, parsed_field,
message, message_content, and delivery) objects under some conditions.
* No tests yet for multicast or link route.


================================================================
Comments from previous pull requests
================================================================
This commit has an updated implementation for review (v2 PR#698)

MaxMessageSize may be specified globally, per vhost, or per vhost user
group. The global setting applies to all vhosts for which maxMessageSize
is unspecified. The vhost setting applies to all vhost user groups for
which maxMessageSize is unspecified. The vhost user group setting
overrides all other settings. A maxMessageSize setting of zero disables
maxMessageSize enforcement.

Links over which maxMessageSize is being enforced will advertise the
size in the max-message-size field of the Attach
frame. Qpid-dispatch ignores the max-message-size field received in
incoming Attach frames.

Message size for maxMessageSize purposes is calculated to be the
number of AMQP octets in the Annotated Message. This includes the
header, delivery-annotations, message-annotations, properties,
application-properties, application-data, and footer
sections. Administrators and users must be aware that a "message"
consisting a single character string (the application-data) will be
much larger over the wire after properties and annotations have been
inserted.

Max message size is enforced on message/transfer ingress only. Once a
message has entered the router network it is free to go to any
destination.

When a message exceeds max size then:

 *  Disposition of rejected is returned to the sender for that delivery.
 *  Copies of the message being delivered through the router network are aborted.
 *  Previous versions of this patch closed the sender's ingress link
    with an error. This ensured that a sender would know that the
    message did not get through and would clearly know why. However,
    spontaneous link closures cause a wide variety of serious problems
    for many clients. Link closure should not be enforced until, at a
    minimum, qpid-proton clients handle the closure cleanly.

Self test includes a four-router linear network with two interior and two
edge routers. Tests try oversize and undersize messages with a variety of sender and
receiver attachment points in that network.