### PR TITLE
DISPATCH-1751: Rework how AMQP session incoming-window is derived

### DIFF
--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -438,25 +438,35 @@ static qd_error_t load_server_config(qd_dispatch_t *qd, qd_server_config_t *conf
         config->max_frame_size = QD_AMQP_MIN_MAX_FRAME_SIZE;
 
     //
-    // Given session frame count and max frame size compute session incoming_capacity
+    // Given session frame count and max frame size, compute session incoming_capacity
+    //   On 64-bit systems the capacity has no practial limit.
+    //   On 32-bit systems the largest default capacity is half the process address space.
     //
-    if (ssn_frames == 0)
-        config->incoming_capacity = (sizeof(size_t) < 8) ? 0x7FFFFFFFLL : 0x7FFFFFFFLL * config->max_frame_size;
-    else {
-        uint64_t mfs      = (uint64_t) config->max_frame_size;
-        uint64_t trial_ic = ssn_frames * mfs;
-        uint64_t limit    = (sizeof(size_t) < 8) ? (1ll << 31) - 1 : 0;
-        if (limit == 0 || trial_ic < limit) {
-            // Silently promote incoming capacity of zero to one
-            config->incoming_capacity = 
-                (trial_ic < QD_AMQP_MIN_MAX_FRAME_SIZE ? QD_AMQP_MIN_MAX_FRAME_SIZE : trial_ic);
+    bool is_64bit = sizeof(size_t) == 8;
+#define MAX_32BIT_CAPACITY ((size_t)(2147483647))
+    if (ssn_frames == 0) {
+        config->incoming_capacity = is_64bit ? MAX_32BIT_CAPACITY * (size_t)config->max_frame_size : MAX_32BIT_CAPACITY;
+    } else {
+        // Limited incoming frames.
+        if (is_64bit) {
+            // Specify this to proton by setting capacity to be
+            // the product (max_frame_size * ssn_frames).
+            config->incoming_capacity = (size_t)config->max_frame_size * (size_t)ssn_frames;
         } else {
-            config->incoming_capacity = limit;
-            uint64_t computed_ssn_frames = limit / mfs;
-            qd_log(qd->connection_manager->log_source, QD_LOG_WARNING,
-                   "Server configuation for I/O adapter entity name:'%s', host:'%s', port:'%s', "
-                   "requested maxSessionFrames truncated from %"PRId64" to %"PRId64,
-                   config->name, config->host, config->port, ssn_frames, computed_ssn_frames);
+            // 32-bit systems have an upper bound to the capacity
+            uint64_t max_32bit_capacity = (uint64_t)MAX_32BIT_CAPACITY;
+            uint64_t capacity     = (uint64_t)config->max_frame_size * (uint64_t)ssn_frames;
+            if (capacity <= max_32bit_capacity) {
+                config->incoming_capacity = (size_t)capacity;
+            } else {
+                config->incoming_capacity = MAX_32BIT_CAPACITY;
+                uint64_t actual_frames = max_32bit_capacity / (uint64_t)config->max_frame_size;
+
+                qd_log(qd->connection_manager->log_source, QD_LOG_WARNING,
+                    "Server configuation for I/O adapter entity name:'%s', host:'%s', port:'%s', "
+                    "requested maxSessionFrames truncated from %"PRId64" to %"PRId64,
+                    config->name, config->host, config->port, ssn_frames, actual_frames);
+            }
         }
     }
 

--- a/tests/system_tests_protocol_settings.py
+++ b/tests/system_tests_protocol_settings.py
@@ -26,6 +26,7 @@ from system_test import TestCase, Qdrouterd, main_module
 from system_test import unittest
 from proton.utils import BlockingConnection
 import subprocess
+import sys
 
 class MaxFrameMaxSessionFramesTest(TestCase):
     """System tests setting proton negotiated size max-frame-size and incoming-window"""
@@ -234,8 +235,13 @@ class MaxSessionFramesDefaultTest(TestCase):
             # if frame size not set then a default is used
             self.assertTrue(" max-frame-size=16384" in open_lines[0])
             begin_lines = [s for s in log_lines if "-> @begin" in s]
-            # incoming-window is defaulted to 2^31-1 (Proton default)
-            self.assertTrue(" incoming-window=2147483647," in begin_lines[0])
+            # incoming-window should be 2^31-1 (64-bit) or
+            # (2^31-1) / max-frame-size (32-bit)
+            is_64bits = sys.maxsize > 2 ** 32
+            expected = " incoming-window=2147483647," if is_64bits else \
+                (" incoming-window=%d," % int(2147483647 / 16384))
+            self.assertTrue(expected in begin_lines[0],
+                            "Expected:'%s' not found in '%s'" % (expected, begin_lines[0]))
 
 
 class MaxFrameMaxSessionFramesZeroTest(TestCase):
@@ -270,8 +276,13 @@ class MaxFrameMaxSessionFramesZeroTest(TestCase):
             # max-frame gets set to protocol min
             self.assertTrue(' max-frame-size=512,' in open_lines[0])
             begin_lines = [s for s in log_lines if "-> @begin" in s]
-            # incoming-window is defaulted to 2^31-1 (Proton default)
-            self.assertTrue(" incoming-window=2147483647," in begin_lines[0])
+            # incoming-window should be 2^31-1 (64-bit) or
+            # (2^31-1) / max-frame-size (32-bit)
+            is_64bits = sys.maxsize > 2 ** 32
+            expected = " incoming-window=2147483647," if is_64bits else \
+                (" incoming-window=%d," % int(2147483647 / 512))
+            self.assertTrue(expected in begin_lines[0],
+                            "Expected:'%s' not found in '%s'" % (expected, begin_lines[0]))
 
 
 class ConnectorSettingsDefaultTest(TestCase):
@@ -323,8 +334,13 @@ class ConnectorSettingsDefaultTest(TestCase):
             self.assertTrue(' max-frame-size=16384,' in open_lines[0])
             self.assertTrue(' channel-max=32767,' in open_lines[0])
             begin_lines = [s for s in log_lines if "<- @begin" in s]
-            # defaults
-            self.assertTrue(" incoming-window=2147483647," in begin_lines[0])
+            # incoming-window should be 2^31-1 (64-bit) or
+            # (2^31-1) / max-frame-size (32-bit)
+            is_64bits = sys.maxsize > 2 ** 32
+            expected = " incoming-window=2147483647," if is_64bits else \
+                (" incoming-window=%d," % int(2147483647 / 16384))
+            self.assertTrue(expected in begin_lines[0],
+                            "Expected:'%s' not found in '%s'" % (expected, begin_lines[0]))
 
 
 class ConnectorSettingsNondefaultTest(TestCase):


### PR DESCRIPTION
Proton allows specification of a session 'capacity'. Initially the
incoming-window will be (capacity / max-frame-size), defining at most
how many max-size transfers will definitely be accepted on the session.

Dispatch listener config defines a maxFrameSize and a maxSessionFrames
the product of which is equal to the capacity to be configured in Proton.

Dispatch vhostUserGroup policy defines a maxFrameSize and a
maxSessionWindow. The maxSessionWindow is passed directly to Proton
as the capacity.

The interface to Proton defines capacity with type 'size_t'. It is possible
to have a (maxFrameSize * maxSessionFrames) product be larger than
that allowed by a size_t on a 32-bit system. Perform the capacity
calculations using 64-bit integers before applying the results and
sending them to Proton.