### PR TITLE
DISPATCH-1505: Qdstat shows policy and vhost entities

### DIFF
--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -150,12 +150,24 @@ def _qdstat_add_display_args(parser, BusManager):
     display.add_argument("-m", "--memory", action="store_const", dest="show",
                          help="Show Router Memory Stats",
                          const=BusManager.displayMemory.__name__)
+    display.add_argument("-p", "--policy", action="store_const", dest="show",
+                         help="Show Router Policy",
+                         const=BusManager.displayPolicy.__name__)
     display.add_argument("--autolinks", action="store_const", dest="show",
                          help="Show Auto Links",
                          const=BusManager.displayAutolinks.__name__)
     display.add_argument("--linkroutes", action="store_const", dest="show",
                          help="Show Link Routes",
                          const=BusManager.displayLinkRoutes.__name__)
+    display.add_argument("--vhosts", action="store_const", dest="show",
+                         help="Show Vhosts",
+                         const=BusManager.displayVhosts.__name__)
+    display.add_argument("--vhostgroups", action="store_const", dest="show",
+                         help="Show Vhost Groups",
+                         const=BusManager.displayVhostgroups.__name__)
+    display.add_argument("--vhoststats", action="store_const", dest="show",
+                         help="Show Vhost Stats",
+                         const=BusManager.displayVhoststats.__name__)
     display.add_argument("--log", action="store_const", dest="show",
                          help="Show recent log entries",
                          const=BusManager.displayLog.__name__)

--- a/tests/system_tests_edge_router.py
+++ b/tests/system_tests_edge_router.py
@@ -1303,7 +1303,7 @@ class RouterTest(TestCase):
                                address=self.routers[0].addresses[0])
         self.assertEqual(outs.count("Router Links"), 2)
         self.assertEqual(outs.count("Router Addresses"), 2)
-        self.assertEqual(outs.count("Connections"), 4)
+        self.assertEqual(outs.count("Connections"), 12)
         self.assertEqual(outs.count("AutoLinks"), 2)
         self.assertEqual(outs.count("Auto Links"), 2)
         self.assertEqual(outs.count("Link Routes"), 4)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -45,6 +45,10 @@ class FakeBusManager:
     def displayEdges(self): pass
     def displayAddresses(self): pass
     def displayMemory(self): pass
+    def displayPolicy(self): pass
+    def displayVhosts(self): pass
+    def displayVhostgroups(self): pass
+    def displayVhoststats(self): pass
     def displayAutolinks(self): pass
     def displayLinkRoutes(self): pass
     def displayLog(self): pass

--- a/tools/qdstat.in
+++ b/tools/qdstat.in
@@ -767,6 +767,195 @@ class BusManager(Node):
                              Header("Pooled", Header.KiMiGi)],
                             [rows])
 
