### PR TITLE
DISPATCH-1762: Connector ssl config errors must prohibit connections

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1254,7 +1254,7 @@ static bool setup_ssl_sasl_and_open(qd_connection_t *ctx)
         if (config->verify_host_name) {
             if (pn_ssl_domain_set_peer_authentication(domain, PN_SSL_VERIFY_PEER_NAME, NULL)) {
                 qd_log(ct->server->log_source, QD_LOG_ERROR,
-                        "SSL peer host name configuration failed for connection [C%"PRIu64"] to %s:%s",
+                        "SSL peer host name verification configuration failed for connection [C%"PRIu64"] to %s:%s",
                         ctx->connection_id, config->host, config->port);
                 failed = true;
             }

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -851,7 +851,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
             ('router', {'id': 'QDR.B',
                         'mode': 'interior'}),
             # Connector to All TLS versions allowed listener
-            ('connector', {'host': '0.0.0.0', 'role': 'inter-router', 'port': cls.PORT_TLS_ALL,
+            ('connector', {'host': 'localhost', 'role': 'inter-router', 'port': cls.PORT_TLS_ALL,
                            'verifyHostname': 'no', 'saslMechanisms': 'PLAIN',
                            'saslUsername': 'test@domain.com', 'saslPassword': 'pass:password',
                            'sslProfile': 'ssl-profile-tls-all'}),

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -916,6 +916,7 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
             self.skipTest("Cyrus library not available. skipping test")
 
         # Poll for a while until the connector error shows up in router B's log
+        time.sleep(0.5)
         pattern = " SERVER (error) SSL CA configuration failed"
         host_port_1 = self.CONNECTOR_HOST + ":" + str(self.PORT_TLS_ALL_1)
         host_port_2 = self.CONNECTOR_HOST + ":" + str(self.PORT_TLS_ALL_2)
@@ -923,13 +924,15 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
         poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
-            with  open(self.routers[1].logfile, 'r') as router_log:
-                log_lines = router_log.read().split("\n")
-            e1_lines = [s for s in log_lines if pattern in s and host_port_1 in s]
-            e2_lines = [s for s in log_lines if pattern in s and host_port_2 in s]
-            verified = len(e1_lines) > 0 and len(e2_lines) > 0
-            if verified:
-                break;
+            logfile = os.path.join(self.routers[1].outdir, self.routers[1].logfile)
+            if os.path.exists(logfile):
+                with  open(logfile, 'r') as router_log:
+                    log_lines = router_log.read().split("\n")
+                e1_lines = [s for s in log_lines if pattern in s and host_port_1 in s]
+                e2_lines = [s for s in log_lines if pattern in s and host_port_2 in s]
+                verified = len(e1_lines) > 0 and len(e2_lines) > 0
+                if verified:
+                    break;
             time.sleep(sleep_time)
         self.assertTrue(verified, "Log line containing '%s' not seen for both connectors in QDR.B log" % pattern)
 
@@ -1052,17 +1055,20 @@ class RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA(RouterT
             self.skipTest("Cyrus library not available. skipping test")
 
         # Poll for a while until the connector error shows up in router B's log
+        time.sleep(0.5)
         pattern = "Connection to localhost:%s failed:" % self.PORT_TLS_ALL
         sleep_time = 0.1 # seconds
         poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
-            with  open(self.routers[1].logfile, 'r') as router_log:
-                log_lines = router_log.read().split("\n")
-            e_lines = [s for s in log_lines if pattern in s]
-            verified = len(e_lines) > 0
-            if verified:
-                break;
+            logfile = os.path.join(self.routers[1].outdir, self.routers[1].logfile)
+            if os.path.exists(logfile):
+                with  open(logfile, 'r') as router_log:
+                    log_lines = router_log.read().split("\n")
+                e_lines = [s for s in log_lines if pattern in s]
+                verified = len(e_lines) > 0
+                if verified:
+                    break;
             time.sleep(sleep_time)
         self.assertTrue(verified, "Log line containing '%s' not seen in QDR.B log" % pattern)
 

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -921,7 +921,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         router_nodes = self.get_router_nodes()
         self.assertTrue(router_nodes)
         node = "QDR.B"
-        self.assertTrue(node not in router_nodes, "%s should not be connected" % node)
+        self.assertNotIn(node, router_nodes, msg=("%s should not be connected" % node))
 
 
 if __name__ == '__main__':

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -923,7 +923,7 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
         poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
-            with  open( os.path.join(self.routers[1].outdir, 'B.log'), 'r') as router_log:
+            with  open(self.routers[1].logfile, 'r') as router_log:
                 log_lines = router_log.read().split("\n")
             e1_lines = [s for s in log_lines if pattern in s and host_port_1 in s]
             e2_lines = [s for s in log_lines if pattern in s and host_port_2 in s]
@@ -1057,7 +1057,7 @@ class RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA(RouterT
         poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
-            with  open(os.path.join(self.routers[1].outdir, 'B.log'), 'r') as router_log:
+            with  open(self.routers[1].logfile, 'r') as router_log:
                 log_lines = router_log.read().split("\n")
             e_lines = [s for s in log_lines if pattern in s]
             verified = len(e_lines) > 0

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -905,7 +905,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         # Poll for a while until the connector error shows up in router B's log
         pattern = " SERVER (error) SSL CA configuration failed"
         sleep_time = 0.1 # seconds
-        poll_duration = 10.0 # seconds
+        poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
             with  open('../setUpClass/B.log', 'r') as router_log:

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -876,11 +876,8 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
             # setup chain of calls to pn_ssl_domain_* functions.
             ('sslProfile', {'name': 'ssl-profile-tls-all',
                             'caCertFile': cls.ssl_file('ca-certificate-INVALID-FILENAME.pem'),
-                            'certFile': cls.ssl_file('client-certificate.pem'),
-                            'privateKeyFile': cls.ssl_file('client-private-key.pem'),
                             'ciphers': 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:' \
-                                       'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS',
-                            'password': 'client-password'})
+                                       'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS'})
         ])
 
         cls.routers.append(cls.tester.qdrouterd("A", config_a, wait=False))
@@ -916,7 +913,6 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
             self.skipTest("Cyrus library not available. skipping test")
 
         # Poll for a while until the connector error shows up in router B's log
-        time.sleep(0.5)
         pattern = " SERVER (error) SSL CA configuration failed"
         host_port_1 = self.CONNECTOR_HOST + ":" + str(self.PORT_TLS_ALL_1)
         host_port_2 = self.CONNECTOR_HOST + ":" + str(self.PORT_TLS_ALL_2)
@@ -1055,7 +1051,6 @@ class RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA(RouterT
             self.skipTest("Cyrus library not available. skipping test")
 
         # Poll for a while until the connector error shows up in router B's log
-        time.sleep(0.5)
         pattern = "Connection to localhost:%s failed:" % self.PORT_TLS_ALL
         sleep_time = 0.1 # seconds
         poll_duration = 60.0 # seconds

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -923,7 +923,7 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
         poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
-            with  open('../setUpClass/B.log', 'r') as router_log:
+            with  open( os.path.join(self.routers[1].outdir, 'B.log'), 'r') as router_log:
                 log_lines = router_log.read().split("\n")
             e1_lines = [s for s in log_lines if pattern in s and host_port_1 in s]
             e2_lines = [s for s in log_lines if pattern in s and host_port_2 in s]
@@ -1057,7 +1057,7 @@ class RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA(RouterT
         poll_duration = 60.0 # seconds
         verified = False
         for tries in range(int(poll_duration / sleep_time)):
-            with  open('../setUpClass/B.log', 'r') as router_log:
+            with  open(os.path.join(self.routers[1].outdir, 'B.log'), 'r') as router_log:
                 log_lines = router_log.read().split("\n")
             e_lines = [s for s in log_lines if pattern in s]
             verified = len(e_lines) > 0

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -932,6 +932,22 @@ class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
             time.sleep(sleep_time)
         self.assertTrue(verified, "Log line containing '%s' not seen for both connectors in QDR.B log" % pattern)
 
+        verified = False
+        pattern1 = "Connection to %s failed:" % host_port_1
+        pattern2 = "Connection to %s failed:" % host_port_2
+        for tries in range(int(poll_duration / sleep_time)):
+            logfile = os.path.join(self.routers[1].outdir, self.routers[1].logfile)
+            if os.path.exists(logfile):
+                with  open(logfile, 'r') as router_log:
+                    log_lines = router_log.read().split("\n")
+                e1_lines = [s for s in log_lines if pattern1 in s]
+                e2_lines = [s for s in log_lines if pattern2 in s]
+                verified = len(e1_lines) > 0 and len(e2_lines) > 0
+                if verified:
+                    break;
+            time.sleep(sleep_time)
+        self.assertTrue(verified, "Log line containing '%s' or '%s' not seen in QDR.B log" % (pattern1, pattern2))
+
         # Show that router A does not have router B in its network
         router_nodes = self.get_router_nodes()
         self.assertTrue(router_nodes)

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -781,18 +781,16 @@ class RouterTestSslInterRouter(RouterTestSslBase):
         self.assertEqual(len(router_nodes), expected_nodes)
 
 
-class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
+class RouterTestSslInterRouterWithInvalidPathToCA(RouterTestSslBase):
     """
     DISPATCH-1762
     Starts 2 routers:
-       Router A listener serves a normal, good certificate
-       Router B connector is configured with a bad CA in its profile but verifyHostname is false.
+       Router A two listeners serve a normal, good certificate
+       Router B two connectors configured with an invalid CA file path in its profile
+          - one sets verifyHostname true, the other false.
     Test proves:
-       Router B must not connect to A.
-
-    DISPATCH-1762 fixes several issues related to failed ssl setup
-    allowing a connector to connect anyway.
-    This test checks only one of the failures.
+       Router B must not connect to A with mis-configured CA file path regardless of
+       verifyHostname setting.
     """
     # Listener ports for each TLS protocol definition
     PORT_NO_SSL  = 0
@@ -803,7 +801,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         """
         Prepares 2 routers to form a network.
         """
-        super(RouterTestSslInterRouterVerifyHostname, cls).setUpClass()
+        super(RouterTestSslInterRouterWithInvalidPathToCA, cls).setUpClass()
 
         if not SASL.extended():
             return
@@ -811,7 +809,164 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         os.environ["ENV_SASL_PASSWORD"] = "password"
 
         # Generate authentication DB
-        super(RouterTestSslInterRouterVerifyHostname, cls).create_sasl_files()
+        super(RouterTestSslInterRouterWithInvalidPathToCA, cls).create_sasl_files()
+
+        # Router expected to be connected
+        cls.connected_tls_sasl_routers = []
+
+        # Generated router list
+        cls.routers = []
+
+        # Saving listener ports for each TLS definition
+        cls.PORT_NO_SSL = cls.tester.get_port()
+        cls.PORT_TLS_ALL_1 = cls.tester.get_port()
+        cls.PORT_TLS_ALL_2 = cls.tester.get_port()
+
+        # Configured connector host
+        cls.CONNECTOR_HOST = "localhost"
+
+        config_a = Qdrouterd.Config([
+            ('router', {'id': 'QDR.A',
+                        'mode': 'interior',
+                        'saslConfigName': 'tests-mech-PLAIN',
+                        'saslConfigDir': os.getcwd()}),
+            # No auth and no SSL for management access
+            ('listener', {'host': '0.0.0.0', 'role': 'normal', 'port': cls.PORT_NO_SSL}),
+            # All TLS versions and normal, good sslProfile config
+            ('listener', {'host': '0.0.0.0', 'role': 'inter-router', 'port': cls.PORT_TLS_ALL_1,
+                          'saslMechanisms': 'PLAIN',
+                          'requireEncryption': 'yes', 'requireSsl': 'yes',
+                          'sslProfile': 'ssl-profile-tls-all'}),
+            # All TLS versions and normal, good sslProfile config
+            ('listener', {'host': '0.0.0.0', 'role': 'inter-router', 'port': cls.PORT_TLS_ALL_2,
+                          'saslMechanisms': 'PLAIN',
+                          'requireEncryption': 'yes', 'requireSsl': 'yes',
+                          'sslProfile': 'ssl-profile-tls-all'}),
+            # SSL Profile for all TLS versions (protocols element not defined)
+            ('sslProfile', {'name': 'ssl-profile-tls-all',
+                            'caCertFile': cls.ssl_file('ca-certificate.pem'),
+                            'certFile': cls.ssl_file('server-certificate.pem'),
+                            'privateKeyFile': cls.ssl_file('server-private-key.pem'),
+                            'ciphers': 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:' \
+                                       'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS',
+                            'password': 'server-password'})
+        ])
+
+        # Router B has a connector to listener that allows all protocols but will not verify hostname.
+        # The sslProfile has a bad caCertFile name and this router should not connect.
+        config_b = Qdrouterd.Config([
+            ('router', {'id': 'QDR.B',
+                        'mode': 'interior'}),
+            # Connector to All TLS versions allowed listener
+            ('connector', {'name': 'connector1',
+                           'host': cls.CONNECTOR_HOST, 'role': 'inter-router',
+                           'port': cls.PORT_TLS_ALL_1,
+                           'verifyHostname': 'no', 'saslMechanisms': 'PLAIN',
+                           'saslUsername': 'test@domain.com', 'saslPassword': 'pass:password',
+                           'sslProfile': 'ssl-profile-tls-all'}),
+            # Connector to All TLS versions allowed listener
+            ('connector', {'name': 'connector2',
+                           'host': cls.CONNECTOR_HOST, 'role': 'inter-router',
+                           'port': cls.PORT_TLS_ALL_2,
+                           'verifyHostname': 'yes', 'saslMechanisms': 'PLAIN',
+                           'saslUsername': 'test@domain.com', 'saslPassword': 'pass:password',
+                           'sslProfile': 'ssl-profile-tls-all'}),
+            # SSL Profile with an invalid caCertFile file path. The correct file path here would allow this
+            # router to connect. The object is to trigger a specific failure in the ssl
+            # setup chain of calls to pn_ssl_domain_* functions.
+            ('sslProfile', {'name': 'ssl-profile-tls-all',
+                            'caCertFile': cls.ssl_file('ca-certificate-INVALID-FILENAME.pem'),
+                            'certFile': cls.ssl_file('client-certificate.pem'),
+                            'privateKeyFile': cls.ssl_file('client-private-key.pem'),
+                            'ciphers': 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:' \
+                                       'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS',
+                            'password': 'client-password'})
+        ])
+
+        cls.routers.append(cls.tester.qdrouterd("A", config_a, wait=False))
+        cls.routers.append(cls.tester.qdrouterd("B", config_b, wait=False))
+
+        # Wait until A is running
+        cls.routers[0].wait_ports()
+
+        # Can't wait until B is connected because it's not supposed to connect.
+
+    def get_router_nodes(self):
+        """
+        Retrieves connected router nodes from QDR.A
+        :return: list of connected router id's
+        """
+        if not SASL.extended():
+            self.skipTest("Cyrus library not available. skipping test")
+
+        url = Url("amqp://0.0.0.0:%d/$management" % self.PORT_NO_SSL)
+        node = Node.connect(url)
+        response = node.query(type="org.apache.qpid.dispatch.router.node", attribute_names=["id"])
+        router_nodes = []
+        for resp in response.get_dicts():
+            router_nodes.append(resp['id'])
+        node.close()
+        return router_nodes
+
+    def test_invalid_ca_path(self):
+        """
+        Prove sslProfile with invalid path to CA prevents the router from joining the network
+        """
+        if not SASL.extended():
+            self.skipTest("Cyrus library not available. skipping test")
+
+        # Poll for a while until the connector error shows up in router B's log
+        pattern = " SERVER (error) SSL CA configuration failed"
+        host_port_1 = self.CONNECTOR_HOST + ":" + str(self.PORT_TLS_ALL_1)
+        host_port_2 = self.CONNECTOR_HOST + ":" + str(self.PORT_TLS_ALL_2)
+        sleep_time = 0.1 # seconds
+        poll_duration = 60.0 # seconds
+        verified = False
+        for tries in range(int(poll_duration / sleep_time)):
+            with  open('../setUpClass/B.log', 'r') as router_log:
+                log_lines = router_log.read().split("\n")
+            e1_lines = [s for s in log_lines if pattern in s and host_port_1 in s]
+            e2_lines = [s for s in log_lines if pattern in s and host_port_2 in s]
+            verified = len(e1_lines) > 0 and len(e2_lines) > 0
+            if verified:
+                break;
+            time.sleep(sleep_time)
+        self.assertTrue(verified, "Log line containing '%s' not seen for both connectors in QDR.B log" % pattern)
+
+        # Show that router A does not have router B in its network
+        router_nodes = self.get_router_nodes()
+        self.assertTrue(router_nodes)
+        node = "QDR.B"
+        self.assertNotIn(node, router_nodes, msg=("%s should not be connected" % node))
+
+
+class RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA(RouterTestSslBase):
+    """
+    DISPATCH-1762
+    Starts 2 routers:
+       Router A listener serves a normal, good certificate.
+       Router B connector is configured with a CA cert that did not sign the server cert, and verifyHostname is false.
+    Test proves:
+       Router B must not connect to A.
+    """
+    # Listener ports for each TLS protocol definition
+    PORT_NO_SSL  = 0
+    PORT_TLS_ALL = 0
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Prepares 2 routers to form a network.
+        """
+        super(RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA, cls).setUpClass()
+
+        if not SASL.extended():
+            return
+
+        os.environ["ENV_SASL_PASSWORD"] = "password"
+
+        # Generate authentication DB
+        super(RouterTestSslInterRouterWithoutHostnameVerificationAndMismatchedCA, cls).create_sasl_files()
 
         # Router expected to be connected
         cls.connected_tls_sasl_routers = []
@@ -846,7 +1001,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         ])
 
         # Router B has a connector to listener that allows all protocols but will not verify hostname.
-        # The sslProfile has a bad caCertFile name and this router should not connect.
+        # The sslProfile has a caCertFile that does not sign the server cert, so this router should not connect.
         config_b = Qdrouterd.Config([
             ('router', {'id': 'QDR.B',
                         'mode': 'interior'}),
@@ -855,16 +1010,12 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
                            'verifyHostname': 'no', 'saslMechanisms': 'PLAIN',
                            'saslUsername': 'test@domain.com', 'saslPassword': 'pass:password',
                            'sslProfile': 'ssl-profile-tls-all'}),
-            # SSL Profile with bad caCertFile name. The correct name here would allow this
-            # router to connect. The object is to trigger a specific failure in the ssl
-            # setup chain of calls to pn_ssl_domain_* functions.
+            # SSL Profile with caCertFile to cert that does not sign the server cert. The correct path here would allow this
+            # router to connect. The object is to trigger a certificate verification failure while hostname verification is off.
             ('sslProfile', {'name': 'ssl-profile-tls-all',
-                            'caCertFile': cls.ssl_file('ca-certificate-BAD.pem'),
-                            'certFile': cls.ssl_file('client-certificate.pem'),
-                            'privateKeyFile': cls.ssl_file('client-private-key.pem'),
+                            'caCertFile': cls.ssl_file('bad-ca-certificate.pem'),
                             'ciphers': 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:' \
-                                       'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS',
-                            'password': 'client-password'})
+                                       'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS'})
         ])
 
         cls.routers.append(cls.tester.qdrouterd("A", config_a, wait=False))
@@ -892,9 +1043,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         node.close()
         return router_nodes
 
-    @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING or not SASL.extended(),
-                  "Cyrus library not available. skipping test")
-    def test_connected_misconfigured_tls_sasl_routers(self):
+    def test_mismatched_ca_and_no_hostname_verification(self):
         """
         Prove that improperly configured ssl-enabled connector prevents the router
         from joining the network
@@ -903,7 +1052,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
             self.skipTest("Cyrus library not available. skipping test")
 
         # Poll for a while until the connector error shows up in router B's log
-        pattern = " SERVER (error) SSL CA configuration failed"
+        pattern = "Connection to localhost:%s failed:" % self.PORT_TLS_ALL
         sleep_time = 0.1 # seconds
         poll_duration = 60.0 # seconds
         verified = False
@@ -922,6 +1071,7 @@ class RouterTestSslInterRouterVerifyHostname(RouterTestSslBase):
         self.assertTrue(router_nodes)
         node = "QDR.B"
         self.assertNotIn(node, router_nodes, msg=("%s should not be connected" % node))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Errors seen passing ssl protocol settings to Proton were logged but
the connector was allowed to connect anyway.

The initial complaint in DISPATCH-1762 was about how a bad ca cert
file name allowed the connection to proceed without using any ca cert
file. A self test is added to check that this particular case is fixed.

This patch prevents all connector connection attempts if there are
any configuration errors reported by Proton.