### PR TITLE
Corrupt raw output testcase  DO NOT MERGE

### DIFF
--- a/src/adaptors/http1/http1_adaptor.c
+++ b/src/adaptors/http1/http1_adaptor.c
@@ -30,9 +30,6 @@
 // to HTTP endpoint processing.
 //
 
-// for debug: will dump raw buffer content to stdout if true
-#define HTTP1_DUMP_BUFFERS false
-
 #define RAW_BUFFER_BATCH  16
 
 

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -424,6 +424,17 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
         qd_buffer_list_t blist;
         uintmax_t length;
         qda_raw_conn_get_read_buffers(hconn->raw_conn, &blist, &length);
+
+        if (HTTP1_DUMP_BUFFERS) {
+            fprintf(stdout, "\nClient raw buffer READ %"PRIuMAX" total octets\n", length);
+            qd_buffer_t *bb = DEQ_HEAD(blist);
+            while (bb) {
+                fprintf(stdout, "  buffer='%.*s'\n", (int)qd_buffer_size(bb), (char*)&bb[1]);
+                bb = DEQ_NEXT(bb);
+            }
+            fflush(stdout);
+        }
+
         if (length) {
             qd_log(log, QD_LOG_DEBUG, "[C%"PRIu64"][L%"PRIu64"] Read %"PRIuMAX" bytes from client",
                    hconn->conn_id, hconn->in_link_id, length);

--- a/src/adaptors/http1/http1_codec.c
+++ b/src/adaptors/http1/http1_codec.c
@@ -268,7 +268,8 @@ void h1_codec_connection_free(h1_codec_connection_t *conn)
 {
     if (conn) {
         // expect application to cancel all requests!
-        assert(DEQ_IS_EMPTY(conn->hrs_queue));
+        fprintf(stderr, ">>>>> FIX ME %s %d\n", __FILE__, __LINE__);
+        //assert(DEQ_IS_EMPTY(conn->hrs_queue));
         decoder_reset(&conn->decoder);
         encoder_reset(&conn->encoder);
         qd_buffer_list_free_buffers(&conn->decoder.incoming);

--- a/src/adaptors/http1/http1_private.h
+++ b/src/adaptors/http1/http1_private.h
@@ -34,6 +34,9 @@
 #include <qpid/dispatch/message.h>
 #include "adaptors/http_common.h"
 
+// for debug: will dump raw buffer content to stdout if true
+#define HTTP1_DUMP_BUFFERS true
+
 typedef struct qdr_http1_out_data_t      qdr_http1_out_data_t;
 typedef struct qdr_http1_out_data_fifo_t qdr_http1_out_data_fifo_t;
 typedef struct qdr_http1_request_base_t  qdr_http1_request_base_t;


### PR DESCRIPTION
Using proton master (commit 341d30f8cff0ba98bac65604ad87e4d01062080c)
To reproduce:

$ mkdir BUILD; cd BUILD; cmake ..; make
$ python tests/run.py "-m" "unittest" "-v" "system_tests_http1_adaptor.Http1AdaptorEdge2EdgeTest"

You should see some output, then the test will hang until it times out.  If you reproduce the problem there will be console output with something like this:

FIXME                                                                                                                                             
SETUP DONE                                                                                                                                        
test_01_streaming (system_tests_http1_adaptor.Http1AdaptorEdge2EdgeTest)                                                                          
Test multiple clients sending streaming messages in parallel ... 2020-10-07 11:18:47.323080 TestServer listening on :9090                         
SERVERS UP                                                                                                                                        
SPAWNING CLIENTS                                                                                                                                  
WAITING CLIENTS                                                                                                                                   
 CHUNK READ HEADER...                                                                                                                             
 CHUNK HEADER=b'1f9' (505)                                                                                                                        
 CHUNK DATA (LEN)=507                                                                                                                             
 CHUNK READ HEADER...                                                                                                                             
 CHUNK HEADER=b'000000' (0)                                                                                                                       
 LAST CHUNK                                                                                                                                       
 CHUNKED BODY=b'000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
00000000000000000000000000000000000000000000000000000000000000000000000000000000**\x00Su\xb0\x00\x00\x02\x00**000000000000000000000000000000000000000\
00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'                                         
SERVER SHUTDOWN 11                                                                                                                                
2020-10-07 11:18:47.752470 TestServer :9090 shutting down                                                                                         
CLIENT POST SHUTDOWN...                                                                                                                           
2020-10-07 11:18:47.772930 TestServer :9090 closed
<snip>

The test sends an http message with a chunked body encoding.  Each chunk is 505 bytes long and is patterned with '0' for the first chunk, '1' for the second, ...  up to '9' then the last chunk is filled with 'a'. 

In the above console output you can see that some extra data appears in the chunk (highlighted).

The router will record the contents of raw buffers that have been passed to the raw connection, before and after the buffers are written.  See the file 

./system_test.dir/system_tests_http1_adaptor/Http1AdaptorEdge2EdgeTest/setUpClass/EA2-3.out

And look for statements like this:

[C1] **Raw Write**: Ptr=0x15dc8a0 len=128                                                                                                             
  value='1f9^M                                                                                                                                    
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'                      
                                                                                                                                                  
[C1] Raw Write: Ptr=0x17b9fe0 len=512                                                                                                             
  value='0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'                                                  
                                                                                                                                                  
[C1] Raw Write: Ptr=0x17ba0cf len=273                                                                                                             
  value='0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
000000000000000^M                                                                                                                                 
1f9^M 

<snip>
[C1] **Raw Written**: Ptr=0x15dc8a0 len=128                                                                                                           
  value='1f9^M                                                                                                                                    
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'                      
                                                                                                                                                  
[C1] Raw Written: Ptr=0x17b9fe0 len=512                                                                                                           
  value='0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'                                                  
                                                                                                                                                  
[C1] Raw Written: Ptr=0x17ba0cf len=273                                                                                                           
  value='0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
000000000000000^M                                                                                                                                 
1f9^M   

use tcpdump/wireshark to capture messages sent to port 8080 (client->router) and port 9090 (router->server) to see what is appearing on the wire 