### PR TITLE
DISPATCH-1901: Allow any proton:io reason failing connection to bad host name

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,10 +67,7 @@ target_link_libraries(clogger ${Proton_LIBRARIES})
 # running tests in parallel (the ctest -j option) without port clashes
 set(USE_BWRAP OFF CACHE BOOL "Wrap test executions with bwrap (https://github.com/containers/bubblewrap)")
 if(USE_BWRAP)
-  # Inaccessible DNS servers produce "proton:io Temporary failure in name resolution".
-  # For system_tests_bad_configuration we need to get "proton:io Name or service not known",
-  # so blank /etc/nsswitch.conf to achieve that.
-  set(BWRAP_ARGS bwrap --bind / / --bind /dev/zero /etc/nsswitch.conf --unshare-net --dev /dev --die-with-parent --)
+  set(BWRAP_ARGS bwrap --bind / / --unshare-net --dev /dev --die-with-parent --)
 else()
   set(BWRAP_ARGS "")
 endif()

--- a/tests/system_tests_bad_configuration.py
+++ b/tests/system_tests_bad_configuration.py
@@ -112,12 +112,8 @@ class RouterTestBadConfiguration(TestCase):
         """
         with open('../setUpClass/test-router.log', 'r') as router_log:
             log_lines = router_log.read().split("\n")
-            expected_errors = [
-                "Connection to %s" % self.unresolvable_host_name
-            ]
-            errors_caught = [line for line in log_lines
-                             if any([expected_error in line for expected_error in expected_errors])
-                             and "failed" in line]
+            expected_log_snip = "Connection to %s" % self.unresolvable_host_name
+            errors_caught = [line for line in log_lines if expected_log_snip in line and "failed" in line]
 
             self.error_caught = any(errors_caught)
 

--- a/tests/system_tests_bad_configuration.py
+++ b/tests/system_tests_bad_configuration.py
@@ -51,12 +51,13 @@ class RouterTestBadConfiguration(TestCase):
         """
         super(RouterTestBadConfiguration, cls).setUpClass()
         cls.name = "test-router"
+        cls.unresolvable_host_name = 'unresolvable.host.name'
         cls.config = Qdrouterd.Config([
             ('router', {'mode': 'standalone', 'id': 'QDR.A'}),
             # Define a connector that uses an unresolvable hostname
             ('connector',
              {'name': 'UnresolvableConn',
-              'host': 'unresolvable.host.name',
+              'host': cls.unresolvable_host_name,
               'port': 'amqp'}),
             ('listener',
              {'port': cls.tester.get_port()}),
@@ -112,11 +113,11 @@ class RouterTestBadConfiguration(TestCase):
         with open('../setUpClass/test-router.log', 'r') as router_log:
             log_lines = router_log.read().split("\n")
             expected_errors = [
-                "proton:io Name or service not known",  # Linux
-                "proton:io unknown node or service",  # macOS
+                "Connection to %s" % self.unresolvable_host_name
             ]
             errors_caught = [line for line in log_lines
-                             if any([expected_error in line for expected_error in expected_errors])]
+                             if any([expected_error in line for expected_error in expected_errors])
+                             and "failed" in line]
 
             self.error_caught = any(errors_caught)
 


### PR DESCRIPTION
The system_tests_bad_configuration test sets up a connector to a
host that is never reachable. The test expects the connection to fail.

On Linux proton normally returns 'Name or service not known'. On macOS
there is some other specific reason.

Another class of errors shows up when DNS is unavailable. On Linux the
reason is 'Temporary failure in name resolution'.

This patch stops looking for specific text from the proton:io error
messages. The test declares success when a qpid-dispatch log message
indicates a connection failure to the host in question.