### PR TITLE
DISPATCH-1803: prevent body_data sections from violating Q2 limit

### DIFF
--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -378,6 +378,20 @@ typedef enum {
 qd_message_body_data_result_t qd_message_next_body_data(qd_message_t *msg, qd_message_body_data_t **body_data);
 
 
+/**
+ * qd_message_body_data_append
+ *
+ * Append the buffers in data as a sequence of one or more BODY_DATA sections
+ * to the given message.  The buffers in data are moved into the message
+ * content by this function.
+ *
+ * @param msg Pointer to message under construction
+ * @param data List of buffers containing body data.
+ * @return The number of buffers stored in the message's content
+ */
+int qd_message_body_data_append(qd_message_t *msg, qd_buffer_list_t *data);
+
+
 /** Put string representation of a message suitable for logging in buffer.
  * @return buffer
  */

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -772,17 +772,7 @@ static int _client_rx_body_cb(h1_codec_request_state_t *hrs, qd_buffer_list_t *b
            "[C%"PRIu64"][L%"PRIu64"] HTTP request body received len=%zu.",
            hconn->conn_id, hconn->in_link_id, len);
 
-    //
-    // Compose a DATA performative for this section of the stream
-    //
-    qd_composed_field_t *field = qd_compose(QD_PERFORMATIVE_BODY_DATA, 0);
-    qd_compose_insert_binary_buffers(field, body);
-
-    //
-    // Extend the streaming message and free the composed field
-    //
-    qd_message_extend(msg, field);
-    qd_compose_free(field);
+    qd_message_body_data_append(msg, body);
 
     //
     // Notify the router that more data is ready to be pushed out on the delivery

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -877,17 +877,7 @@ static int _server_rx_body_cb(h1_codec_request_state_t *hrs, qd_buffer_list_t *b
            "[C%"PRIu64"][L%"PRIu64"] HTTP response body received len=%zu.",
            hconn->conn_id, hconn->in_link_id, len);
 
-    //
-    // Compose a DATA performative for this section of the stream
-    //
-    qd_composed_field_t *field = qd_compose(QD_PERFORMATIVE_BODY_DATA, 0);
-    qd_compose_insert_binary_buffers(field, body);
-
-    //
-    // Extend the streaming message and free the composed field
-    //
-    qd_message_extend(msg, field);
-    qd_compose_free(field);
+    qd_message_body_data_append(msg, body);
 
     //
     // Notify the router that more data is ready to be pushed out on the delivery

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -388,10 +388,7 @@ static int on_data_chunk_recv_callback(nghttp2_session *session,
     qd_buffer_list_append(&buffers, (uint8_t *)data, len);
 
     if (stream_data->in_dlv) {
-        qd_composed_field_t *body = qd_compose(QD_PERFORMATIVE_BODY_DATA, 0);
-        qd_compose_insert_binary_buffers(body, &buffers);
-        qd_message_extend(stream_data->message, body);
-        qd_compose_free(body);
+        qd_message_body_data_append(stream_data->message, &buffers);
     }
     else {
         if (!stream_data->body) {

--- a/src/adaptors/reference_adaptor.c
+++ b/src/adaptors/reference_adaptor.c
@@ -462,16 +462,10 @@ static void on_stream(void *context)
         qd_buffer_list_append(&buffer_list, (const uint8_t*) content, content_length);
 
         //
-        // Compose a DATA performative for this section of the stream
+        // append this data to the streaming message as one or more DATA
+        // performatives
         //
-        qd_composed_field_t *field = qd_compose(QD_PERFORMATIVE_BODY_DATA, 0);
-        qd_compose_insert_binary_buffers(field, &buffer_list);
-
-        //
-        // Extend the streaming message and free the composed field
-        //
-        depth = qd_message_extend(adaptor->streaming_message, field);
-        qd_compose_free(field);
+        depth = qd_message_body_data_append(adaptor->streaming_message, &buffer_list);
 
         //
         // Notify the router that more data is ready to be pushed out on the delivery

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -139,10 +139,7 @@ static int handle_incoming(qdr_tcp_connection_t *conn)
     grant_read_buffers(conn);
 
     if (conn->instream) {
-        qd_composed_field_t *field = qd_compose(QD_PERFORMATIVE_BODY_DATA, 0);
-        qd_compose_insert_binary_buffers(field, &buffers);
-        qd_message_extend(qdr_delivery_message(conn->instream), field);
-        qd_compose_free(field);
+        qd_message_body_data_append(qdr_delivery_message(conn->instream), &buffers);
         qdr_delivery_continue(tcp_adaptor->core, conn->instream, false);
         qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG, "[C%"PRIu64"][L%"PRIu64"] Continuing message with %i bytes", conn->conn_id, conn->incoming_id, count);
     } else {

--- a/tests/message_test.c
+++ b/tests/message_test.c
@@ -939,6 +939,98 @@ static char *test_check_body_data(void * context)
 }
 
 
+// Verify that qd_message_body_data_append() will break up a long binary data
+// field in order to avoid triggering Q2
+//
+static char *test_check_body_data_append(void * context)
+{
+    char *result = 0;
+
+    // generate a buffer list of binary data large enough to trigger Q2
+    //
+    const int buffer_count = (QD_QLIMIT_Q2_UPPER * 3) + 5;
+    qd_buffer_list_t bin_data = DEQ_EMPTY;
+    for (int i = 0; i < buffer_count; ++i) {
+        qd_buffer_t *buffy = qd_buffer();
+        // "fill" the buffer:
+        qd_buffer_insert(buffy, qd_buffer_capacity(buffy));
+        DEQ_INSERT_TAIL(bin_data, buffy);
+    }
+
+    // simulate building a message as an adaptor would:
+    qd_message_t *msg = qd_message();
+    qd_composed_field_t *field = qd_compose(QD_PERFORMATIVE_HEADER, 0);
+    qd_compose_start_list(field);
+    qd_compose_insert_bool(field, 0);     // durable
+    qd_compose_insert_null(field);        // priority
+    qd_compose_end_list(field);
+    field = qd_compose(QD_PERFORMATIVE_PROPERTIES, field);
+    qd_compose_start_list(field);
+    qd_compose_insert_ulong(field, 666);    // message-id
+    qd_compose_insert_null(field);                 // user-id
+    qd_compose_insert_string(field, "/whereevah"); // to
+    qd_compose_insert_string(field, "my-subject");  // subject
+    qd_compose_insert_string(field, "/reply-to");   // reply-to
+    qd_compose_end_list(field);
+
+    qd_message_compose_2(msg, field, false);
+    qd_compose_free(field);
+    qd_message_body_data_append(msg, &bin_data);
+    qd_message_set_receive_complete(msg);
+
+    // now validate the message body sections
+
+    qd_message_t *out_msg = qd_message_copy(msg);
+    if (qd_message_check_depth(out_msg, QD_DEPTH_BODY) != QD_MESSAGE_DEPTH_OK) {
+        result = "Invalid body depth check";
+        goto exit;
+    }
+
+    int bd_count = 0;
+    int total_buffers = 0;
+    qd_message_body_data_t *body_data = 0;
+    bool done = false;
+    while (!done) {
+        switch (qd_message_next_body_data(msg, &body_data)) {
+        case QD_MESSAGE_BODY_DATA_INCOMPLETE:
+        case QD_MESSAGE_BODY_DATA_INVALID:
+        case QD_MESSAGE_BODY_DATA_NOT_DATA:
+            result = "Next body data failed to get next body data";
+            goto exit;
+        case QD_MESSAGE_BODY_DATA_NO_MORE:
+            done = true;
+            break;
+        case QD_MESSAGE_BODY_DATA_OK:
+            bd_count += 1;
+            // qd_message_body_data_append() breaks the buffer list up into
+            // smaller lists that are no bigger than QD_QLIMIT_Q2_LOWER buffers
+            // long
+            total_buffers += qd_message_body_data_buffer_count(body_data);
+            if (qd_message_body_data_buffer_count(body_data) > QD_QLIMIT_Q2_LOWER) {
+                result = "Body data list length too long!";
+                goto exit;
+            }
+            qd_message_body_data_release(body_data);
+            break;
+        }
+    }
+
+    if (bd_count != (buffer_count / QD_QLIMIT_Q2_LOWER) + 1) {
+        result = "Unexpected count of body data sections!";
+        goto exit;
+    }
+
+    if (total_buffers != buffer_count) {
+        result = "Not all buffers were decoded!";
+    }
+
+exit:
+    qd_message_free(msg);
+    qd_message_free(out_msg);
+    return result;
+}
+
+
 int message_tests(void)
 {
     int result = 0;
@@ -953,6 +1045,7 @@ int message_tests(void)
     TEST_CASE(test_incomplete_annotations, 0);
     TEST_CASE(test_check_weird_messages, 0);
     TEST_CASE(test_check_body_data, 0);
+    TEST_CASE(test_check_body_data_append, 0);
 
     return result;
 }


### PR DESCRIPTION
This may be the wrong way to solve this - fixing it at the message construction phase rather than at message decode.

This patch adds a new body-data message API call:
void qd_message_body_data_append(qd_message_t *msg, qd_buffer_list_t *data);

A single call to this would replace this logic in the adaptors:

-    //                                                                                                                                           
-    // Compose a DATA performative for this section of the stream                                                                                
-    //                                                                                                                                           
-    qd_composed_field_t *field = qd_compose(QD_PERFORMATIVE_BODY_DATA, 0);                                                                       
-    qd_compose_insert_binary_buffers(field, body);                                                                                               
-                                                                                                                                                 
-    //                                                                                                                                           
-    // Extend the streaming message and free the composed field                                                                                  
-    //                                                                                                                                           
-    qd_message_extend(msg, field);                                                                                                               
-    qd_compose_free(field);                                                                                                                      