+
+    def displayPolicy(self, show_date_id=True):
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
+        heads = []
+        heads.append(Header("attr"))
+        heads.append(Header("value"))
+        rows = []
+
+        objects = self.query('org.apache.qpid.dispatch.policy')
+
+        policy = objects[0]
+
+        if show_date_id:
+            self.display_datetime_router_id()
+
+        rows.append(('Maximum Concurrent Connections', PlainNum(policy.maxConnections)))
+        rows.append(('Maximum Message Size',           PlainNum(policy.maxMessageSize)))
+        rows.append(('Enable Vhost Policy',            policy.enableVhostPolicy))
+        rows.append(('Enable Vhost Name Patterns',     policy.enableVhostNamePatterns))
+        rows.append(('Policy Directory',               policy.policyDir if len(policy.policyDir) > 0 else '(nil)'))
+        rows.append(('Default Vhost',                  policy.defaultVhost if len(policy.defaultVhost) > 0 else '(nil)'))
+
+        disp.formattedTable("Policy Configuration", heads, rows)
+
+        heads = []
+        heads.append(Header("attr"))
+        heads.append(Header("value"))
+        rows = []
+
+        rows.append(('Connections Processed',       PlainNum(policy.connectionsProcessed)))
+        rows.append(('Connections Denied',          PlainNum(policy.connectionsDenied)))
+        rows.append(('Connections Current',         PlainNum(policy.connectionsCurrent)))
+        rows.append(('Links Denied',                PlainNum(policy.linksDenied)))
+        rows.append(('Maximum Message Size Denied', PlainNum(policy.maxMessageSizeDenied)))
+        rows.append(('Total Denials',               PlainNum(policy.totalDenials)))
+
+        disp.formattedTable("\nPolicy Status", heads, rows)
+
+    def showNodefaultString(self, dict, key):
+        return dict[key] if key in dict else "."
+
+    def showNodefaultInt(self, dict, key):
+        return PlainNum(dict[key]) if key in dict else "."
+
+    def displayVhosts(self, show_date_id=True):
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
+
+        vhosts = self.query('org.apache.qpid.dispatch.vhost')
+
+        if len(vhosts) == 0:
+            print("No Vhosts")
+            return
+        heads = []
+        heads.append(Header("hostname"))
+        heads.append(Header("maxConnections"))
+        heads.append(Header("maxMessageSize"))
+        heads.append(Header("maxConnectionsPerUser"))
+        heads.append(Header("maxConnectionsPerHost"))
+        heads.append(Header("allowUnknownUser"))
+        heads.append(Header("groups"))
+        rows = []
+        for vhost in vhosts:
+            rows.append((
+                vhost.hostname,
+                PlainNum(vhost.maxConnections),
+                PlainNum(vhost.maxMessageSize),
+                PlainNum(vhost.maxConnectionsPerUser),
+                PlainNum(vhost.maxConnectionsPerHost),
+                vhost.allowUnknownUser,
+                PlainNum(len(vhost.groups))
+                ))
+        disp.formattedTable("Vhosts", heads, rows)
+
+    def displayVhostgroups(self, show_date_id=True):
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
+
+        vhosts = self.query('org.apache.qpid.dispatch.vhost')
+
+        if len(vhosts) == 0:
+            print("No Vhosts")
+            return
+        heads = []
+        heads.append(Header("vhost"))
+        heads.append(Header("group"))
+        heads.append(Header("users"))
+        heads.append(Header("remoteHosts"))
+        heads.append(Header("maxConnectionsPerUser"))
+        heads.append(Header("maxConnectionsPerHost"))
+        heads.append(Header("maxMessageSize"))
+        heads.append(Header("maxFrameSize"))
+        heads.append(Header("maxSessionWindow"))
+        heads.append(Header("maxSessions"))
+        heads.append(Header("maxSenders"))
+        heads.append(Header("maxReceivers"))
+        heads.append(Header("allowDynamicSource"))
+        heads.append(Header("allowAnonymousSender"))
+        heads.append(Header("allowUserIdProxy"))
+        heads.append(Header("allowWaypointLinks"))
+        heads.append(Header("allowDynamicLinkRoutes"))
+        heads.append(Header("allowAdminStatusUpdate"))
+        heads.append(Header("allowFallbackLinks"))
+        heads.append(Header("sources"))
+        heads.append(Header("targets"))
+        heads.append(Header("sourcePattern"))
+        heads.append(Header("targetPattern"))
+        rows = []
+        for vhost in vhosts:
+            groups = vhost["groups"]
+            if len(groups) > 0:
+                for groupname in groups:
+                    group = groups[groupname]
+                    rows.append((
+                        vhost.hostname,
+                        groupname,
+                        self.showNodefaultString(group, "users"),
+                        self.showNodefaultString(group, "remoteHosts"),
+                        self.showNodefaultInt(group, "maxConnectionsPerUser"),
+                        self.showNodefaultInt(group, "maxConnectionsPerHost"),
+                        self.showNodefaultInt(group, "maxMessageSize"),
+                        self.showNodefaultInt(group, "maxFrameSize"),
+                        self.showNodefaultInt(group, "maxSessionWindow"),
+                        self.showNodefaultInt(group, "maxSessions"),
+                        self.showNodefaultInt(group, "maxSenders"),
+                        self.showNodefaultInt(group, "maxReceivers"),
+                        self.showNodefaultString(group, "allowDynamicSource"),
+                        self.showNodefaultString(group, "allowAnonymousSender"),
+                        self.showNodefaultString(group, "allowUserIdProxy"),
+                        self.showNodefaultString(group, "allowWaypointLinks"),
+                        self.showNodefaultString(group, "allowDynamicLinkRoutes"),
+                        self.showNodefaultString(group, "allowAdminStatusUpdate"),
+                        self.showNodefaultString(group, "allowFallbackLinks"),
+                        self.showNodefaultString(group, "sources"),
+                        self.showNodefaultString(group, "targets"),
+                        self.showNodefaultString(group, "sourcePattern"),
+                        self.showNodefaultString(group, "targetPattern")
+                    ))
+        disp.formattedTable("Vhost Groups", heads, rows)
+
+    def displayVhoststats(self, show_date_id=True):
+        disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
+
+        vstats = self.query('org.apache.qpid.dispatch.vhostStats')
+
+        if len(vstats) == 0:
+            print("No Vhost Stats")
+            return
+        heads = []
+        heads.append(Header("hostname"))
+        heads.append(Header("connectionsApproved"))
+        heads.append(Header("connectionsDenied"))
+        heads.append(Header("connectionsCurrent"))
+        heads.append(Header("sessionDenied"))
+        heads.append(Header("senderDenied"))
+        heads.append(Header("receiverDenied"))
+        heads.append(Header("maxMessageSizeDenied"))
+        rows = []
+
+        for vstat in vstats:
+            rows.append((
+                vstat.hostname,
+                PlainNum(vstat.connectionsApproved),
+                PlainNum(vstat.connectionsDenied),
+                PlainNum(vstat.connectionsCurrent),
+                PlainNum(vstat.sessionDenied),
+                PlainNum(vstat.senderDenied),
+                PlainNum(vstat.receiverDenied),
+                PlainNum(vstat.maxMessageSizeDenied)
+                ))
+        disp.formattedTable("Vhost Stats", heads, rows)
+
+        heads = []
+        heads.append(Header("vhost"))
+        heads.append(Header("user"))
+        heads.append(Header("remote hosts"))
+        rows = []
+
+        for vstat in vstats:
+            ustates = vstat["perUserState"]
+            if len(ustates) > 0:
+                for ustate in ustates:
+                    rows.append((
+                        vstat.hostname,
+                        ustate,
+                        ustates[ustate]
+                        ))
+        disp.formattedTable("\nVhost User Stats", heads, rows)
+
+
+
     def displayLog(self):
         log = self.get_log(limit=self.opts.limit)
         for line in log:
@@ -792,6 +981,15 @@ class BusManager(Node):
         self.displayGeneral(show_date_id=False)
         print("")
         self.displayMemory(show_date_id=False)
+        print("")
+        self.displayPolicy(show_date_id=False)
+        print("")
+        self.displayVhosts(show_date_id=False)
+        print("")
+        # Groups is an ugly display. Show it only on demand.
+        # self.displayVhostgroups(show_date_id=False)
+        # print("")
+        self.displayVhoststats(show_date_id=False)
         print("")
 
     def has_nodes(self):


### PR DESCRIPTION
  -p --policy   - base policy settings and status
  --vhosts      - vhost configuration with no group data
  --vhostgroups - vhost group configuration
  --vhoststats  - per-vhost statistics, per-vhost/user connections info

Policy is present even if it is not specified in the router config file.
Vhosts are present only if enabled in base policy.

The vhostgroups display is kind of ugly with superwide rows and
does not lend itself to the tabular format.  Similar to --log, it
is excluded from --all-entities and printed only on demand.