### PR TITLE
DISPATCH-1801: add qd_delivery_state_t for all disposition data

### DIFF
--- a/include/qpid/dispatch/delivery_state.h
+++ b/include/qpid/dispatch/delivery_state.h
@@ -1,0 +1,60 @@
+#ifndef __delivery_state_h__
+#define __delivery_state_h__ 1
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdbool.h>
+
+/**
+ * AMQP 1.0 defines a delivery-state type property.  Delivery-state is passed
+ * via the Disposition and transfer performatives and holds state data
+ * associated with the delivery.
+ *
+ * Different delivery-state data are provided with the Modified and Rejected
+ * terminal outcomes.
+ */
+
+typedef struct {
+
+    // REJECTED - see section 3.4.3
+    struct qdr_error_t *error;
+
+    // MODIFIED - see section 3.4.5
+    struct pn_data_t *annotations;
+    bool              delivery_failed;
+    bool              undeliverable_here;
+
+    // raw state data available for custom outcomes
+    // Example: DECLARED and Transactional state
+    struct pn_data_t *extension;
+
+} qd_delivery_state_t;
+
+// allocate
+qd_delivery_state_t *qd_delivery_state();
+
+// this constructor takes ownership of err. err will be freed by
+// qd_delivery_state_free()
+qd_delivery_state_t *qd_delivery_state_from_error(struct qdr_error_t *err);
+
+// dispose
+void qd_delivery_state_free(qd_delivery_state_t *ds);
+
+#endif
+

--- a/include/qpid/dispatch/protocol_adaptor.h
+++ b/include/qpid/dispatch/protocol_adaptor.h
@@ -21,6 +21,8 @@
 
 #include <qpid/dispatch/router_core.h>
 #include <qpid/dispatch/policy_spec.h>
+#include <qpid/dispatch/delivery_state.h>
+
 
 typedef struct qdr_protocol_adaptor_t  qdr_protocol_adaptor_t;
 typedef struct qdr_connection_t        qdr_connection_t;
@@ -846,16 +848,16 @@ void qdr_link_delete(qdr_link_t *link);
 qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterator_t *ingress,
                                  bool settled, qd_bitmask_t *link_exclusion, int ingress_index,
                                  uint64_t remote_disposition,
-                                 pn_data_t *remote_extension_state);
+                                 qd_delivery_state_t *remote_state);
 qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
                                     qd_iterator_t *ingress, qd_iterator_t *addr,
                                     bool settled, qd_bitmask_t *link_exclusion, int ingress_index,
                                     uint64_t remote_disposition,
-                                    pn_data_t *remote_extension_state);
+                                    qd_delivery_state_t *remote_state);
 qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *msg, bool settled,
                                                 const uint8_t *tag, int tag_length,
                                                 uint64_t remote_disposition,
-                                                pn_data_t *remote_extension_state);
+                                                qd_delivery_state_t *remote_state);
 
 /**
  * qdr_link_process_deliveries
@@ -909,14 +911,17 @@ void qdr_link_set_drained(qdr_core_t *core, qdr_link_t *link);
 
 
 /**
- * Write the disposition and state data that has arrived from the remote endpoint to the delivery
+ * Set the remote delivery state for dlv. Ownership of dstate is transferred to
+ * the dlv and true is returned. Caller must free dstate if false is returned.
  */
-void qdr_delivery_set_remote_extension_state(qdr_delivery_t *dlv, uint64_t remote_dispo, pn_data_t *remote_ext_state);
+bool qdr_delivery_set_remote_delivery_state(qdr_delivery_t *dlv, qd_delivery_state_t *dstate);
 
 /**
- * Extract the disposition and state data that is to be sent to the remote endpoint via the delivery
+ * Extract the disposition and delivery state data that is to be sent to the
+ * remote endpoint via the delivery. Caller takes ownership of the returned
+ * delivery_state and must free it when done.
  */
-pn_data_t *qdr_delivery_take_local_extension_state(qdr_delivery_t *dlv, uint64_t *dispo);
+qd_delivery_state_t *qdr_delivery_take_local_delivery_state(qdr_delivery_t *dlv, uint64_t *dispo);
 
 
 qdr_connection_info_t *qdr_connection_info(bool             is_encrypted,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set(qpid_dispatch_SOURCES
   compose.c
   connection_manager.c
   container.c
+  delivery_state.c
   discriminator.c
   dispatch.c
   entity.c

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -515,8 +515,7 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
                                                       rmsg->dlv,
                                                       rmsg->dispo,
                                                       true,   // settled,
-                                                      0,      // error
-                                                      0,      // dispo data
+                                                      0,      // delivery state
                                                       false);
                 }
                 qdr_link_flow(qdr_http1_adaptor->core, hconn->out_link, 1, false);
