### PR TITLE
DISPATCH-1690: clean up last inbound message on link close

### DIFF
--- a/include/qpid/dispatch/container.h
+++ b/include/qpid/dispatch/container.h
@@ -234,6 +234,8 @@ void qd_link_q3_block(qd_link_t *link);
 void qd_link_q3_unblock(qd_link_t *link);
 uint64_t qd_link_link_id(const qd_link_t *link);
 void qd_link_set_link_id(qd_link_t *link, uint64_t link_id);
+struct qd_message_t;
+void qd_link_set_incoming_msg(qd_link_t *link, struct qd_message_t *msg);
 
 qd_session_t *qd_session(pn_session_t *pn_ssn);
 void qd_session_cleanup(qd_connection_t *qd_conn);

--- a/src/message.c
+++ b/src/message.c
@@ -1312,6 +1312,7 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
         pn_record_def(record, PN_DELIVERY_CTX, PN_WEAKREF);
         pn_record_set(record, PN_DELIVERY_CTX, (void*) msg);
         msg->content->max_message_size = qd_connection_max_message_size(qdc);
+        qd_link_set_incoming_msg(qdl, (qd_message_t*) msg);
     }
 
     //

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -482,6 +482,7 @@ static bool AMQP_rx_handler(void* context, qd_link_t *link)
                                                    dtag.size,
                                                    pn_disposition_type(pn_delivery_remote(pnd)),
                                                    pn_disposition_data(pn_delivery_remote(pnd)));
+        qd_link_set_incoming_msg(link, (qd_message_t*) 0);  // msg no longer exclusive to qd_link
         qdr_node_connect_deliveries(link, delivery, pnd);
         qdr_delivery_decref(router->router_core, delivery, "release protection of return from deliver_to_routed_link");
         return next_delivery;
@@ -714,6 +715,7 @@ static bool AMQP_rx_handler(void* context, qd_link_t *link)
     //
 
     if (delivery) {
+        qd_link_set_incoming_msg(link, (qd_message_t*) 0);  // msg no longer exclusive to qd_link
         qdr_node_connect_deliveries(link, delivery, pnd);
         qdr_delivery_decref(router->router_core, delivery, "release protection of return from deliver");
     } else {

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -42,7 +42,7 @@ leak:qd_container_register_node_type
 leak:^qdr_send_to2$
 
 # DISPATCH-1661, DISPATCH-1662
-leak:^qdr_terminus$
+# leak:^qdr_terminus$
 
 # Ubuntu 18.04 (Bionic)
 leak:qdr_link_issue_credit_CT


### PR DESCRIPTION
If an incoming link fails/closes before the current inbound message
has been forwarded to the core the current inbound message is not
freed.  This patch adds a weak reference (safe pointer) in the link to
the current inbound message.  This reference is cleared once the
message has been delivered to the core.  Should the link close prior
to delivery this weak reference is used to clean up the message.