### PR TITLE
DISPATCH-1816: prevent activation from running after reconnecting

### DIFF
--- a/src/adaptors/http1/http1_private.h
+++ b/src/adaptors/http1/http1_private.h
@@ -247,7 +247,9 @@ void qdr_http1_client_core_delivery_update(qdr_http1_adaptor_t      *adaptor,
                                            uint64_t                  disp,
                                            bool                      settled);
 void qdr_http1_client_conn_cleanup(qdr_http1_connection_t *hconn);
-
+void qdr_http1_client_core_conn_close(qdr_http1_adaptor_t *adaptor,
+                                      qdr_http1_connection_t *hconn,
+                                      const char *error);
 // http1_server.c protocol adaptor callbacks
 //
 void qdr_http1_server_core_link_flow(qdr_http1_adaptor_t    *adaptor,
@@ -266,6 +268,9 @@ void qdr_http1_server_core_delivery_update(qdr_http1_adaptor_t      *adaptor,
                                            uint64_t                  disp,
                                            bool                      settled);
 void qdr_http1_server_conn_cleanup(qdr_http1_connection_t *hconn);
+void qdr_http1_server_core_conn_close(qdr_http1_adaptor_t *adaptor,
+                                      qdr_http1_connection_t *hconn,
+                                      const char *error);
 
 // recording of stats:
 void qdr_http1_record_client_request_info(qdr_http1_adaptor_t *adaptor, qdr_http1_request_base_t *request);

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -101,6 +101,9 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
 
 void qdr_core_free(qdr_core_t *core)
 {
+    // have adaptors clean up all core resources
+    qdr_adaptors_finalize(core);
+
     //
     // Stop and join the thread
     //
@@ -221,7 +224,6 @@ void qdr_core_free(qdr_core_t *core)
     // at this point all the conn identifiers have been freed
     qd_hash_free(core->conn_id_hash);
 
-    qdr_adaptors_finalize(core);
     qdr_modules_finalize(core);
 
     qdr_agent_free(core->mgmt_agent);


### PR DESCRIPTION
DISPATCH-1791: avoid leaking qdr_delivery_t

Move the adaptor finalize prior to stopping the core thread.  This
allows the core thread to release qdr_delivery_t that were decref'ed
during the adaptor finalize code.