@@ -1557,8 +1556,7 @@ uint64_t qdr_http1_client_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
                                           rmsg->dlv,
                                           rmsg->dispo,
                                           true,   // settled,
-                                          0,      // error
-                                          0,      // dispo data
+                                          0,      // delivery state
                                           false);
         return PN_ACCEPTED;
     }

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -456,8 +456,7 @@ static void _accept_and_settle_request(_server_request_t *hreq)
                                       hreq->request_dlv,
                                       hreq->request_dispo,
                                       true,   // settled
-                                      0,      // error
-                                      0,      // dispo data
+                                      0,      // delivery state
                                       false);
     // can now release the delivery
     qdr_delivery_set_context(hreq->request_dlv, 0);
@@ -657,8 +656,7 @@ static bool _process_request(_server_request_t *hreq)
                                                   hreq->request_dlv,
                                                   hreq->request_dispo,
                                                   true,   // settled
-                                                  0,      // error
-                                                  0,      // dispo data
+                                                  0,      // delivery state
                                                   false);
                 hreq->request_acked = hreq->request_settled = true;
             }
@@ -718,8 +716,7 @@ static bool _process_request(_server_request_t *hreq)
                                               hreq->request_dlv,
                                               hreq->request_dispo,
                                               hreq->request_settled,
-                                              0,      // error
-                                              0,      // dispo data
+                                              0,      // delivery state
                                               false);
             hreq->request_acked = true;
             if (hreq->request_settled) {

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -933,7 +933,7 @@ static int on_frame_recv_callback(nghttp2_session *session,
 
         if (stream_data->out_dlv && !stream_data->disp_updated && !stream_data->out_dlv_decrefed && stream_data->status == QD_STREAM_FULLY_CLOSED ) {
             stream_data->disp_updated = true;
-            qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, 0, false);
+            qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, false);
             qd_log(http2_adaptor->log_source, QD_LOG_TRACE, "[C%"PRIu64"][S%"PRId32"] In on_frame_recv_callback NGHTTP2_DATA QD_STREAM_FULLY_CLOSED, qdr_delivery_remote_state_updated(stream_data->out_dlv)", conn->conn_id, stream_data->stream_id);
         }
     }
@@ -1000,7 +1000,7 @@ static int on_frame_recv_callback(nghttp2_session *session,
             }
 
             if (stream_data->out_dlv && !stream_data->disp_updated && !stream_data->out_dlv_decrefed && stream_data->status == QD_STREAM_FULLY_CLOSED) {
-                qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, 0, false);
+                qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, false);
                 qd_log(http2_adaptor->log_source, QD_LOG_TRACE, "[C%"PRIu64"][S%"PRId32"] In on_frame_recv_callback NGHTTP2_HEADERS QD_STREAM_FULLY_CLOSED, qdr_delivery_remote_state_updated(stream_data->out_dlv)", conn->conn_id, stream_data->stream_id);
                 stream_data->disp_updated = true;
             }
@@ -1783,7 +1783,7 @@ uint64_t handle_outgoing_http(qdr_http2_stream_data_t *stream_data)
         if (qd_message_send_complete(qdr_delivery_message(stream_data->out_dlv))) {
             advance_stream_status(stream_data);
             if (!stream_data->disp_updated && stream_data->status == QD_STREAM_FULLY_CLOSED) {
-                qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, 0, false);
+                qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, false);
                 qd_log(http2_adaptor->log_source, QD_LOG_TRACE, "[C%"PRIu64"][S%"PRId32"] In handle_outgoing_http, qdr_delivery_remote_state_updated(stream_data->out_dlv)", conn->conn_id, stream_data->stream_id);
                 stream_data->disp_updated = true;
                 qdr_delivery_decref(http2_adaptor->core, stream_data->out_dlv, "HTTP2 adaptor out_dlv - handle_outgoing_http");
