### PR TITLE
DISPATCH-1642: Change parse tree insert to fail on duplicate entry

### DIFF
--- a/src/parse_tree.h
+++ b/src/parse_tree.h
@@ -20,10 +20,8 @@
  */
 
 #include <stdbool.h>
-
-#include <qpid/dispatch/ctools.h>
+#include <qpid/dispatch/error.h>
 #include <qpid/dispatch/iterator.h>
-#include <qpid/dispatch/alloc.h>
 
 
 typedef struct qd_parse_node qd_parse_tree_t;
@@ -58,17 +56,28 @@ const char *qd_parse_address_token_sep();
 bool qd_parse_tree_validate_pattern(const qd_parse_tree_t *tree,
                                     const qd_iterator_t *pattern);
 
-// returns old payload or NULL if new
-void *qd_parse_tree_add_pattern(qd_parse_tree_t *node,
-                                const qd_iterator_t *pattern,
-                                void *payload);
+// Inserts payload in tree using pattern as the lookup key
+//
+// @param node root of parse tree
+// @param pattern match pattern (copied)
+// @param payload stored in tree (referenced)
+// @return QD_ERROR_NONE (0) on success else qd_error_t code
+//
+qd_error_t qd_parse_tree_add_pattern(qd_parse_tree_t *node,
+                                     const qd_iterator_t *pattern,
+                                     void *payload);
 
 // returns old payload or NULL if not present
+//
+// @param node root of parse tree
+// @param pattern match pattern of payload to remove
+//
 void *qd_parse_tree_remove_pattern(qd_parse_tree_t *node,
                                    const qd_iterator_t *pattern);
 
 // retrieves the payload pointer
-// returns true if pattern found
+// returns true if pattern found and sets *payload
+//
 bool qd_parse_tree_get_pattern(qd_parse_tree_t *tree,
                                const qd_iterator_t *pattern,
                                void **payload);
