### PR TITLE
DISPATCH-1885 Preserve test docstring in @SkipIfNeeded decorator

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import errno, os, time, socket, random, subprocess, shutil, unittest, __main__, re, sys
+import functools
 from datetime import datetime
 from subprocess import PIPE, STDOUT
 from copy import copy
@@ -911,6 +912,7 @@ class SkipIfNeeded(object):
 
     def __call__(self, f):
 
+        @functools.wraps(f)
         def wrap(*args, **kwargs):
             """
             Wraps original test method's invocation and dictates whether or


### PR DESCRIPTION
`functools.wraps` is available in Python 2.6, I checked.

The tests mentioned in issue description do not have docstring on their own, so the docstring line is now omitted:

```
{noformat}
test 43
      Start 43: system_tests_authz_service_plugin

43: Test command: /usr/bin/bwrap "--bind" "/" "/" "--bind" "/dev/zero" "/etc/nsswitch.conf" "--unshare-net" "--dev" "/dev" "--die-with-parent" "--" "/opt/hostedtoolcache/Python/3.7.9/x64/bin/python" "/home/runner/work/qpid-dispatch/qpid-dispatch/qpid-dispatch/build/tests/run.py" "-m" "unittest" "-v" "system_tests_authz_service_plugin"
43: Test timeout computed to be: 600
43: test_authorized (system_tests_authz_service_plugin.AuthServicePluginAuthzDeprecatedTest) ... ok
43: test_dynamic_source_anonymous_sender (system_tests_authz_service_plugin.AuthServicePluginAuthzDeprecatedTest) ... ok
43: test_unauthorized (system_tests_authz_service_plugin.AuthServicePluginAuthzDeprecatedTest) ... ok
43: test_unauthorized_anonymous_sender_target (system_tests_authz_service_plugin.AuthServicePluginAuthzDeprecatedTest) ... ok
43: test_wildcard (system_tests_authz_service_plugin.AuthServicePluginAuthzDeprecatedTest) ... ok
43: test_authorized (system_tests_authz_service_plugin.AuthServicePluginAuthzTest) ... ok
{noformat}
```

Here it's working for tests that do have their own docstrings

```
{noformat}
 test 42
      Start 42: system_tests_auth_service_plugin

42: Test command: /usr/bin/bwrap "--bind" "/" "/" "--bind" "/dev/zero" "/etc/nsswitch.conf" "--unshare-net" "--dev" "/dev" "--die-with-parent" "--" "/opt/hostedtoolcache/Python/3.7.9/x64/bin/python" "/home/runner/work/qpid-dispatch/qpid-dispatch/qpid-dispatch/build/tests/run.py" "-m" "unittest" "-v" "system_tests_auth_service_plugin"
42: Test timeout computed to be: 600
42: test_invalid_credentials (system_tests_auth_service_plugin.AuthServicePluginDeprecatedTest)
42: Check authentication fails when invalid credentials are presented. ... ok
42: test_valid_credentials (system_tests_auth_service_plugin.AuthServicePluginDeprecatedTest)
42: Check authentication succeeds when valid credentials are presented. ... ok
42: test_invalid_credentials (system_tests_auth_service_plugin.AuthServicePluginTest)
42: Check authentication fails when invalid credentials are presented. ... ok
42: test_valid_credentials (system_tests_auth_service_plugin.AuthServicePluginTest)
42: Check authentication succeeds when valid credentials are presented. ... ok
42: 
42: ----------------------------------------------------------------------
42: Ran 4 tests in 1.359s
42: 
42: OK
{noformat}
```