### PR TITLE
DISPATCH-960 Handle invalid configs when resolving port

### DIFF
--- a/tests/c_unittests/test_amqp.cpp
+++ b/tests/c_unittests/test_amqp.cpp
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "qdr_doctest.h"
+
+extern "C" {
+#include <qpid/dispatch/amqp.h>
+}
+
+TEST_CASE("test_qd_port_int") {
+    SUBCASE("numeric ports, edge cases") {
+        CHECK(qd_port_int("-1") == -1);
+        CHECK(qd_port_int("0") == 0);
+        CHECK(qd_port_int("1") == 1);
+        CHECK(qd_port_int("5672") == 5672);
+        CHECK(qd_port_int("65535") == 65535);
+        CHECK(qd_port_int("65536") == -1);
+    }
+    SUBCASE("well known symbolic ports") {
+        CHECK(qd_port_int("amqp") == 5672);
+        CHECK(qd_port_int("amqps") == 5671);
+        CHECK(qd_port_int("http") == 80);
+    }
+    SUBCASE("invalid inputs") {
+        CHECK(qd_port_int("") == -1);
+
+        CHECK(qd_port_int("42http") == -1);
+        CHECK(qd_port_int("http42") == -1);
+
+        CHECK(qd_port_int("no_such_port") == -1);
+    }
+}


### PR DESCRIPTION
The current implementation is failing with the tests in this PR in the following ways. The value `36875` is random (from reading uninitialized memory). CC @fgiorgetti 

```
$ c_unittests -r=xml -ts=* -tc=test_qd_port_int

/home/jdanek/repos/qpid/qpid-dispatch/tests/c_unittests/test_amqp.cpp:32: Failure:
  CHECK(qd_port_int("0") == 0)
with expansion:
  36875 == 0

/home/jdanek/repos/qpid/qpid-dispatch/tests/c_unittests/test_amqp.cpp:44: Failure:
  CHECK(qd_port_int("") == -1)
with expansion:
  0 == -1

/home/jdanek/repos/qpid/qpid-dispatch/tests/c_unittests/test_amqp.cpp:46: Failure:
  CHECK(qd_port_int("42http") == -1)
with expansion:
  42 == -1

/home/jdanek/repos/qpid/qpid-dispatch/tests/c_unittests/test_amqp.cpp:47: Failure:
  CHECK(qd_port_int("http42") == -1)
with expansion:
  36875 == -1

/home/jdanek/repos/qpid/qpid-dispatch/tests/c_unittests/test_amqp.cpp:49: Failure:
  CHECK(qd_port_int("no_such_port") == -1)
with expansion:
  36875 == -1
Process finished with exit code 1
```