### PR TITLE
DISPATCH-1929 Add QD_ENABLE_ASSERTIONS CMake option to turn on asserts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,7 @@ jobs:
         -DCMAKE_C_COMPILER_LAUNCHER=ccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG
+        -DQD_ENABLE_ASSERTIONS=ON
         -DCONSOLE_INSTALL=OFF
         -DUSE_BWRAP=ON
         -DRUNTIME_CHECK=${{matrix.runtimeCheck}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,16 @@ if (CMAKE_BUILD_TYPE MATCHES "Deb|Cover")
   set (has_debug_symbols " (has debug symbols)")
 endif (CMAKE_BUILD_TYPE MATCHES "Deb|Cover")
 message(STATUS "Build type is \"${CMAKE_BUILD_TYPE}\"${has_debug_symbols}")
+# This is commonly needed so define it before we include anything else.
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
 
 option(QD_MEMORY_STATS "Track memory pool usage statistics" ON)
+
+if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+    option(QD_ENABLE_ASSERTIONS "Enable assertions" ON)
+else()
+    option(QD_ENABLE_ASSERTIONS "Enable assertions" OFF)
+endif()
 
 file(STRINGS "${CMAKE_SOURCE_DIR}/VERSION.txt" QPID_DISPATCH_VERSION)
 
@@ -187,6 +195,32 @@ include_directories(
     ${Proton_Core_INCLUDE_DIRS}
     ${PYTHON_INCLUDE_PATH}
     )
+
+# Originally from the LLVM project, https://opensource.apple.com/source/llvmCore/llvmCore-2358.3/CMakeLists.txt.auto.html
+if(QD_ENABLE_ASSERTIONS)
+    # MSVC doesn't like _DEBUG on release builds.
+    if(NOT MSVC)
+        add_definitions(-D_DEBUG)
+    endif()
+    # On non-Debug builds cmake automatically defines NDEBUG, so we explicitly undefine it:
+    if(NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+        # NOTE: use `add_compile_options` rather than `add_definitions` since
+        # `add_definitions` does not support generator expressions.
+        add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+
+        # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+        foreach (flags_var_to_scrub
+                CMAKE_CXX_FLAGS_RELEASE
+                CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                CMAKE_CXX_FLAGS_MINSIZEREL
+                CMAKE_C_FLAGS_RELEASE
+                CMAKE_C_FLAGS_RELWITHDEBINFO
+                CMAKE_C_FLAGS_MINSIZEREL)
+            string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+                    "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+        endforeach()
+    endif()
+endif()
 
 if (NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
  add_compile_options(-Werror)

--- a/README
+++ b/README
@@ -206,3 +206,36 @@ order to use this option.
 
 False positive leak errors can be suppressed via the lsan.supp file in
 the tests directory.
+
+
+CMake Build Options
+===================
+
+Use `cmake-gui` to explore the CMake build options available.
+Existing build directory can be opened with `cmake-gui -S .. -B .`
+
+-DCMAKE_BUILD_TYPE=
+-------------------
+
+Dispatch defaults to building with the `RelWithDebInfo` CMake preset.
+Other options include `Debug` (disables optimizations) and `Coverage`.
+
+-DQD_ENABLE_ASSERTIONS=
+-----------------------
+
+Seting this to `ON` enables asserts irrespective of `CMAKE_BUILD_TYPE`.
+
+-DQD_MEMORY_STATS=
+------------------
+
+Dispatch will track memory pool usage statistics if this is enabled.
+
+-DCONSOLE_INSTALL=
+------------------
+
+Web console will not be built if this is set to `OFF`.
+
+-DRUNTIME_CHECK=
+----------------
+
+Enables C/C++ runtime checkers. See "Run Time Validation" chapter above.


### PR DESCRIPTION
This is the way LLVM configures this. It allows turning on asserts irrespective of the chosen CMAKE_BUILD_TYPE.

I read through https://stackoverflow.com/questions/22140520/how-to-enable-assert-in-cmake-release-mode/65954915 and this seemed the most straight-forward solution. I'd like to turn this on in some/most (and maybe all-except-one) CI builds.