### PR TITLE
DISPATCH-1720: use `npm ci` because it's appropriate and fast

### DIFF
--- a/.github/workflows/console.yaml
+++ b/.github/workflows/console.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: cd console/react && npm install
+        run: cd console/react && npm ci
 
       - name: Run Tests
         run: cd console/react && npm run test
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: cd console/react && npm install
+        run: cd console/react && npm ci
 
       - name: Install Typescript
         run: cd console/react && npm install typescript


### PR DESCRIPTION
https://docs.npmjs.com/cli/ci.html