### PR TITLE
DISPATCH-1646: fix FindLibWebSockets.cmake to honor requested version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include(CheckLibraryExists)
 include(CheckSymbolExists)
 include(CheckFunctionExists)
 include(CheckIncludeFiles)
+include(CMakeDependentOption)
 
 ##
 ## Find dependencies
@@ -59,11 +60,26 @@ find_package(Threads REQUIRED)
 find_package(Proton 0.23 REQUIRED COMPONENTS Core Proactor)
 message(STATUS "Found Proton: ${Proton_LIBRARIES} (found version \"${Proton_VERSION}\")" )
 
+##
 ## Optional dependencies
-find_package(LibWebSockets)
-option(USE_LIBWEBSOCKETS "Use libwebsockets for WebSocket support" ${LIBWEBSOCKETS_FOUND})
+##
 
+# Web Sockets
+find_package(LibWebSockets 2.4.2)
+CMAKE_DEPENDENT_OPTION(USE_LIBWEBSOCKETS "Use libwebsockets for WebSocket support" ON
+                         "LIBWEBSOCKETS_FOUND" OFF)
+if (LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
+  # This is a fix for DISPATCH-1513. libwebsockets versions 3.2.0 introduces a new flag called LWS_SERVER_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER
+  # The new flag allows (as the flag says) HTTP pver HTTPS listeners. Since this flag is not available before lws 3.2.0 we need
+  # to selectively comment out a test.
+  set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "#")
+  set(LWS_VERSION_WITH_SSL_FIX "3.2.0")
+  if ((LIBWEBSOCKETS_VERSION_STRING STREQUAL LWS_VERSION_WITH_SSL_FIX) OR (LIBWEBSOCKETS_VERSION_STRING STRGREATER  LWS_VERSION_WITH_SSL_FIX))
+    set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "")
+  endif()
+endif(LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
 
+# Python
 if (PYTHON_VERSION_MAJOR STREQUAL 3)
     set(PY_STRING "python3")
 elseif(PYTHON_VERSION_MAJOR STREQUAL 2)

--- a/cmake/FindLibWebSockets.cmake
+++ b/cmake/FindLibWebSockets.cmake
@@ -32,6 +32,8 @@
 #   CMAKE_INSTALL_PREFIX           - Install location for the current project.
 #   LIBWEBSOCKETS_INCLUDEDIR       - Preferred include directory e.g. <prefix>/include
 
+set(LIBWEBSOCKETS_FOUND FALSE)
+
 find_library(LIBWEBSOCKETS_LIBRARIES
   NAMES websockets libwebsockets
   HINTS "${LIBWEBSOCKETS_LIBRARYDIR}" "${LIBWEBSOCKETS_ROOT}" "${CMAKE_INSTALL_PREFIX}"
@@ -51,26 +53,13 @@ if(LIBWEBSOCKETS_INCLUDE_DIRS AND EXISTS "${LIBWEBSOCKETS_INCLUDE_DIRS}/lws_conf
   unset(lws_version_str)
 endif()
 
-set(lws_required "2.4.2")
-if (LIBWEBSOCKETS_VERSION_STRING AND (LIBWEBSOCKETS_VERSION_STRING VERSION_LESS lws_required))
-  message(STATUS "Found libwebsockets version ${LIBWEBSOCKETS_VERSION_STRING} but need at least ${lws_required}")
+if (LIBWEBSOCKETS_VERSION_STRING AND LibWebSockets_FIND_VERSION AND (LIBWEBSOCKETS_VERSION_STRING VERSION_LESS LibWebSockets_FIND_VERSION))
+  message(STATUS "Found libwebsockets version ${LIBWEBSOCKETS_VERSION_STRING} but least ${LibWebSockets_FIND_VERSION} is required. WebSocket support disabled.")
 else()
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(
     LibWebSockets DEFAULT_MSG LIBWEBSOCKETS_VERSION_STRING LIBWEBSOCKETS_LIBRARIES LIBWEBSOCKETS_INCLUDE_DIRS)
 endif()
-
-
-if (LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
-  # This is a fix for DISPATCH-1513. libwebsockets versions 3.2.0 introduces a new flag called LWS_SERVER_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER
-  # The new flag allows (as the flag says) HTTP pver HTTPS listeners. Since this flag is not available before lws 3.2.0 we need
-  # to selectively comment out a test.
-  set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "#")
-  set(LWS_VERSION_WITH_SSL_FIX "3.2.0")
-  if ((LIBWEBSOCKETS_VERSION_STRING STREQUAL LWS_VERSION_WITH_SSL_FIX) OR (LIBWEBSOCKETS_VERSION_STRING STRGREATER  LWS_VERSION_WITH_SSL_FIX))
-    set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "")
-  endif()
-endif(LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
 
 if(NOT LIBWEBSOCKETS_FOUND)
   unset(LIBWEBSOCKETS_LIBRARIES)


### PR DESCRIPTION
This updates our custom FindLibWebSockets script to set LIBWEBSOCKETS_FOUND based on a minimum required version passed in "find_package".

It also removes any feature-specific hacks out of the script and into the proper CMakeLists.txt file.  The purpose of the script is to simply determine if the proper libwebsockets is available, not set additional unrelated build flags.
