### PR TITLE
DISPATCH-1842: Handle managament deletes of httpConnector by deleting…

### DIFF
--- a/include/qpid/dispatch/protocol_adaptor.h
+++ b/include/qpid/dispatch/protocol_adaptor.h
@@ -387,6 +387,19 @@ qdr_connection_t *qdr_connection_opened(qdr_core_t                    *core,
  */
 void qdr_connection_closed(qdr_connection_t *conn);
 
+/**
+ * qdr_core_close_connection
+ *
+ * This function is called when a connection is closed, usually by a management request.
+ * Initiates a core thread action that quite simply sets the closed flag on the passed in connection object
+ * and activates the connection. The qdr_connection_process() further processes this connection and calls
+ * back the appropriate protocol adaptor's conn_close_handler, where the io thread can further perform
+ * any appropriate cleanup.
+ *
+ * @param qdr_connection_t *conn - the connection that needs to be closed. The pointer returned by qdr_connection_opened
+ */
+void qdr_core_close_connection(qdr_connection_t *conn);
+
 bool qdr_connection_route_container(qdr_connection_t *conn);
 
 /**

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -296,6 +296,12 @@ static void free_http2_stream_data(qdr_http2_stream_data_t *stream_data, bool on
     if (stream_data->remote_site) free(stream_data->remote_site);
 
     qd_log(http2_adaptor->log_source, QD_LOG_TRACE, "[C%"PRIu64"][S%"PRId32"] Freeing stream_data in free_http2_stream_data (%lx)", conn->conn_id,  stream_data->stream_id, (long) stream_data);
+
+    // If the httpConnector was deleted, a client request has nowhere to go because of lack of receiver and hence credit.
+    // No delivery was created. The message that was created for such a hanging request must be freed here..
+    if (!stream_data->in_dlv && stream_data->message) {
+        qd_message_free(stream_data->message);
+    }
     free_qdr_http2_stream_data_t(stream_data);
 }
 

--- a/src/adaptors/http2/http2_adaptor.h
+++ b/src/adaptors/http2/http2_adaptor.h
@@ -142,6 +142,7 @@ struct qdr_http2_connection_t {
     bool                      client_magic_sent;
     bool                      woken_by_ping;
     bool                      first_pinged;
+    bool                      delete_egress_connections;  // If set to true, the egress qdr_connection_t and qdr_http2_connection_t objects will be deleted
 
     DEQ_LINKS(qdr_http2_connection_t);
  };

--- a/src/adaptors/http_common.h
+++ b/src/adaptors/http_common.h
@@ -67,8 +67,7 @@ struct qd_http_connector_t {
     qd_server_t                  *server;
     qd_timer_t                   *timer;
     long                          delay;
-    struct qdr_http_connection_t *dispatcher;
-
+    void                         *ctx;
     DEQ_LINKS(qd_http_connector_t);
 };
 DEQ_DECLARE(qd_http_connector_t, qd_http_connector_list_t);

--- a/src/router_core/agent_connection.c
+++ b/src/router_core/agent_connection.c
@@ -514,14 +514,8 @@ static void qdra_connection_update_set_status(qdr_core_t *core, qdr_query_t *que
             // This connection has been force-closed.
             // Inter-router and edge connections may not be force-closed
             if (conn->role != QDR_ROLE_INTER_ROUTER && conn->role != QDR_ROLE_EDGE_CONNECTION) {
-                conn->closed = true;
-                conn->error  = qdr_error(QD_AMQP_COND_CONNECTION_FORCED, "Connection forced-closed by management request");
-                conn->admin_status = QDR_CONN_ADMIN_DELETED;
-
+                qdr_close_connection_CT(core, conn);
                 qd_log(core->log, QD_LOG_INFO, "[C%"PRIu64"] Connection force-closed by request from connection [C%"PRIu64"]", conn->identity, query->in_conn);
-
-                //Activate the connection, so the I/O threads can finish the job.
-                qdr_connection_activate_CT(core, conn);
                 query->status = QD_AMQP_OK;
                 qdr_manage_write_connection_map_CT(core, conn, query->body, qdr_connection_columns);
             }

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -975,6 +975,7 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *pe
 void qdr_forward_deliver_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery_t *dlv);
 void qdr_connection_free(qdr_connection_t *conn);
 void qdr_connection_activate_CT(qdr_core_t *core, qdr_connection_t *conn);
+void qdr_close_connection_CT(qdr_core_t *core, qdr_connection_t *conn);
 qdr_link_t *qdr_connection_new_streaming_link_CT(qdr_core_t *core, qdr_connection_t *conn);
 qdr_address_config_t *qdr_config_for_address_CT(qdr_core_t *core, qdr_connection_t *conn, qd_iterator_t *iter);
 qd_address_treatment_t qdr_treatment_for_address_hash_CT(qdr_core_t *core, qd_iterator_t *iter, qdr_address_config_t **addr_config);


### PR DESCRIPTION
… connection objects associated with the connector. This prevents the router crash from happening