### PR TITLE
DISPATCH-1726 Bump apache-rat-plugin from 0.12 to 0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
                 <plugin>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
-                    <version>0.12</version>
+                    <version>0.13</version>
                     <executions>
                       <execution>
                         <phase>verify</phase>


### PR DESCRIPTION
Bumps apache-rat-plugin from 0.12 to 0.13.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>