### PR TITLE
DISPATCH-1614: Nullify address inlink and outlink when connection lost

### DIFF
--- a/src/router_core/modules/edge_router/addr_proxy.c
+++ b/src/router_core/modules/edge_router/addr_proxy.c
@@ -271,7 +271,9 @@ static void on_conn_event(void *context, qdrc_event_t event, qdr_connection_t *c
                 // Nullify the edge link references in case there are any left over from an earlier
                 // instance of an edge connection.
                 //
+                assert(addr->edge_inlink  == 0);
                 addr->edge_inlink  = 0;
+                assert(addr->edge_outlink == 0);
                 addr->edge_outlink = 0;
 
                 //
@@ -323,6 +325,11 @@ static void on_conn_event(void *context, qdrc_event_t event, qdr_connection_t *c
     }
 
     case QDRC_EVENT_CONN_EDGE_LOST :
+        for (qdr_address_t *addr = DEQ_HEAD(ap->core->addrs); addr; addr = DEQ_NEXT(addr)) {
+            addr->edge_inlink  = 0;
+            addr->edge_outlink = 0;
+        }
+
         ap->edge_conn_established = false;
         ap->edge_conn             = 0;
         break;

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -581,6 +581,9 @@ void qdr_core_unbind_address_link_CT(qdr_core_t *core, qdr_address_t *addr, qdr_
             qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_NO_LONGER_LOCAL_DEST, addr);
         } else if (DEQ_SIZE(addr->rlinks) == 1 && qd_bitmask_cardinality(addr->rnodes) == 0)
             qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ONE_LOCAL_DEST, addr);
+        if (addr->edge_outlink == link) {
+            addr->edge_outlink = 0;
+        }
     } else {
         bool removed = qdr_del_link_ref(&addr->inlinks, link, QDR_LINK_LIST_CLASS_ADDRESS);
         if (removed) {
@@ -593,6 +596,9 @@ void qdr_core_unbind_address_link_CT(qdr_core_t *core, qdr_address_t *addr, qdr_
                 if (!!addr->fallback && !link->fallback)
                     qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ONE_SOURCE, addr->fallback);
             }
+        }
+        if (addr->edge_inlink == link) {
+            addr->edge_inlink = 0;
         }
     }
 }


### PR DESCRIPTION
Prevent segfault referencing deleted links when connection is lost.
Assert that the pointers are null when a connection is created.