### PR TITLE
DISPATCH-1721: Qdstat table vhostgroups: too wide; missing default settings

### DIFF
--- a/python/qpid_dispatch/management/client.py
+++ b/python/qpid_dispatch/management/client.py
@@ -384,3 +384,6 @@ class Node(object):
 
     def get_log(self, limit=None, type=None):
         return self.call(self.node_request(operation=u"GET-LOG", entityType=type, limit=limit)).body
+
+    def get_schema(self, type=None):
+        return self.call(self.node_request(operation=u"GET-SCHEMA")).body

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -467,8 +467,15 @@ class QdstatTestVhostPolicy(system_test.TestCase):
                         'sources': '*',
                         'targets': '*',
                         'allowDynamicSource': True
-                    }
-                }
+                    },
+                    'HGCrawler': {
+                        'users': 'Farmers',
+                        'remoteHosts': '*',
+                        'sources': '*',
+                        'targets': '*',
+                        'allowDynamicSource': True
+                    },
+                },
             })
         ])
         cls.router = cls.tester.qdrouterd('test-router', config)
@@ -505,11 +512,15 @@ class QdstatTestVhostPolicy(system_test.TestCase):
         out = self.run_qdstat(['--vhostgroups'])
         self.assertTrue("Vhost Groups" in out)
         self.assertTrue("allowAdminStatusUpdate" in out)
+        self.assertTrue("Vhost '$default' UserGroup '$default'" in out)
+        self.assertTrue("Vhost '$default' UserGroup 'HGCrawler'" in out)
 
     def test_vhostgroups_csv(self):
         out = self.run_qdstat(['--vhostgroups', '--csv'])
         self.assertTrue("Vhost Groups" in out)
         self.assertTrue("allowAdminStatusUpdate" in out)
+        self.assertTrue("Vhost '$default' UserGroup '$default'" in out)
+        self.assertTrue("Vhost '$default' UserGroup 'HGCrawler'" in out)
 
     def test_vhoststats(self):
         out = self.run_qdstat(['--vhoststats'])

--- a/tools/qdstat.in
+++ b/tools/qdstat.in
@@ -806,11 +806,32 @@ class BusManager(Node):
 
         disp.formattedTable("\nPolicy Status", heads, rows)
 
-    def showNodefaultString(self, dict, key):
-        return dict[key] if key in dict else "."
+    def showNodefaultString(self, dict, key, schema):
+        if key in dict:
+            res = dict[key]
+        elif 'default' in schema[key]:
+            res = schema[key]['default']
+        else:
+            res = '(nil)'
+        return res
 
-    def showNodefaultInt(self, dict, key):
-        return PlainNum(dict[key]) if key in dict else "."
+    def showNodefaultBool(self, dict, key, schema):
+        if key in dict:
+            res = dict[key]
+        elif 'default' in schema[key]:
+            res = schema[key]['default']
+        else:
+            res = 'False'
+        return res
+
+    def showNodefaultInt(self, dict, key, schema):
+        if key in dict:
+            res = PlainNum(dict[key])
+        elif 'default' in schema[key]:
+            res = PlainNum(schema[key]['default'])
+        else:
+            res = '(nil)'
+        return res
 
     def displayVhosts(self, show_date_id=True):
         disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
@@ -853,15 +874,17 @@ class BusManager(Node):
         disp = Display(prefix="  ", bodyFormat=self.bodyFormat)
 
         vhosts = self.query('org.apache.qpid.dispatch.vhost')
+        schema = self.get_schema()
+        vg_schema = schema['entityTypes']['vhostUserGroupSettings']['attributes']
 
         if len(vhosts) == 0:
             print("No Vhosts")
             return
+        # Create table for all vhosts and groups omitting
+        # strings that are potentially 'very long'.
         heads = []
         heads.append(Header("vhost"))
         heads.append(Header("group"))
-        heads.append(Header("users"))
-        heads.append(Header("remoteHosts"))
         heads.append(Header("maxConnectionsPerUser"))
         heads.append(Header("maxConnectionsPerHost"))
 
@@ -882,10 +905,6 @@ class BusManager(Node):
         heads.append(Header("allowDynamicLinkRoutes"))
         heads.append(Header("allowAdminStatusUpdate"))
         heads.append(Header("allowFallbackLinks"))
-        heads.append(Header("sources"))
-        heads.append(Header("targets"))
-        heads.append(Header("sourcePattern"))
-        heads.append(Header("targetPattern"))
         rows = []
         for vhost in vhosts:
             groups = vhost["groups"]
@@ -895,31 +914,46 @@ class BusManager(Node):
                     row = []
                     row.append(vhost.hostname)
                     row.append(groupname)
