### PR TITLE
NO-JIRA Use checked allocation API from DISPATCH-1685

### DIFF
--- a/include/qpid/dispatch/ctools.h
+++ b/include/qpid/dispatch/ctools.h
@@ -31,9 +31,9 @@
 
 #define CT_ASSERT(exp) { assert(exp); }
 
-#define NEW(t)             (t*)  malloc(sizeof(t))
-#define NEW_ARRAY(t,n)     (t*)  malloc(sizeof(t)*(n))
-#define NEW_PTR_ARRAY(t,n) (t**) malloc(sizeof(t*)*(n))
+#define NEW(t)             (t*)  qd_malloc(sizeof(t))
+#define NEW_ARRAY(t,n)     (t*)  qd_malloc(sizeof(t)*(n))
+#define NEW_PTR_ARRAY(t,n) (t**) qd_malloc(sizeof(t*)*(n))
 
 //
 // If available, use aligned_alloc for cache-line-aligned allocations.  Otherwise

--- a/src/remote_sasl.c
+++ b/src/remote_sasl.c
@@ -68,7 +68,7 @@ typedef struct {
 
 static void allocate_buffer(buffer_t* buffer)
 {
-    buffer->start = malloc(buffer->capacity);
+    buffer->start = qd_malloc(buffer->capacity);
     memset(buffer->start, 0, buffer->capacity);
 }
 

--- a/src/router_core/modules/address_lookup_client/lookup_client.c
+++ b/src/router_core/modules/address_lookup_client/lookup_client.c
@@ -71,7 +71,7 @@ static char* disambiguated_link_name(qdr_connection_info_t *conn, char *original
 {
     size_t olen = strlen(original);
     size_t clen = strlen(conn->container);
-    char *name = (char*) malloc(olen + clen + 2);
+    char *name = (char*) qd_malloc(olen + clen + 2);
     memset(name, 0, olen + clen + 2);
     strcat(name, original);
     name[olen] = '@';

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1459,7 +1459,7 @@ qd_router_t *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *are
     }
 
     size_t dplen = 9 + strlen(area) + strlen(id);
-    node_id = (char*) malloc(dplen);
+    node_id = (char*) qd_malloc(dplen);
     strcpy(node_id, area);
     strcat(node_id, "/");
     strcat(node_id, id);

--- a/src/server.c
+++ b/src/server.c
@@ -1477,7 +1477,7 @@ void qd_server_run(qd_dispatch_t *qd)
     qd_log(qd_server->log_source, QD_LOG_INFO, "Running in DEBUG Mode");
 #endif
     int n = qd_server->thread_count - 1; /* Start count-1 threads + use current thread */
-    sys_thread_t **threads = (sys_thread_t **)calloc(n, sizeof(sys_thread_t*));
+    sys_thread_t **threads = (sys_thread_t **)qd_calloc(n, sizeof(sys_thread_t*));
     for (i = 0; i < n; i++) {
         threads[i] = sys_thread(thread_run, qd_server);
     }


### PR DESCRIPTION
These are in response to fb-infer warnings of the following kind

```
/qpid-dispatch/src/router_core/core_events.c:46: error: Null Dereference
  pointer `sub` last assigned on line 45 could be null and is dereferenced by call to `memset()` at line 46, column 5.
  44. {
  45.     qdrc_event_subscription_t *sub = NEW(qdrc_event_subscription_t);
  46.     ZERO(sub);
          ^
  47.
  48.     sub->context         = context;
```

```
/qpid-dispatch/src/remote_sasl.c:72: error: Null Dereference
  pointer `buffer->start` last assigned on line 71 could be null and is dereferenced by call to `memset()` at line 72, column 5.
  70. {
  71.     buffer->start = malloc(buffer->capacity);
  72.     memset(buffer->start, 0, buffer->capacity);
          ^
  73. }
  74.
```