### PR TITLE
DISPATCH-1750 Set nodejs version to latest LTS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@
 
 language: c
 cache: ccache
+node_js: lts/*
 jobs:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ addons:
     - lcov
 
 before_install:
+# Install and use the latest Node.js LTS version
 - nvm install "lts/*"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@
 
 language: c
 cache: ccache
-node_js: lts/*
 jobs:
   fast_finish: true
   allow_failures:
@@ -116,6 +115,9 @@ addons:
     - tox
     # code coverage
     - lcov
+
+before_install:
+- nvm install "lts/*"
 
 install:
 - NPROC=2


### PR DESCRIPTION
There is a known issue with a transitive dependency `node-fs-extra` which, starting in version 9.0.0, needs at least nodejs 10 or maybe 10.3.

https://github.com/google/docsy/issues/265 and https://github.com/jprichardson/node-fs-extra/issues/856