### PR TITLE
DISPATCH-1900 calling calloc with zero nmemb or zero size is permitted

### DIFF
--- a/include/qpid/dispatch/ctools.h
+++ b/include/qpid/dispatch/ctools.h
@@ -237,7 +237,7 @@ static inline void *qd_malloc(size_t size)
 static inline void *qd_calloc(size_t nmemb, size_t size)
 {
     void *ptr = calloc(nmemb, size);
-    if (!ptr) {
+    if (!ptr && nmemb && size) {
         perror("qd_calloc");
         abort();
     }

--- a/include/qpid/dispatch/ctools.h
+++ b/include/qpid/dispatch/ctools.h
@@ -236,7 +236,6 @@ static inline void *qd_malloc(size_t size)
 
 static inline void *qd_calloc(size_t nmemb, size_t size)
 {
-    assert(nmemb && size);
     void *ptr = calloc(nmemb, size);
     if (!ptr) {
         perror("qd_calloc");


### PR DESCRIPTION
Let's see what Travis thinks about this.