### PR TITLE
DISPATCH-1766: Remove stale code processing 'sslProfile trustedCertsF…

### DIFF
--- a/console/react/test_data/schema.js
+++ b/console/react/test_data/schema.js
@@ -897,11 +897,6 @@ export default {
           description:
             "yes: Require the connection to the peer to be encrypted; no: Permit non-encrypted communication with the peer"
         },
-        trustedCertsFile: {
-          type: "path",
-          description:
-            "This optional setting can be used to reduce the set of available CAs for client authentication.  If used, this setting must provide the absolute path to a PEM file that contains the trusted certificates."
-        },
         role: {
           default: "normal",
           type: ["normal", "inter-router", "route-container", "edge"],

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -193,7 +193,6 @@ typedef struct qd_server_config_t {
         char *ssl_uid_name_mapping_file;
         char *ssl_password;
         char *ssl_trusted_certificate_db;
-        char *ssl_trusted_certificates;
         char *ssl_ciphers;
         char *ssl_protocols;
     } sasl_plugin_config;
@@ -313,14 +312,6 @@ typedef struct qd_server_config_t {
      * Path to the file containing the PEM-formatted set of certificates of trusted CAs.
      */
     char *ssl_trusted_certificate_db;
-
-    /**
-     * Path to an optional file containing the PEM-formatted set of certificates of
-     * trusted CAs for a particular connection/listener.  This must be a subset of the
-     * set of certificates in the ssl_trusted_certificate_db.  If this is left NULL,
-     * the entire set within the db will be used.
-     */
-    char *ssl_trusted_certificates;
 
     /**
      * Iff true, require that the peer's certificate be supplied and that it be authentic

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -807,7 +807,7 @@
                 },
                 "trustedCertsFile": {
                     "type": "path",
-                    "description": "This optional setting can be used to reduce the set of available CAs for client authentication.  If used, this setting must provide the absolute path to a PEM file that contains the trusted certificates.",
+                    "description": "(DEPRECATED) Use sslProfile caCertFile instead.",
                     "deprecationName": "trustedCerts",
                     "create": true
                 },

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -39,7 +39,6 @@ struct qd_config_ssl_profile_t {
     char        *name;
     char        *ssl_password;
     char        *ssl_trusted_certificate_db;
-    char        *ssl_trusted_certificates;
     char        *ssl_uid_format;
     char        *uid_name_mapping_file;
     char        *ssl_certificate_file;
@@ -180,7 +179,6 @@ void qd_server_config_free(qd_server_config_t *cf)
     if (cf->ssl_protocols)              free(cf->ssl_protocols);
     if (cf->ssl_password)               free(cf->ssl_password);
     if (cf->ssl_trusted_certificate_db) free(cf->ssl_trusted_certificate_db);
-    if (cf->ssl_trusted_certificates)   free(cf->ssl_trusted_certificates);
     if (cf->ssl_uid_format)             free(cf->ssl_uid_format);
     if (cf->ssl_uid_name_mapping_file)  free(cf->ssl_uid_name_mapping_file);
 
@@ -192,7 +190,6 @@ void qd_server_config_free(qd_server_config_t *cf)
     if (cf->sasl_plugin_config.ssl_protocols)              free(cf->sasl_plugin_config.ssl_protocols);
     if (cf->sasl_plugin_config.ssl_password)               free(cf->sasl_plugin_config.ssl_password);
     if (cf->sasl_plugin_config.ssl_trusted_certificate_db) free(cf->sasl_plugin_config.ssl_trusted_certificate_db);
-    if (cf->sasl_plugin_config.ssl_trusted_certificates)   free(cf->sasl_plugin_config.ssl_trusted_certificates);
     if (cf->sasl_plugin_config.ssl_uid_format)             free(cf->sasl_plugin_config.ssl_uid_format);
     if (cf->sasl_plugin_config.ssl_uid_name_mapping_file)  free(cf->sasl_plugin_config.ssl_uid_name_mapping_file);
 
@@ -395,6 +392,13 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
     config->multi_tenant         = qd_entity_opt_bool(entity, "multiTenant", false);  CHECK();
     config->policy_vhost         = qd_entity_opt_string(entity, "policyVhost", 0);    CHECK();
     config->conn_props           = qd_entity_opt_map(entity, "openProperties");       CHECK();
+
+    const char *unused           = qd_entity_opt_string(entity, "trustedCertsFile", 0);
+    if (unused) {
+        qd_log(qd->connection_manager->log_source, QD_LOG_WARNING,
+               "Configuration listener attribute 'trustedCertsFile' is not used. Specify sslProfile caCertFile instead.");
+    }
+
     set_config_host(config, entity);
 
     if (config->sasl_password) {
@@ -485,7 +489,6 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
             config->ssl_protocols = SSTRDUP(ssl_profile->ssl_protocols);
             config->ssl_password = SSTRDUP(ssl_profile->ssl_password);
             config->ssl_trusted_certificate_db = SSTRDUP(ssl_profile->ssl_trusted_certificate_db);
-            config->ssl_trusted_certificates = SSTRDUP(ssl_profile->ssl_trusted_certificates);
             config->ssl_uid_format = SSTRDUP(ssl_profile->ssl_uid_format);
             config->ssl_uid_name_mapping_file = SSTRDUP(ssl_profile->uid_name_mapping_file);
         }
@@ -510,7 +513,6 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
                 config->sasl_plugin_config.ssl_protocols = SSTRDUP(auth_ssl_profile->ssl_protocols);
                 config->sasl_plugin_config.ssl_password = SSTRDUP(auth_ssl_profile->ssl_password);
                 config->sasl_plugin_config.ssl_trusted_certificate_db = SSTRDUP(auth_ssl_profile->ssl_trusted_certificate_db);
-                config->sasl_plugin_config.ssl_trusted_certificates = SSTRDUP(auth_ssl_profile->ssl_trusted_certificates);
                 config->sasl_plugin_config.ssl_uid_format = SSTRDUP(auth_ssl_profile->ssl_uid_format);
                 config->sasl_plugin_config.ssl_uid_name_mapping_file = SSTRDUP(auth_ssl_profile->uid_name_mapping_file);
             } else {
@@ -550,7 +552,6 @@ static bool config_ssl_profile_free(qd_connection_manager_t *cm, qd_config_ssl_p
     free(ssl_profile->name);
     free(ssl_profile->ssl_password);
     free(ssl_profile->ssl_trusted_certificate_db);
-    free(ssl_profile->ssl_trusted_certificates);
     free(ssl_profile->ssl_uid_format);
     free(ssl_profile->uid_name_mapping_file);
     free(ssl_profile->ssl_certificate_file);
@@ -622,7 +623,6 @@ qd_config_ssl_profile_t *qd_dispatch_configure_ssl_profile(qd_dispatch_t *qd, qd
     ssl_profile->ssl_ciphers   = qd_entity_opt_string(entity, "ciphers", 0);                   CHECK();
     ssl_profile->ssl_protocols = qd_entity_opt_string(entity, "protocols", 0);                 CHECK();
     ssl_profile->ssl_trusted_certificate_db = qd_entity_opt_string(entity, "caCertFile", 0);   CHECK();
-    ssl_profile->ssl_trusted_certificates   = qd_entity_opt_string(entity, "trustedCertsFile", 0);   CHECK();
     ssl_profile->ssl_uid_format             = qd_entity_opt_string(entity, "uidFormat", 0);          CHECK();
     ssl_profile->uid_name_mapping_file      = qd_entity_opt_string(entity, "uidNameMappingFile", 0); CHECK();
 

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -353,7 +353,7 @@ static void listener_start(qd_http_listener_t *hl, qd_http_server_t *hs) {
         info.ssl_cert_filepath = config->ssl_certificate_file;
         info.ssl_private_key_filepath = config->ssl_private_key_file;
         info.ssl_private_key_password = config->ssl_password;
-        info.ssl_ca_filepath = config->ssl_trusted_certificates ? config->ssl_trusted_certificates : config->ssl_trusted_certificate_db;
+        info.ssl_ca_filepath = config->ssl_trusted_certificate_db;
         info.ssl_cipher_list = config->ssl_ciphers;
 
         info.options |=

--- a/src/server.c
+++ b/src/server.c
@@ -404,8 +404,6 @@ static qd_error_t listener_setup_ssl(qd_connection_t *ctx, const qd_server_confi
     }
 
     const char *trusted = config->ssl_trusted_certificate_db;
-    if (config->ssl_trusted_certificates)
-        trusted = config->ssl_trusted_certificates;
 
     // do we force the peer to send a cert?
     if (config->ssl_require_peer_authentication) {
@@ -1198,12 +1196,10 @@ static void setup_ssl_sasl_and_open(qd_connection_t *ctx)
         }
         // should we force the peer to provide a cert?
         if (config->ssl_require_peer_authentication) {
-            const char *trusted = (config->ssl_trusted_certificates)
-                ? config->ssl_trusted_certificates
-                : config->ssl_trusted_certificate_db;
+
             if (pn_ssl_domain_set_peer_authentication(domain,
                                                       PN_SSL_VERIFY_PEER,
-                                                      trusted)) {
+                                                      config->ssl_trusted_certificate_db)) {
                 qd_log(ct->server->log_source, QD_LOG_ERROR,
                        "SSL peer auth configuration failed for %s:%s",
                        config->host, config->port);


### PR DESCRIPTION
…ile'

This attribute does not exist in the schema.

Deprecate 'listener trustedCertsFile'. Print a warning that the setting
has no effect if it is used.