### PR TITLE
Dispatch 1684 SwitchoverTest opens fallback receiver on primary connection and not on fallback connection

### DIFF
--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -607,8 +607,6 @@ void qdr_core_unbind_address_link_CT(qdr_core_t *core, qdr_address_t *addr, qdr_
                     qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_NO_LONGER_SOURCE, addr->fallback);
             } else if (DEQ_SIZE(addr->inlinks) == 1) {
                 qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ONE_SOURCE, addr);
-                if (!!addr->fallback && !link->fallback)
-                    qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ONE_SOURCE, addr->fallback);
             }
         }
     }

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -607,6 +607,8 @@ void qdr_core_unbind_address_link_CT(qdr_core_t *core, qdr_address_t *addr, qdr_
                     qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_NO_LONGER_SOURCE, addr->fallback);
             } else if (DEQ_SIZE(addr->inlinks) == 1) {
                 qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ONE_SOURCE, addr);
+                if (!!addr->fallback && !link->fallback)
+                    qdrc_event_addr_raise(core, QDRC_EVENT_ADDR_ONE_SOURCE, addr->fallback);
             }
         }
     }

--- a/tests/system_tests_fallback_dest.py
+++ b/tests/system_tests_fallback_dest.py
@@ -602,7 +602,7 @@ class SwitchoverTest(MessagingHandler):
         self.primary_conn       = event.container.connect(self.primary_host)
         self.fallback_conn     = event.container.connect(self.fallback_host)
         self.primary_receiver   = event.container.create_receiver(self.primary_conn, self.addr)
-        self.fallback_receiver = event.container.create_receiver(self.primary_conn, self.addr, name=self.addr)
+        self.fallback_receiver = event.container.create_receiver(self.fallback_conn, self.addr, name=self.addr)
         self.fallback_receiver.source.capabilities.put_object(symbol("qd.fallback"))
 
     def on_link_opened(self, event):

--- a/tests/system_tests_fallback_dest.py
+++ b/tests/system_tests_fallback_dest.py
@@ -81,356 +81,370 @@ class RouterTest(TestCase):
         cls.routers[0].wait_router_connected('INT.B')
         cls.routers[1].wait_router_connected('INT.A')
 
+        cls.ROUTER_INTA = cls.routers[0].addresses[0]
+        cls.ROUTER_INTB = cls.routers[1].addresses[0]
+        cls.ROUTER_EA1 = cls.routers[2].addresses[0]
+        cls.ROUTER_EA2 = cls.routers[3].addresses[0]
+        cls.ROUTER_EB1 = cls.routers[4].addresses[0]
+        cls.ROUTER_EB2 = cls.routers[5].addresses[0]
+
+        cls.ROUTER_INTA_WP = cls.routers[0].addresses[1]
+        cls.ROUTER_INTB_WP = cls.routers[1].addresses[1]
+        cls.ROUTER_EA1_WP = cls.routers[2].addresses[1]
+        cls.ROUTER_EA2_WP = cls.routers[3].addresses[1]
+        cls.ROUTER_EB1_WP = cls.routers[4].addresses[1]
+        cls.ROUTER_EB2_WP = cls.routers[5].addresses[1]
+
 
     def test_01_sender_first_primary_same_interior(self):
