### PR TITLE
DISPATCH-1778: Extra data included in adaptor outbound streams

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -2450,6 +2450,12 @@ int qd_message_body_data_buffers(qd_message_body_data_t *body_data, pn_raw_buffe
         buffers[idx].size     = qd_buffer_size(buffer) - (buffer == body_data->payload.buffer ? body_data->payload.offset : 0);
         buffers[idx].offset   = 0;
 
+        if (buffer == body_data->last_buffer) {
+            // Don't process beyond the end of this body_data section
+            actual_count++;
+            break;
+        }
+
         buffer = DEQ_NEXT(buffer);
         actual_count++;
         idx++;


### PR DESCRIPTION
Body_data processing failed to contain output to the current section.
This patch prevents qd_message_body_data_buffers from sending too
much data if new sections are added before the current section is
disposed.