### PR TITLE
DISPATCH-1739 Add GitHub Action w/ sharding and bubblewrap

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,199 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  compile:
+    name: "Compile (${{matrix.os}}, ${{matrix.runtimeCheck}})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        buildType: [RelWithDebInfo]
+        runtimeCheck: [asan]
+    env:
+      BuildType: ${{matrix.buildType}}
+      ProtonBuildDir: ${{github.workspace}}/qpid-proton/build
+      DispatchBuildDir: ${{github.workspace}}/qpid-dispatch/build
+      InstallPrefix: ${{github.workspace}}/install
+
+      ProtonCMakeExtraArgs: '-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_BINDINGS=python -DRUNTIME_CHECK=${{matrix.runtimeCheck}}'
+      DispatchCMakeExtraArgs: '-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCONSOLE_INSTALL=OFF -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DRUNTIME_CHECK=${{matrix.runtimeCheck}}'
+
+      CCACHE_BASEDIR: ${{github.workspace}}
+      CCACHE_DIR: ${{github.workspace}}/.ccache
+      CCACHE_COMPRESS: 'true'
+      CCACHE_MAXSIZE: '400MB'
+    steps:
+
+      - name: Show environment (Linux)
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: env -0 | sort -z | tr '\0' '\n'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'apache/qpid-proton'
+          ref: 'master'
+          path: 'qpid-proton'
+
+      - uses: actions/checkout@v2
+        with:
+          path: 'qpid-dispatch'
+
+      # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-ccache
+        with:
+          path: .ccache
+          key: ${{ matrix.os }}-${{ matrix.runtimeCheck }}-${{ env.cache-name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.runtimeCheck }}-${{ env.cache-name }}
+
+      - name: Create Build and Install directories
+        run: mkdir -p "${ProtonBuildDir}" "${DispatchBuildDir}" "{InstallPrefix}"
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+          architecture: x64
+
+      - name: Install python dependencies
+        run: python -m pip install setuptools wheel tox
+
+      - name: Install Linux dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt install -y swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev ccache ninja-build pixz
+
+      - name: Zero ccache stats
+        run: ccache -z
+
+      - name: qpid-proton cmake configure
+        working-directory: ${{env.ProtonBuildDir}}
+        run: cmake "${{github.workspace}}/qpid-proton" "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" "-DCMAKE_BUILD_TYPE=${BuildType}" "-DBUILD_TESTING=OFF" "-DENABLE_FUZZ_TESTING=OFF" "-GNinja" ${ProtonCMakeExtraArgs}
+
+      - name: qpid-proton cmake build/install
+        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} -t install
+
+      - name: Display ccache stats
+        run: ccache -s
+
+      - name: qpid-dispatch cmake configure
+        working-directory: ${{env.DispatchBuildDir}}
+        run: cmake "${{github.workspace}}/qpid-dispatch" "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" "-DCMAKE_BUILD_TYPE=${BuildType}" "-GNinja" "-DUSE_BWRAP=ON" ${DispatchCMakeExtraArgs}
+
+      - name: qpid-dispatch cmake build/install
+        run: cmake --build "${DispatchBuildDir}" --config ${BuildType} -t install
+
+      - name: Display ccache stats
+        run: ccache -s
+
+      # github actions/upload-artifact@v2 does not preserve executable permission on binaries
+      - name: Compress build
+        working-directory: ${{github.workspace}}
+        run: tar -I pixz -cf /tmp/archive.tar.xz --exclude '*.o' --exclude '*.pyc' --exclude '.git' --exclude='qpid-dispatch/build/console' qpid-dispatch install qpid-proton/build/python/pkgs
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: qpid_dispatch_wrk_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}
+          path: /tmp/archive.tar.xz
+
+  test:
+    name: 'Test (${{matrix.os}}, ${{matrix.runtimeCheck}}, shard ${{matrix.shard}} of ${{matrix.shards}})'
+    runs-on: ${{ matrix.os }}
+    needs: [compile]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        buildType: [RelWithDebInfo]
+        runtimeCheck: [asan]
+        shard: [1, 2]
+        shards: [2]
+    env:
+      BuildType: ${{matrix.buildType}}
+      ProtonBuildDir: ${{github.workspace}}/qpid-proton/build
+      DispatchBuildDir: ${{github.workspace}}/qpid-dispatch/build
+      InstallPrefix: ${{github.workspace}}/install
+      LD_LIBRARY_PATH: ${{github.workspace}}/install/lib
+    steps:
+
+      - name: Show environment (Linux)
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: env -0 | sort -z | tr '\0' '\n'
+
+      - name: Download Build
+        uses: actions/download-artifact@v2
+        with:
+          name: qpid_dispatch_wrk_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+          architecture: x64
+
+      - name: Install python dependencies
+        run: python -m pip install tox
+
+      - name: Install Linux dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt install -y libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp1 libwebsockets15 pixz bubblewrap
+
+      - name: Unpack archive
+        run: tar -I pixz -xf archive.tar.xz
+
+      - name: install qpid-proton python wheel
+        run: python -m pip install ${ProtonBuildDir}/python/pkgs/python_qpid_proton*.whl
+
+      - name: CTest
+        working-directory: ${{env.DispatchBuildDir}}
+        run: |
+          ulimit -c unlimited
+          ctest -C ${BuildType} -V -T Test --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: ${{ ! cancelled() }}
+        with:
+          name: Test_Results_${{matrix.os}}_${{matrix.buildType}}_${{matrix.shard}}
+          path: ${{env.DispatchBuildDir}}/Testing/**/*.xml
+
+      - name: Upload core files (if any)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cores_${{matrix.os}}_${{matrix.buildType}}_${{matrix.shard}}
+          path: |
+            **/core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,7 +64,18 @@ target_link_libraries(test-receiver ${Proton_LIBRARIES})
 add_executable(clogger clogger.c)
 target_link_libraries(clogger ${Proton_LIBRARIES})
 
-set(TEST_WRAP ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/run.py)
+# Bubblewrap is an unprivileged sandboxing tool for Linux. Setting --unshare-net allows
+# running tests in parallel (the ctest -j option) without port clashes
+set(USE_BWRAP OFF CACHE BOOL "Wrap test executions with bwrap (https://github.com/containers/bubblewrap)")
+if(USE_BWRAP)
+  # Inaccessible DNS servers produce "proton:io Temporary failure in name resolution".
+  # For system_tests_bad_configuration we need to get "proton:io Name or service not known",
+  # so blank /etc/nsswitch.conf to achieve that.
+  set(BWRAP_ARGS bwrap --bind / / --bind /dev/zero /etc/nsswitch.conf --unshare-net --dev /dev --die-with-parent --)
+else()
+  set(BWRAP_ARGS "")
+endif()
+set(TEST_WRAP ${BWRAP_ARGS} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/run.py)
 
 add_test(unit_tests_size_10000 ${TEST_WRAP} unit_tests_size 10000)
 add_test(unit_tests_size_512   ${TEST_WRAP} unit_tests_size 512)


### PR DESCRIPTION
This is a CI job triggered by pushes and pull requests sent to GitHub.

Output artifacts include parts of the workspace before running tests; this is
what the machines running test shards get. At the end, each shard outputs
a XML CTest report.

Note that `ctest -j2` results in test log lines being mixed up in stdout.
Refer to the output XML report or use grep (grep for lines starting with
the test number) to get understandable logs.

* Using python 3.6 as this is the version that works on all platforms tested.
* Using four shards, as adding more does not help much.
* Using ctest -j2, mostly just to exercise bubblewrap. Bwrap is more useful on Travis