### PR TITLE
DISPATCH-1678: fix misleading ASAN tracebacks for pooled items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,15 @@
 # under the License
 #
 
-sudo: true
 language: c
 cache: ccache
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - os: osx
   include:
   - name: "apache-rat:check"
     os: linux
-    sudo: false
     env: []
     language: java
     addons:
@@ -45,16 +43,24 @@ matrix:
     after_script:
     - cat target/rat.txt || true
   # prepending /usr/bin to PATH to avoid mismatched python interpreters in /opt
-  - os: linux
+  - name: "qdrouterd:Debug"
+    os: linux
     env:
     - PATH="/usr/bin:$PATH" PROTON_VERSION=master BUILD_TYPE=Debug
-  - os: linux
+    - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
+  - name: "qdrouterd:Coverage"
+    os: linux
     env:
     - PATH="/usr/bin:$PATH" PROTON_VERSION=0.31.0 BUILD_TYPE=Coverage
-  - os: linux
+  - name: "qdrouterd:RelWithDebInfo+MemoryDebug"
+    os: linux
     env:
     - PATH="/usr/bin:$PATH" PROTON_VERSION=0.31.0 BUILD_TYPE=RelWithDebInfo
-    - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
+    - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
+  - name: "qdrouterd:Default Build"
+    os: linux
+    env:
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.31.0
   - os: osx
     osx_image: xcode11
     env:

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -2,58 +2,22 @@
 # found by AddressSanitizer (ASAN)
 #
 leak:_flush_send_queue_CT
-leak:add_session_to_free_list
-leak:compose_message_annotations
-leak:qd_parse_annotations
-leak:qd_compose_insert_string_n
-leak:qd_core_agent_query_handler
 leak:qd_dispatch_configure_connector
-leak:qd_dispatch_configure_listener
-leak:qd_dispatch_configure_ssl_profile
-leak:qd_manage_response_handler
+leak:parse_failover_property_list
+leak:load_server_config
 leak:qd_message_receive
-leak:qd_policy_amqp_open
-leak:qd_policy_amqp_open_connector
 leak:qd_policy_c_counts_alloc
 leak:qd_policy_open_fetch_settings
-leak:qdi_router_configure_body
-leak:qdr_action
-leak:qdr_add_local_address_CT
-leak:qdr_connection_opened
-leak:qdr_core_subscribe
 leak:qdr_error_description
-leak:qdr_forward_balanced_CT
-leak:qdr_forward_closest_CT
-leak:qdr_forward_multicast_CT
-leak:qdr_link_deliver
-leak:qdr_link_deliver_to_routed_link
-leak:qdr_link_deliver_to_routed_link
-leak:qdr_link_outbound_detach_CT
-leak:qdr_manage_advance_address_CT
-leak:qdr_node_connect_deliveries
-leak:qdr_route_add_auto_link_CT
-leak:qdr_route_add_link_route_CT
-leak:qdr_route_connection_opened_CT
-leak:qdr_subscribe_CT
-leak:router_annotate_message
-leak:qd_container_register_node_type
 
-# DISPATCH-1663
-leak:^qdr_send_to2$
-
-# DISPATCH-1661, DISPATCH-1662
-# leak:^qdr_terminus$
-
-# Ubuntu 18.04 (Bionic)
-leak:qdr_link_issue_credit_CT
-leak:qdr_delivery_push_CT
+# expected, not a bug:
+#
+leak:qdr_core_subscribe
 
 # Ubuntu 16.04 (Xenial)
+#
 leak:_ctypes_alloc_format_string
 leak:__strdup
-leak:add_link_to_free_list
-leak:qd_parse_internal
-
 
 ####
 #### Miscellaneous 3rd party libraries, test code, etc:

--- a/tests/run_unit_tests_size.c
+++ b/tests/run_unit_tests_size.c
@@ -21,6 +21,7 @@
 #include <qpid/dispatch/alloc.h>
 
 void qd_log_initialize(void);
+void qd_log_finalize(void);
 void qd_error_initialize();
 
 int message_tests();
@@ -49,6 +50,7 @@ int main(int argc, char** argv)
     result += parse_tests();
     result += buffer_tests();
 
+    qd_log_finalize();
     qd_alloc_finalize();
     return result;
 }

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -1849,12 +1849,8 @@ class ConnectionLinkRouteTest(TestCase):
         ]
 
         cfg = Qdrouterd.Config(config)
-        router = self.tester.qdrouterd("X", cfg, wait=False)
         # we expect the router to fail
-        while router.poll() is None:
-            sleep(0.1)
-        self.assertRaises(RuntimeError, router.teardown)
-        self.assertNotEqual(0, router.returncode)
+        router = self.tester.qdrouterd("X", cfg, wait=False, expect=Process.EXIT_FAIL)
 
     def test_mgmt(self):
         # test create, delete, and query

--- a/tests/system_tests_open_properties.py
+++ b/tests/system_tests_open_properties.py
@@ -28,7 +28,7 @@ from proton.handlers import MessagingHandler
 from proton.reactor import Container
 from test_broker import FakeBroker
 from system_test import TestCase, unittest, main_module, Qdrouterd
-from system_test import retry, TIMEOUT, wait_port, QdManager
+from system_test import retry, TIMEOUT, wait_port, QdManager, Process
 
 
 def strip_default_options(options):
@@ -351,9 +351,10 @@ class OpenPropertiesBadConfigTest(TestCase):
                       })
             ]
 
-            router = self.tester.qdrouterd(name, Qdrouterd.Config(config), wait=False)
+            router = self.tester.qdrouterd(name, Qdrouterd.Config(config),
+                                           wait=False,
+                                           expect=Process.EXIT_FAIL)
             router.wait(timeout=TIMEOUT)
-            self.assertRaises(RuntimeError, router.teardown)
             self.assertTrue(self._find_in_output(router.outfile + '.out', err))
 
 
@@ -377,9 +378,10 @@ class OpenPropertiesBadConfigTest(TestCase):
                           })
                 ]
 
-                router = self.tester.qdrouterd(name, Qdrouterd.Config(config), wait=False)
+                router = self.tester.qdrouterd(name, Qdrouterd.Config(config),
+                                               wait=False,
+                                               expect=Process.EXIT_FAIL)
                 router.wait(timeout=TIMEOUT)
-                self.assertRaises(RuntimeError, router.teardown)
                 err = "ValidationError: openProperties not allowed for role %s" % role
                 self.assertTrue(self._find_in_output(router.outfile + '.out', err))
 


### PR DESCRIPTION
This patch updates the alloc_pool.c debug code to free any "leaked"
items to prevent ASAN from printing tracebacks for them.  These
tracebacks are misleading since ASAN only tracks the initial heap
malloc, not the last time the item was allocated from the pool.

Add a list of alloc_pool.c types that are known/expected to leak. If
the alloc_pool.c debug code finds a leak for a type which is NOT on
this list the router will abort on shutdown (debug build only).

Update the .travis.yml to clean up warnings and include a test run of
the default build case.

Update the LSAN suppression file.

Improve dumping of logs on router crash.