### PR TITLE
DISPATCH-1849: Don't dereference a peer delivery that has already bee…

### DIFF
--- a/src/adaptors/http2/http2_adaptor.h
+++ b/src/adaptors/http2/http2_adaptor.h
@@ -104,6 +104,7 @@ struct qdr_http2_stream_data_t {
     bool                     out_msg_send_complete; // we use this flag to save the send_complete flag because the delivery and message associated with this stream might have been freed.
     bool                     disp_updated;   // Has the disposition already been set on the out_dlv
     bool                     disp_applied;   // Has the disp been applied to the out_dlv. The stream is ready to be freed now.
+    bool                     in_dlv_released;
 
     //for stats:
     char                    *method;


### PR DESCRIPTION
…n released. Check the in_dlv_released flag before dereferencing the in_dlv