### PR TITLE
DISPATCH-1645: Use uint64_t for max message size at run time

### DIFF
--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -604,7 +604,7 @@ bool qd_connection_strip_annotations_in(const qd_connection_t *c);
 
 void qd_connection_wake(qd_connection_t *ctx);
 
-int qd_connection_max_message_size(const qd_connection_t *c);
+uint64_t qd_connection_max_message_size(const qd_connection_t *c);
 
 /**
  * @}

--- a/src/container.c
+++ b/src/container.c
@@ -159,7 +159,7 @@ static void setup_outgoing_link(qd_container_t *container, pn_link_t *pn_link)
 }
 
 
-static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link, int max_size)
+static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link, uint64_t max_size)
 {
     qd_node_t *node = container->default_node;
 
@@ -192,7 +192,7 @@ static void setup_incoming_link(qd_container_t *container, pn_link_t *pn_link, i
     link->remote_snd_settle_mode = pn_link_remote_snd_settle_mode(pn_link);
 
     if (max_size) {
-        pn_link_set_max_message_size(pn_link, (uint64_t)max_size);
+        pn_link_set_max_message_size(pn_link, max_size);
     }
     pn_link_set_context(pn_link, link);
     node->ntype->incoming_handler(node->context, link);

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -109,8 +109,8 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
-    int                  max_message_size;               // configured max; 0 if no max to enforce
-    int                  bytes_received;                 // bytes returned by pn_link_recv() when enforcing max_message_size
+    uint64_t             max_message_size;               // configured max; 0 if no max to enforce
+    uint64_t             bytes_received;                 // bytes returned by pn_link_recv() when enforcing max_message_size
     uint32_t             fanout;                         // The number of receivers for this message, including in-process subscribers.
     qd_link_t_sp         input_link_sp;                  // message received on this link
 

--- a/src/policy.h
+++ b/src/policy.h
@@ -50,7 +50,7 @@ struct qd_policy__settings_s {
     int  maxSessions;
     int  maxSenders;
     int  maxReceivers;
-    int  maxMessageSize;
+    uint64_t  maxMessageSize;
     bool allowDynamicSource;
     bool allowAnonymousSender;
     bool allowUserIdProxy;

--- a/src/server.c
+++ b/src/server.c
@@ -1668,6 +1668,6 @@ sys_mutex_t *qd_server_get_activation_lock(qd_server_t * server)
     return server->conn_activation_lock;
 }
 
-int qd_connection_max_message_size(const qd_connection_t *c) {
+uint64_t qd_connection_max_message_size(const qd_connection_t *c) {
     return (c && c->policy_settings) ? c->policy_settings->maxMessageSize : 0;
 }


### PR DESCRIPTION
Policy settings and statistics were using unsigned 64 bit values.
Runtime code was demoting them to signed 32 bit values.

The 1.12 implementation works correctly only for max message
size limits less than 2^31. This includes value up to 2,147,483,647.