### PR TITLE
DISPATCH-1684: Test should open fallback receiver on fallback connection

### DIFF
--- a/tests/system_tests_fallback_dest.py
+++ b/tests/system_tests_fallback_dest.py
@@ -588,7 +588,7 @@ class SwitchoverTest(MessagingHandler):
         self.primary_conn       = event.container.connect(self.primary_host)
         self.fallback_conn     = event.container.connect(self.fallback_host)
         self.primary_receiver   = event.container.create_receiver(self.primary_conn, self.addr)
-        self.fallback_receiver = event.container.create_receiver(self.primary_conn, self.addr, name=self.addr)
+        self.fallback_receiver = event.container.create_receiver(self.fallback_conn, self.addr, name=self.addr)
         self.fallback_receiver.source.capabilities.put_object(symbol("qd.fallback"))
 
     def on_link_opened(self, event):


### PR DESCRIPTION
Fallback_dest test class SwitchoverTest mistakenly opens the fallback
receiver on the primary connection.

Opening the fallback receiver on the fallback connection triggers two
test errors:
  test_29_switchover_local_edge_pri_remote_interior
  test_30_switchover_local_interior_pri_remote_edge
  AssertionError: None != 'Timeout Expired - n_tx=0, n_rx=0, n_rel=250, phase=1'

This PR must not be committed before the fix for these two errors
is in place. See PR-765.