### PR TITLE
Move deletion of AMQP adaptor to core thread

### DIFF
--- a/src/router_core/router_core_thread.c
+++ b/src/router_core/router_core_thread.c
@@ -168,6 +168,9 @@ void qdr_adaptors_finalize(qdr_core_t *core)
         adaptor = DEQ_PREV(adaptor);
     }
 
+    // release the default AMQP adaptor (it is not a module)
+    assert(DEQ_SIZE(core->protocol_adaptors) == 1);
+    qdr_protocol_adaptor_free(core, DEQ_HEAD(core->protocol_adaptors));
 }
 
 

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -2001,7 +2001,6 @@ void qd_router_free(qd_router_t *router)
 
     qd_container_set_default_node_type(router->qd, 0, 0, QD_DIST_BOTH);
 
-    qdr_protocol_adaptor_free(router->router_core, amqp_direct_adaptor);
     qdr_core_free(router->router_core);
     qd_tracemask_free(router->tracemask);
     qd_timer_free(router->timer);


### PR DESCRIPTION
This fixes a race where the core thread is accessing the adaptor while
it is being shut down.