@@ -114,10 +123,16 @@ bool qd_parse_tree_walk(qd_parse_tree_t *tree, qd_parse_tree_visit_t *callback, 
 // parse tree functions using string interface
 //
 
-// returns old payload or NULL if new
-void *qd_parse_tree_add_pattern_str(qd_parse_tree_t *node,
-                                    const char *pattern,
-                                    void *payload);
+// Inserts payload in tree using pattern as the lookup key
+//
+// @param node root of parse tree
+// @param pattern match pattern (copied)
+// @param payload stored in tree (referenced)
+// @return QD_ERROR_NONE (0) on success else qd_error_t code
+//
+qd_error_t qd_parse_tree_add_pattern_str(qd_parse_tree_t *node,
+                                         const char *pattern,
+                                         void *payload);
 
 // returns true on match and sets *payload
 bool qd_parse_tree_retrieve_match_str(qd_parse_tree_t *tree,

--- a/src/policy.c
+++ b/src/policy.c
@@ -1350,21 +1350,18 @@ bool qd_policy_host_pattern_add(qd_policy_t *policy, const char *hostPattern)
 {
     void *payload = strdup(hostPattern);
     sys_mutex_lock(policy->tree_lock);
-    void *oldp = qd_parse_tree_add_pattern_str(policy->hostname_tree, hostPattern, payload);
-    if (oldp) {
-        void *recovered = qd_parse_tree_add_pattern_str(policy->hostname_tree, (char *)oldp, oldp);
-        assert (recovered);
-        (void)recovered;        /* Silence compiler complaints of unused variable */
-    }
+    qd_error_t rc = qd_parse_tree_add_pattern_str(policy->hostname_tree, hostPattern, payload);
     sys_mutex_unlock(policy->tree_lock);
-    if (oldp) {
+
+    if (rc != QD_ERROR_NONE) {
+        const char *err = qd_error_name(rc);
         free(payload);
         qd_log(policy->log_source,
-            QD_LOG_WARNING,
-            "vhost hostname pattern '%s' failed to replace optimized pattern '%s'",
-            hostPattern, (char *)oldp);
+               QD_LOG_WARNING,
+               "vhost hostname pattern '%s' add failed: %s",
+               hostPattern, err ? err : "unknown error");
     }
-    return oldp == 0;
+    return rc == QD_ERROR_NONE;
 }
 
 

--- a/src/router_core/agent_config_address.c
+++ b/src/router_core/agent_config_address.c
@@ -337,7 +337,6 @@ void qdra_config_address_create_CT(qdr_core_t         *core,
                                    qd_parsed_field_t  *in_body)
 {
     char *pattern = NULL;
-    qd_iterator_t *iter = NULL;
 
     while (true) {
         //
@@ -399,7 +398,7 @@ void qdra_config_address_create_CT(qdr_core_t         *core,
         if (fallback && (waypoint || in_phase > 0 || out_phase > 0)) {
             msg = "Fallback cannot be specified with waypoint or non-zero ingress and egress phases";
         }
-            
+
         if (msg) {
             query->status = QD_AMQP_BAD_REQUEST;
             query->status.description = msg;
@@ -414,19 +413,6 @@ void qdra_config_address_create_CT(qdr_core_t         *core,
         if (!pattern) {
             query->status = QD_AMQP_BAD_REQUEST;
             query->status.description = msg;
-            qd_log(core->agent_log, QD_LOG_ERROR, "Error performing CREATE of %s: %s", CONFIG_ADDRESS_TYPE, query->status.description);
-            break;
-        }
-
-        iter = qd_iterator_string(pattern, ITER_VIEW_ALL);
-
-        //
-        // Ensure that there isn't another configured address with the same pattern
-        //
-
-        if (qd_parse_tree_get_pattern(core->addr_parse_tree, iter, (void **)&addr)) {
-            query->status = QD_AMQP_BAD_REQUEST;
-            query->status.description = "Address prefix conflicts with an existing entity";
             qd_log(core->agent_log, QD_LOG_ERROR, "Error performing CREATE of %s: %s", CONFIG_ADDRESS_TYPE, query->status.description);
             break;
         }
@@ -461,11 +447,34 @@ void qdra_config_address_create_CT(qdr_core_t         *core,
         }
 
         //
-        // The request is good.  Create the entity and insert it into the hash index and list.
+        // The request is valid.  Attempt to insert the address pattern into
+        // the parse tree, fail if there is already an entry for that pattern
+        //
+        addr = new_qdr_address_config_t();
+        if (!addr) {
+            query->status = QD_AMQP_BAD_REQUEST;
+            query->status.description = "Out of memory";
+            qd_log(core->agent_log, QD_LOG_ERROR, "Error performing CREATE of %s: %s", CONFIG_ADDRESS_TYPE, query->status.description);
+            break;
+        }
+        ZERO(addr);
+
+        //
+        // Insert the uninitialized address to check if it already exists in
+        // the parse tree.  On success initialize it.  This is thread safe
+        // since the current thread (core) is the only thread allowed to use
+        // the parse tree
         //
 
-        addr = new_qdr_address_config_t();
-        ZERO(addr);
+        qd_error_t rc = qd_parse_tree_add_pattern_str(core->addr_parse_tree, pattern, addr);
+        if (rc) {
+            free_qdr_address_config_t(addr);
+            query->status = QD_AMQP_BAD_REQUEST;
+            query->status.description = qd_error_name(rc);
+            qd_log(core->agent_log, QD_LOG_ERROR, "Error performing CREATE of %s: %s", CONFIG_ADDRESS_TYPE, query->status.description);
+            break;
+        }
+
         addr->ref_count = 1; // Represents the reference from the addr_config list
         addr->name      = name ? (char*) qd_iterator_copy(name) : 0;
         addr->identity  = qdr_identifier(core);
@@ -477,9 +486,6 @@ void qdra_config_address_create_CT(qdr_core_t         *core,
         addr->priority  = priority;
         addr->fallback  = fallback;
         pattern = 0;
-
-        qd_iterator_reset_view(iter, ITER_VIEW_ALL);
-        qd_parse_tree_add_pattern(core->addr_parse_tree, iter, addr);
 
         DEQ_INSERT_TAIL(core->addr_config, addr);
         if (name) {
@@ -517,7 +523,6 @@ void qdra_config_address_create_CT(qdr_core_t         *core,
         qdr_query_free(query);
 
     free(pattern);
-    qd_iterator_free(iter);
 }
 
 


### PR DESCRIPTION
This avoids having to look up the pattern first in order to avoid duplication (which is expensive as it searches the entire tree).