-                    row.append(self.showNodefaultString(group, "users"))
-                    row.append(self.showNodefaultString(group, "remoteHosts"))
-                    row.append(self.showNodefaultInt(group, "maxConnectionsPerUser"))
-                    row.append(self.showNodefaultInt(group, "maxConnectionsPerHost"))
+                    row.append(self.showNodefaultInt(group, "maxConnectionsPerUser", vg_schema))
+                    row.append(self.showNodefaultInt(group, "maxConnectionsPerHost", vg_schema))
                     if have_max_message_size:
-                        row.append(self.showNodefaultInt(group, "maxMessageSize"))
-                    row.append(self.showNodefaultInt(group, "maxFrameSize"))
-                    row.append(self.showNodefaultInt(group, "maxSessionWindow"))
-                    row.append(self.showNodefaultInt(group, "maxSessions"))
-                    row.append(self.showNodefaultInt(group, "maxSenders"))
-                    row.append(self.showNodefaultInt(group, "maxReceivers"))
-                    row.append(self.showNodefaultString(group, "allowDynamicSource"))
-                    row.append(self.showNodefaultString(group, "allowAnonymousSender"))
-                    row.append(self.showNodefaultString(group, "allowUserIdProxy"))
-                    row.append(self.showNodefaultString(group, "allowWaypointLinks"))
-                    row.append(self.showNodefaultString(group, "allowDynamicLinkRoutes"))
-                    row.append(self.showNodefaultString(group, "allowAdminStatusUpdate"))
-                    row.append(self.showNodefaultString(group, "allowFallbackLinks"))
-                    row.append(self.showNodefaultString(group, "sources"))
-                    row.append(self.showNodefaultString(group, "targets"))
-                    row.append(self.showNodefaultString(group, "sourcePattern"))
-                    row.append(self.showNodefaultString(group, "targetPattern"))
+                        row.append(self.showNodefaultInt(group, "maxMessageSize", vg_schema))
+                    row.append(self.showNodefaultInt(group, "maxFrameSize", vg_schema))
+                    row.append(self.showNodefaultInt(group, "maxSessionWindow", vg_schema))
+                    row.append(self.showNodefaultInt(group, "maxSessions", vg_schema))
+                    row.append(self.showNodefaultInt(group, "maxSenders", vg_schema))
+                    row.append(self.showNodefaultInt(group, "maxReceivers", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowDynamicSource", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowAnonymousSender", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowUserIdProxy", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowWaypointLinks", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowDynamicLinkRoutes", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowAdminStatusUpdate", vg_schema))
+                    row.append(self.showNodefaultBool(group, "allowFallbackLinks", vg_schema))
                     rows.append(tuple(row))
-
         disp.formattedTable("Vhost Groups", heads, rows)
+
+        # Create tables per vhost and per usergroup
+        # showing only potentially lengthy strings.
+        heads = []
+        heads.append(Header("attr"))
+        heads.append(Header("value"))
+
+        for vhost in vhosts:
+            groups = vhost["groups"]
+            if len(groups) > 0:
+                for groupname in groups:
+                    group = groups[groupname]
+                    rows = []
+                    rows.append(("vhost",         vhost.hostname))
+                    rows.append(("group",         groupname))
+                    rows.append(("users",         self.showNodefaultString(group, "users", vg_schema)))
+                    rows.append(("remoteHosts",   self.showNodefaultString(group, "remoteHosts", vg_schema)))
+                    rows.append(("sources",       self.showNodefaultString(group, "sources", vg_schema)))
+                    rows.append(("targets",       self.showNodefaultString(group, "targets", vg_schema)))
+                    rows.append(("sourcePattern", self.showNodefaultString(group, "sourcePattern", vg_schema)))
+                    rows.append(("targetPattern", self.showNodefaultString(group, "targetPattern", vg_schema)))
+                    disp.formattedTable(("\nVhost '%s' UserGroup '%s'" % (vhost.hostname, groupname)), heads, rows)
 
     def displayVhoststats(self, show_date_id=True):
         disp = Display(prefix="  ", bodyFormat=self.bodyFormat)


### PR DESCRIPTION
At a minimum the table is about 200 columns wide. If large lists of user
names and/or sources and targets are specified the table is so wide
that it becomes unreadable.

 * Break up groups display into single table for boolean and integer
   settings and individual tables for groups strings that might be large.

Entity management does not return appropriate defaults for table
vhostUserGroupSettings.

 * Fetch the schema from the target router and use those defaults.

 * Enforce a 'false' default on booleans that are not required and have
   no default. The fetched schema does not include the 'false' default.