### PR TITLE
DISPATCH-1854: Add delivery id to be printed in log prefix

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -61,6 +61,8 @@ const char     *MULTICAST_DISTRIBUTION = "multicast";
 const char     *BALANCED_DISTRIBUTION  = "balanced";
 const char     *UNAVAILABLE_DISTRIBUTION = "unavailable";
 
+sys_atomic_t global_delivery_id;
+
 qd_dispatch_t *qd = 0;
 
 qd_dispatch_t *qd_dispatch_get_dispatch()

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -587,6 +587,7 @@ qdr_link_t *qdr_link_first_attach(qdr_connection_t *conn,
     link->identity = qdr_identifier(conn->core);
     *link_id = link->identity;
     link->conn = conn;
+    link->conn_id = conn->identity;
     link->name = (char*) malloc(strlen(name) + 1);
 
     if (terminus_addr) {
@@ -1100,6 +1101,7 @@ qdr_link_t *qdr_create_link_CT(qdr_core_t        *core,
     link->identity       = qdr_identifier(core);
     link->user_context   = 0;
     link->conn           = conn;
+    link->conn_id        = conn->identity;
     link->link_type      = link_type;
     link->link_direction = dir;
     link->capacity       = conn->link_capacity;

--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -21,6 +21,7 @@
 #include "qpid/dispatch/alloc.h"
 #include "delivery.h"
 #include <stdio.h>
+#include <inttypes.h>
 
 struct qdrc_endpoint_t {
     qdrc_endpoint_desc_t *desc;
@@ -143,6 +144,10 @@ qdr_delivery_t *qdrc_endpoint_delivery_CT(qdr_core_t *core, qdrc_endpoint_t *end
     *tag                = core->next_tag++;
     dlv->tag_length = 8;
     dlv->ingress_index = -1;
+    dlv->delivery_id = next_delivery_id();
+    dlv->link_id     = endpoint->link->identity;
+    dlv->conn_id     = endpoint->link->conn_id;
+    qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdrc_endpoint_delivery_CT", DLV_ARGS(dlv));
     return dlv;
 }
 

--- a/src/router_core/delivery.h
+++ b/src/router_core/delivery.h
@@ -62,6 +62,9 @@ struct qdr_delivery_t {
     qdr_link_work_t        *link_work;         ///< Delivery work item for this delivery
     qdr_subscription_ref_list_t subscriptions;
     qdr_delivery_ref_list_t peers;             /// Use this list if there if the delivery has more than one peer.
+    uint32_t                delivery_id;       /// id for logging
+    uint64_t                link_id;           /// id for logging
+    uint64_t                conn_id;           /// id for logging
     bool                    multicast;         /// True if this delivery is targeted for a multicast address.
     bool                    via_edge;          /// True if this delivery arrived via an edge-connection.
     bool                    stuck;             /// True if this delivery was counted as stuck.
@@ -69,6 +72,14 @@ struct qdr_delivery_t {
 
 ALLOC_DECLARE(qdr_delivery_t);
 
+/** Delivery Id for logging - thread safe
+ */
+extern sys_atomic_t global_delivery_id;
+static inline uint32_t next_delivery_id() { return sys_atomic_inc(&global_delivery_id); }
+
+// Common log line prefix
+#define DLV_FMT       "[C%"PRIu64"][L%"PRIu64"][D%"PRIu32"]"
+#define DLV_ARGS(dlv) dlv->conn_id, dlv->link_id, dlv->delivery_id
 
 ///////////////////////////////////////////////////////////////////////////////
 //                               Delivery API

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -153,6 +153,10 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *in
     ZERO(out_dlv);
     set_safe_ptr_qdr_link_t(out_link, &out_dlv->link_sp);
     out_dlv->msg        = qd_message_copy(msg);
+    out_dlv->delivery_id = next_delivery_id();
+    out_dlv->link_id     = out_link->identity;
+    out_dlv->conn_id     = out_link->conn_id;
+    qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_forward_new_delivery_CT", DLV_ARGS(out_dlv));
 
     if (in_dlv) {
         out_dlv->settled       = in_dlv->settled;
@@ -963,6 +967,7 @@ void qdr_forward_link_direct_CT(qdr_core_t       *core,
     out_link->core           = core;
     out_link->identity       = qdr_identifier(core);
     out_link->conn           = conn;
+    out_link->conn_id        = conn->identity;
     out_link->link_type      = QD_LINK_ENDPOINT;
     out_link->link_direction = qdr_link_direction(in_link) == QD_OUTGOING ? QD_INCOMING : QD_OUTGOING;
     out_link->admin_enabled  = true;

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -484,6 +484,7 @@ struct qdr_link_t {
     uint8_t   priority;
     uint8_t   rate_cursor;
     uint32_t  core_ticks;
+    uint64_t  conn_id;
 
     DEQ_LINKS_N(STREAMING_POOL, qdr_link_t);
 };

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1485,6 +1485,8 @@ qd_router_t *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *are
     router->lock  = sys_mutex();
     router->timer = qd_timer(qd, qd_router_timer_handler, (void*) router);
 
+    sys_atomic_init(&global_delivery_id, 1);
+
     //
     // Inform the field iterator module of this router's mode, id, and area.  The field iterator
     // uses this to offload some of the address-processing load from the router.


### PR DESCRIPTION
Delivery Id is similar to connection id and link id. It will be printed
with log statements as a common prefix allowing for easier delivery
tracking.

Implementation notes:

1. Connection/Link/Delivery Id caching

This patch saves the connection id in links and the connection and link
ids in the delivery. The these copies are made once at object creation
and used as necessary. The cached copies eliminate hunting for the
values at log-statement time.

The caching is slightly complicated by initial delivery handoff in
the adaptors. That handoff is logged as the delivery's connection and
link ids are rewritten. For instance:

    TCP_ADAPTOR (debug) [C1][L1][D121] initial_delivery ownership passed to [C22][L68][D121]

Here a TCP_ADAPTOR egress dispatcher on [C1][L1] is passing delivery [D121]
to tcp [C22][L68].

The cache strategy may print connection and link ids after the connection
or link has disappeared. That's usually not a problem and the strategy
eliminates the defensive code required to test if the connection or link
still exists.

2. Delivery ids replace printing the address of the delivery

Delivery addresses get reused a lot and grepping for them is hard.

3. Common macros to print the connection, link, and delivery ids from a delivery

    DLV_FMT  - the format string defining conn-link-delivery log prefix
    DLV_ARGS - accessor to get log prefix values from delivery

    DLV_FMT is a quoted string similar to PRIu64 and PRIu32 and as such
    must be used outside of quotation marks in the source.

    DLV_ARGS(dlv) takes an argument which is a pointer to a
    qd_delivery_t object.

A typical usage changes code like this:

-    qd_log(core->log, QD_LOG_DEBUG, "Delivery decref_CT:  dlv:%lx rc:%"PRIu32" link:%"PRIu64" %s",
-          (long) dlv, ref_count - 1,  link_identity, label);
+    qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery decref_CT: rc:%"PRIu32" %s",
+           DLV_ARGS(dlv), ref_count - 1, label);