### PR TITLE
Added debug-dump backtrace for leaked objects in pooled memory.

### DIFF
--- a/include/qpid/dispatch/alloc_pool.h
+++ b/include/qpid/dispatch/alloc_pool.h
@@ -66,6 +66,7 @@ typedef struct {
     qd_alloc_pool_t      *global_pool;
     sys_mutex_t          *lock;
     qd_alloc_pool_list_t  tpool_list;
+    void                 *debug;
     uint32_t              trailer;
 } qd_alloc_type_desc_t;
 

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -547,10 +547,11 @@ void qd_alloc_finalize(void)
             qd_alloc_item_t *item = DEQ_HEAD(qtype->allocated);
             while (item) {
                 size_t i;
-                char   **strings;
-                strings = backtrace_symbols (item->backtrace, item->backtrace_size);
+                char **strings;
+                strings = backtrace_symbols(item->backtrace, item->backtrace_size);
                 for (i = 0; i < item->backtrace_size; i++)
-                    fprintf (dump_file, "%s\n", strings[i]);
+                    fprintf(dump_file, "%s\n", strings[i]);
+                free(strings);
                 fprintf(dump_file, "\n");
                 item = DEQ_NEXT(item);
             }

--- a/src/log.c
+++ b/src/log.c
@@ -33,7 +33,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
 #include <syslog.h>
 
 #define TEXT_MAX QD_LOG_TEXT_MAX
@@ -90,6 +89,17 @@ void qd_log_global_options(const char* _format, bool _utc) {
     if (_format) format = _format;
     utc = _utc;
 }
+
+
+void qd_log_formatted_time(struct timeval *time, char *buf, size_t buflen)
+{
+    time_t sec = time->tv_sec;
+    struct tm *tm_time = utc ? gmtime(&sec) : localtime(&sec);
+    char fmt[100];
+    strftime(fmt, sizeof fmt, format, tm_time);
+    snprintf(buf, buflen, fmt, time->tv_usec);
+}
+
 
 static const char* SINK_STDOUT = "stdout";
 static const char* SINK_STDERR = "stderr";
@@ -309,11 +319,7 @@ static void write_log(qd_log_source_t *log_source, qd_log_entry_t *entry)
         char buf[100];
         buf[0] = '\0';
 
-        time_t sec = entry->time.tv_sec;
-        struct tm *time = utc ? gmtime(&sec) : localtime(&sec);
-        char fmt[100];
-        strftime(fmt, sizeof fmt, format, time);
-        snprintf(buf, 100, fmt, entry->time.tv_usec);
+        qd_log_formatted_time(&entry->time, buf, 100);
 
         aprintf(&begin, end, "%s ", buf);
     }

--- a/src/log_private.h
+++ b/src/log_private.h
@@ -20,10 +20,12 @@
  */
 
 #include <qpid/dispatch/log.h>
+#include <time.h>
 
 void qd_log_initialize(void);
 void qd_log_global_options(const char* format, bool utc);
 void qd_log_finalize(void);
+void qd_log_formatted_time(struct timeval *time, char *buf, size_t buflen);
 
 #define QD_LOG_TEXT_MAX 2048
 #endif


### PR DESCRIPTION
If QD_MEMORY_DEBUG is defined, this stores a backtrace for each allocated pool object so that objects left unfreed can be better described at shutdown.

This is a fairly expensive feature.  We may want to consider providing an extra definable option so we can use QD_MEMORY_DEBUG without using this new feature.