-        test = SenderFirstTest(self.routers[0].addresses[0],
-                               self.routers[0].addresses[0],
+        test = SenderFirstTest(self.ROUTER_INTA,
+                               self.ROUTER_INTA,
                                'dest.01', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_02_sender_first_fallback_same_interior(self):
-        test = SenderFirstTest(self.routers[0].addresses[0],
-                               self.routers[0].addresses[0],
+        test = SenderFirstTest(self.ROUTER_INTA,
+                               self.ROUTER_INTA,
                                'dest.02', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_03_sender_first_primary_same_edge(self):
-        test = SenderFirstTest(self.routers[2].addresses[0],
-                               self.routers[2].addresses[0],
+        test = SenderFirstTest(self.ROUTER_EA1,
+                               self.ROUTER_EA1,
                                'dest.03', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_04_sender_first_fallback_same_edge(self):
-        test = SenderFirstTest(self.routers[2].addresses[0],
-                               self.routers[2].addresses[0],
+        test = SenderFirstTest(self.ROUTER_EA1,
+                               self.ROUTER_EA1,
                                'dest.04', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_05_sender_first_primary_interior_interior(self):
-        test = SenderFirstTest(self.routers[0].addresses[0],
-                               self.routers[1].addresses[0],
+        test = SenderFirstTest(self.ROUTER_INTA,
+                               self.ROUTER_INTB,
                                'dest.05', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_06_sender_first_fallback_interior_interior(self):
-        test = SenderFirstTest(self.routers[0].addresses[0],
-                               self.routers[1].addresses[0],
+        test = SenderFirstTest(self.ROUTER_INTA,
+                               self.ROUTER_INTB,
                                'dest.06', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_07_sender_first_primary_edge_interior(self):
-        test = SenderFirstTest(self.routers[2].addresses[0],
-                               self.routers[1].addresses[0],
+        test = SenderFirstTest(self.ROUTER_EA1,
+                               self.ROUTER_INTB,
                                'dest.07', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_08_sender_first_fallback_edge_interior(self):
-        test = SenderFirstTest(self.routers[2].addresses[0],
-                               self.routers[1].addresses[0],
+        test = SenderFirstTest(self.ROUTER_EA1,
+                               self.ROUTER_INTB,
                                'dest.08', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_09_sender_first_primary_interior_edge(self):
-        test = SenderFirstTest(self.routers[1].addresses[0],
-                               self.routers[2].addresses[0],
+        test = SenderFirstTest(self.ROUTER_INTB,
+                               self.ROUTER_EA1,
                                'dest.09', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_10_sender_first_fallback_interior_edge(self):
-        test = SenderFirstTest(self.routers[1].addresses[0],
-                               self.routers[2].addresses[0],
+        test = SenderFirstTest(self.ROUTER_INTB,
+                               self.ROUTER_EA1,
                                'dest.10', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_11_sender_first_primary_edge_edge(self):
-        test = SenderFirstTest(self.routers[2].addresses[0],
-                               self.routers[4].addresses[0],
+        test = SenderFirstTest(self.ROUTER_EA1,
+                               self.ROUTER_EB1,
                                'dest.11', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_12_sender_first_fallback_edge_edge(self):
-        test = SenderFirstTest(self.routers[2].addresses[0],
-                               self.routers[4].addresses[0],
+        test = SenderFirstTest(self.ROUTER_EA1,
+                               self.ROUTER_EB1,
                                'dest.12', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_13_receiver_first_primary_same_interior(self):
-        test = ReceiverFirstTest(self.routers[0].addresses[0],
-                                 self.routers[0].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_INTA,
+                                 self.ROUTER_INTA,
                                  'dest.13', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_14_receiver_first_fallback_same_interior(self):
-        test = ReceiverFirstTest(self.routers[0].addresses[0],
-                                 self.routers[0].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_INTA,
+                                 self.ROUTER_INTA,
                                  'dest.14', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_15_receiver_first_primary_same_edge(self):
-        test = ReceiverFirstTest(self.routers[2].addresses[0],
-                                 self.routers[2].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_EA1,
+                                 self.ROUTER_EA1,
                                  'dest.15', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_16_receiver_first_fallback_same_edge(self):
-        test = ReceiverFirstTest(self.routers[2].addresses[0],
-                                 self.routers[2].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_EA1,
+                                 self.ROUTER_EA1,
                                  'dest.16', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_17_receiver_first_primary_interior_interior(self):
-        test = ReceiverFirstTest(self.routers[0].addresses[0],
-                                 self.routers[1].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_INTA,
+                                 self.ROUTER_INTB,
                                  'dest.17', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_18_receiver_first_fallback_interior_interior(self):
-        test = ReceiverFirstTest(self.routers[0].addresses[0],
-                                 self.routers[1].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_INTA,
+                                 self.ROUTER_INTB,
                                  'dest.18', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_19_receiver_first_primary_edge_interior(self):
-        test = ReceiverFirstTest(self.routers[2].addresses[0],
-                                 self.routers[1].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_EA1,
+                                 self.ROUTER_INTB,
                                  'dest.19', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_20_receiver_first_fallback_edge_interior(self):
-        test = ReceiverFirstTest(self.routers[2].addresses[0],
-                                 self.routers[1].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_EA1,
+                                 self.ROUTER_INTB,
                                  'dest.20', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_21_receiver_first_primary_interior_edge(self):
-        test = ReceiverFirstTest(self.routers[1].addresses[0],
-                                 self.routers[2].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_INTB,
+                                 self.ROUTER_EA1,
                                  'dest.21', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_22_receiver_first_fallback_interior_edge(self):
-        test = ReceiverFirstTest(self.routers[1].addresses[0],
-                                 self.routers[2].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_INTB,
+                                 self.ROUTER_EA1,
                                  'dest.22', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_23_receiver_first_primary_edge_edge(self):
-        test = ReceiverFirstTest(self.routers[2].addresses[0],
-                                 self.routers[4].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_EA1,
+                                 self.ROUTER_EB1,
                                  'dest.23', False)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_24_receiver_first_fallback_edge_edge(self):
-        test = ReceiverFirstTest(self.routers[2].addresses[0],
-                                 self.routers[4].addresses[0],
+        test = ReceiverFirstTest(self.ROUTER_EA1,
+                                 self.ROUTER_EB1,
                                  'dest.24', True)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_25_switchover_same_edge(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[2].addresses[0],
-                              self.routers[2].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_EA1,
+                              self.ROUTER_EA1,
                               'dest.25')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_26_switchover_same_interior(self):
-        test = SwitchoverTest(self.routers[0].addresses[0],
-                              self.routers[0].addresses[0],
-                              self.routers[0].addresses[0],
+        test = SwitchoverTest(self.ROUTER_INTA,
+                              self.ROUTER_INTA,
+                              self.ROUTER_INTA,
                               'dest.26')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_27_switchover_local_edge_alt_remote_interior(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[0].addresses[0],
-                              self.routers[2].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_INTA,
+                              self.ROUTER_EA1,
                               'dest.27')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_28_switchover_local_edge_alt_remote_edge(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[4].addresses[0],
-                              self.routers[2].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_EB1,
+                              self.ROUTER_EA1,
                               'dest.28')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_29_switchover_local_edge_pri_remote_interior(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[2].addresses[0],
-                              self.routers[0].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_EA1,
+                              self.ROUTER_INTA,
                               'dest.29')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_30_switchover_local_interior_pri_remote_edge(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[2].addresses[0],
-                              self.routers[4].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_EA1,
+                              self.ROUTER_EB1,
                               'dest.30')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_31_switchover_local_interior_alt_remote_interior(self):
-        test = SwitchoverTest(self.routers[1].addresses[0],
-                              self.routers[0].addresses[0],
-                              self.routers[1].addresses[0],
+        test = SwitchoverTest(self.ROUTER_INTB,
+                              self.ROUTER_INTA,
+                              self.ROUTER_INTB,
                               'dest.31')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_32_switchover_local_interior_alt_remote_edge(self):
-        test = SwitchoverTest(self.routers[1].addresses[0],
-                              self.routers[3].addresses[0],
-                              self.routers[1].addresses[0],
+        test = SwitchoverTest(self.ROUTER_INTB,
+                              self.ROUTER_EA2,
+                              self.ROUTER_INTB,
                               'dest.32')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_33_switchover_local_interior_pri_remote_interior(self):
-        test = SwitchoverTest(self.routers[1].addresses[0],
-                              self.routers[1].addresses[0],
-                              self.routers[0].addresses[0],
+        test = SwitchoverTest(self.ROUTER_INTB,
+                              self.ROUTER_INTB,
+                              self.ROUTER_INTA,
                               'dest.33')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_34_switchover_local_interior_pri_remote_edge(self):
-        test = SwitchoverTest(self.routers[1].addresses[0],
-                              self.routers[1].addresses[0],
-                              self.routers[4].addresses[0],
+        test = SwitchoverTest(self.ROUTER_INTB,
+                              self.ROUTER_INTB,
+                              self.ROUTER_EB1,
                               'dest.34')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_35_switchover_mix_1(self):
-        test = SwitchoverTest(self.routers[0].addresses[0],
-                              self.routers[1].addresses[0],
-                              self.routers[2].addresses[0],
+        test = SwitchoverTest(self.ROUTER_INTA,
+                              self.ROUTER_INTB,
+                              self.ROUTER_EA1,
                               'dest.35')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_36_switchover_mix_2(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[1].addresses[0],
-                              self.routers[0].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_INTB,
+                              self.ROUTER_INTA,
                               'dest.36')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_37_switchover_mix_3(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[1].addresses[0],
-                              self.routers[4].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_INTB,
+                              self.ROUTER_EB1,
                               'dest.37')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_38_switchover_mix_4(self):
-        test = SwitchoverTest(self.routers[2].addresses[0],
-                              self.routers[3].addresses[0],
-                              self.routers[4].addresses[0],
+        test = SwitchoverTest(self.ROUTER_EA1,
+                              self.ROUTER_EA2,
+                              self.ROUTER_EB1,
                               'dest.38')
         test.run()
         self.assertEqual(None, test.error)
 
     def test_39_auto_link_sender_first_fallback_same_interior(self):
-        test = SenderFirstAutoLinkTest(self.routers[0].addresses[0],
-                                       self.routers[0].addresses[1])
+        test = SenderFirstAutoLinkTest(self.ROUTER_INTA,
+                                       self.ROUTER_INTA_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_40_auto_link_sender_first_fallback_same_edge(self):
-        test = SenderFirstAutoLinkTest(self.routers[2].addresses[0],
-                                       self.routers[2].addresses[1])
+        test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
+                                       self.ROUTER_EA1_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_41_auto_link_sender_first_fallback_interior_interior(self):
-        test = SenderFirstAutoLinkTest(self.routers[0].addresses[0],
-                                       self.routers[1].addresses[1])
+        test = SenderFirstAutoLinkTest(self.ROUTER_INTA,
+                                       self.ROUTER_INTB_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_42_auto_link_sender_first_fallback_edge_interior(self):
-        test = SenderFirstAutoLinkTest(self.routers[2].addresses[0],
-                                       self.routers[0].addresses[1])
+        test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
+                                       self.ROUTER_INTA_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_43_auto_link_sender_first_fallback_interior_edge(self):
-        test = SenderFirstAutoLinkTest(self.routers[1].addresses[0],
-                                       self.routers[2].addresses[1])
+        test = SenderFirstAutoLinkTest(self.ROUTER_INTB,
+                                       self.ROUTER_EA1_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_44_auto_link_sender_first_fallback_edge_edge(self):
-        test = SenderFirstAutoLinkTest(self.routers[2].addresses[0],
-                                       self.routers[4].addresses[1])
+        test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
+                                       self.ROUTER_EB1_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_45_auto_link_receiver_first_fallback_same_interior(self):
-        test = ReceiverFirstAutoLinkTest(self.routers[0].addresses[0],
-                                         self.routers[0].addresses[1])
+        test = ReceiverFirstAutoLinkTest(self.ROUTER_INTA,
+                                         self.ROUTER_INTA_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_46_auto_link_receiver_first_fallback_same_edge(self):
-        test = ReceiverFirstAutoLinkTest(self.routers[2].addresses[0],
-                                         self.routers[2].addresses[1])
+        test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
+                                         self.ROUTER_EA1_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_47_auto_link_receiver_first_fallback_interior_interior(self):
-        test = ReceiverFirstAutoLinkTest(self.routers[0].addresses[0],
-                                         self.routers[1].addresses[1])
+        test = ReceiverFirstAutoLinkTest(self.ROUTER_INTA,
+                                         self.ROUTER_INTB_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_48_auto_link_receiver_first_fallback_edge_interior(self):
-        test = ReceiverFirstAutoLinkTest(self.routers[2].addresses[0],
-                                         self.routers[1].addresses[1])
+        test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
+                                         self.ROUTER_INTB_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_49_auto_link_receiver_first_fallback_interior_edge(self):
-        test = ReceiverFirstAutoLinkTest(self.routers[1].addresses[0],
-                                         self.routers[2].addresses[1])
+        test = ReceiverFirstAutoLinkTest(self.ROUTER_INTB,
+                                         self.ROUTER_EA1_WP)
         test.run()
         self.assertEqual(None, test.error)
 
     def test_50_auto_link_receiver_first_fallback_edge_edge(self):
-        test = ReceiverFirstAutoLinkTest(self.routers[2].addresses[0],
-                                         self.routers[4].addresses[1])
+        test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
+                                         self.ROUTER_EB1_WP)
         test.run()
         self.assertEqual(None, test.error)
 


### PR DESCRIPTION
DISPATCH-1684: fallback dest test improvement reveals router bug. Work In Progress - do not merge
