### PR TITLE
DISPATCH-1640: How to avoid having message size limits block edge man…

### DIFF
--- a/docs/books/modules/user-guide/setting-global-connection-limits.adoc
+++ b/docs/books/modules/user-guide/setting-global-connection-limits.adoc
@@ -37,12 +37,12 @@ This example sets the incoming connection limit and message size:
 ----
 policy {
     maxConnections: 10000
-    maxMessageSize: 500000
+    maxMessageSize: 2000000
 }
 ----
 `maxConnections`::
 The total number of concurrent client connections that can be open for this router. This limit is always enforced, even if no other policy settings have been defined. The limit is applied to all incoming connections regardless of remote host, authenticated user, or targeted vhost. The default (and the maximum) value is `65535`.
 
 `maxMessageSize`::
-The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied only to transfers over user connections and is not applied to inter-router or edge router connections. This limit may be overridden by vhost or by vhost user group settings. A value of `0` disables this limit.
+The maximum size in bytes of AMQP message transfers allowed for this router as messages enter the router network. This limit is applied to transfers over user connections and to transfers to interior routers from edge routers. This limit is not applied to interior-to-interior router connections. This limit may be overridden by vhost or by vhost user group settings. A value of `0` disables this limit. Administrators are advised not set interior router maximum message sizes so low that edge router management requests or responses are blocked. Administrators are also advised to set edge router maximum message sizes lower than the attached interior router maximum message size.
 --

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1872,7 +1872,7 @@
                 "maxMessageSize": {
                     "type": "integer",
                     "default": 0,
-                    "description": "The maximum size in bytes of AMQP message transfers allowed for this router. This limit is applied only to transfers over user connections and is not applied to interrouter or edge router connections. This limit may be overridden by vhost or by vhost user group settings. A value of zero disables this limit.",
+                    "description": "The maximum size in bytes of AMQP message transfers allowed for this router as messages enter the router network. This limit is applied to transfers over user connections and to transfers to interior routers from edge routers. This limit is not applied to interior-to-interior router connections. This limit may be overridden by vhost or by vhost user group settings. A value of zero disables this limit. Administrators are advised not set interior router maximum message sizes so low that edge router management requests or responses are blocked. Administrators are also advised to set edge router maximum message sizes lower than the attached interior router maximum message size.",
                     "required": false,
                     "create": true
                 },


### PR DESCRIPTION
…agement

* Interior routers perform max message size checks on message ingress.
  Once a message has entered the interior router network it is never again
  checked for max message size.

* Edge routers perform max message size checks on message ingress.
  Once a message has entered the edge router it may be forwarded to
  another locally connected destination and it is not again checked for
  max message size.

* Messages that are accepted by an edge router and are then forwarded to
  an interior router are also checked for max message size by the interior
  router.

* Management requests and responses that are destined to an interior
  router are checked for max message size by the interior router.

The recommendation to avoid blocking edge router management is to set
the interior router's max message size greater than the size of expected
edge router management requests and responses. Typically management
responses are larger and are under 5,000,000 bytes.

Another recommendation is to keep edge router max message sizes 1 kilobyte
smaller than the attached interior router max message size. This keeps
edge router connections stable while forwarding edge router user
messages to the interior router network.