### PR TITLE
DISPATCH-1846: TCP adaptor: fix test stall

### DIFF
--- a/tests/TCP_echo_client.py
+++ b/tests/TCP_echo_client.py
@@ -147,7 +147,6 @@ class TcpEchoClient:
                          selectors.EVENT_READ | selectors.EVENT_WRITE)
 
             # event loop
-            time.sleep(0.1)  # DISPATCH-1820 investigation
             while self.keep_running:
                 if self.timeout > 0.0:
                     elapsed = time.time() - start_time


### PR DESCRIPTION
* Wait until all echo server addresses are known to interior routers.
* Add 'ES_' prefix to server addresses. Having the mobile address
  the same as the router name worked but was confusing when viewed
  by qdstat.
* Turn off echo server logging.