@@ -2024,7 +2024,7 @@ static void restart_streams(qdr_http2_connection_t *http_conn)
 
             if (stream_data->out_dlv && !stream_data->disp_updated && !stream_data->out_dlv_decrefed && stream_data->status == QD_STREAM_FULLY_CLOSED ) {
                 // A call to qdr_delivery_remote_state_updated will free the out_dlv
-                qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, 0, false);
+                qdr_delivery_remote_state_updated(http2_adaptor->core, stream_data->out_dlv, stream_data->out_dlv_local_disposition, true, 0, false);
                 qd_log(http2_adaptor->log_source, QD_LOG_TRACE, "[C%"PRIu64"][S%"PRId32"] In restart_streams QD_STREAM_FULLY_CLOSED, qdr_delivery_remote_state_updated(stream_data->out_dlv)", http_conn->conn_id, stream_data->stream_id);
                 stream_data->disp_updated = true;
             }

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -270,7 +270,7 @@ static void handle_disconnected(qdr_tcp_connection_t* conn)
         qdr_connection_set_context(conn->qdr_conn, 0);
     }
     if (conn->initial_delivery) {
-        qdr_delivery_remote_state_updated(tcp_adaptor->core, conn->initial_delivery, PN_RELEASED, true, 0, 0, false);
+        qdr_delivery_remote_state_updated(tcp_adaptor->core, conn->initial_delivery, PN_RELEASED, true, 0, false);
         qdr_delivery_decref(tcp_adaptor->core, conn->initial_delivery, "tcp-adaptor.handle_disconnected - initial_delivery");
         conn->initial_delivery = 0;
     }

--- a/src/delivery_state.c
+++ b/src/delivery_state.c
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <qpid/dispatch/delivery_state.h>
+#include <qpid/dispatch/router_core.h>
+#include <qpid/dispatch/alloc_pool.h>
+
+
+ALLOC_DECLARE(qd_delivery_state_t);
+ALLOC_DEFINE(qd_delivery_state_t);
+
+qd_delivery_state_t *qd_delivery_state()
+{
+    qd_delivery_state_t *dstate = new_qd_delivery_state_t();
+    ZERO(dstate);
+    return dstate;
+}
+
+
+
+qd_delivery_state_t *qd_delivery_state_from_error(qdr_error_t *err)
+{
+    if (err) {
+        qd_delivery_state_t *dstate = qd_delivery_state();
+        dstate->error = err;
+        return dstate;
+    }
+    return 0;
+}
+
+
+void qd_delivery_state_free(qd_delivery_state_t *dstate)
+{
+    if (dstate) {
+        qdr_error_free(dstate->error);
+        if (dstate->annotations)
+            pn_data_free(dstate->annotations);
+        if (dstate->extension)
+            pn_data_free(dstate->extension);
+        free_qd_delivery_state_t(dstate);
+    }
+}
+

--- a/src/router_core/DESIGN
+++ b/src/router_core/DESIGN
@@ -80,11 +80,13 @@ Router Core Objects
 
   qdr_terminus_t
   qdr_error_t
+  qd_delivery_state_t
 
-    The terminus and error objects are used to hold all of the content of a Proton
-    terminus and error state.  These are needed to ensure that these Proton state
-    objects are not ever held within the core thread where thread safety with Proton
-    may be a problem.
+    The these objects are used to hold a copy of the relevent content
+    of Proton terminus, condition, disposition, and error state
+    objects.  These are needed to ensure that references to these
+    Proton state objects are not held within the core thread where
+    thread safety with Proton may be a problem.
 
 
 =========

--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -123,9 +123,8 @@ void qdrc_endpoint_send_CT(qdr_core_t *core, qdrc_endpoint_t *ep, qdr_delivery_t
     dlv->presettled    = presettled;
     *tag               = core->next_tag++;
     dlv->tag_length    = 8;
-    dlv->error         = 0;
     dlv->ingress_index = -1;
-    
+
     qdr_forward_deliver_CT(core, ep->link, dlv);
 }
 

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -144,7 +144,6 @@ struct qdr_action_t {
         //
         struct {
             qdr_delivery_t *delivery;
-            qdr_error_t    *error;
             uint64_t        disposition;
             uint8_t         tag[32];
             int             tag_length;

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -197,8 +197,8 @@ class FakeService(FakeBroker):
     Like a broker, but proactively connects to the message bus
     Useful for testing link routes
     """
-    def __init__(self, url, container_id=None):
-        super(FakeService, self).__init__(url, container_id)
+    def __init__(self, url, container_id=None, **handler_kwargs):
+        super(FakeService, self).__init__(url, container_id, **handler_kwargs)
 
     def on_start(self, event):
         event.container.connect(url=self.url)


### PR DESCRIPTION
This patch organizes all delivery state into a single public structure
qd_delivery_state_t.  This structure combines the existing separate
extension state and qdr_error_t (Proton Condition) elements into a
single class.  It also contains the additional data associated with a
MODIFIED outcome.

This structure corresponds to the 'delivery-state' archetype described
in Section 3.4 Delivery State in the AMQP 1.0 specification.