### PR TITLE
DISPATCH-1942 Use findPython when on CMake3.15+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,14 @@ else (NOT APPLE)
   set(rt "")
 endif (NOT APPLE)
 
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
+# This setting mirrors FindPythonInterp behavior on Windows/macOS, which did not consult registry/frameworks first.
+if (NOT DEFINED Python_FIND_REGISTRY)
+    set(Python_FIND_REGISTRY "LAST")
+endif ()
+if (NOT DEFINED Python_FIND_FRAMEWORK)
+    set(Python_FIND_FRAMEWORK "LAST")
+endif ()
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 find_package(Threads REQUIRED)
 find_package(Proton 0.33.0 REQUIRED COMPONENTS Core Proactor)
 message(STATUS "Found Proton: ${Proton_LIBRARIES} (found version \"${Proton_VERSION}\")" )
@@ -102,9 +108,9 @@ if (LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
 endif(LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
 
 # Python
-if (PYTHON_VERSION_MAJOR STREQUAL 3)
+if (Python_VERSION_MAJOR STREQUAL 3)
     set(PY_STRING "python3")
-elseif(PYTHON_VERSION_MAJOR STREQUAL 2)
+elseif(Python_VERSION_MAJOR STREQUAL 2)
     set(PY_STRING "python")
 endif()
 
@@ -142,7 +148,7 @@ set(CONSOLE_BASE_INSTALL_DIR "share/qpid-dispatch/console")
 set(CONSOLE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${CONSOLE_BASE_INSTALL_DIR}")
 set(CONSOLE_STAND_ALONE_INSTALL_DIR "${CONSOLE_INSTALL_DIR}")
 
-set(RUN ${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/run.py)
+set(RUN ${Python_EXECUTABLE} ${CMAKE_BINARY_DIR}/run.py)
 
 # define the configuration directory based on whether or not the install prefix is defined
 if(NOT DEFINED SYSCONF_INSTALL_DIR)
@@ -173,7 +179,7 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}/include
     ${Proton_Proactor_INCLUDE_DIRS}
     ${Proton_Core_INCLUDE_DIRS}
-    ${PYTHON_INCLUDE_PATH}
+    ${Python_INCLUDE_DIRS}
     )
 
 # Originally from the LLVM project, https://opensource.apple.com/source/llvmCore/llvmCore-2358.3/CMakeLists.txt.auto.html

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This is a wrapper hack purely so that we can use FindPython
+# with cmake 2.8.12 and its supplied older modules
+
+if (POLICY CMP0094)  # https://cmake.org/cmake/help/latest/policy/CMP0094.html
+    cmake_policy(SET CMP0094 NEW)  # FindPython should return the first matching Python on PATH
+endif ()
+
+if (DEFINED PYTHON_EXECUTABLE AND DEFINED Python_EXECUTABLE)
+    message(FATAL_ERROR "Both PYTHON_EXECUTABLE and Python_EXECUTABLE are defined. Define at most one of those.")
+endif ()
+
+# FindPython was added in CMake 3.12, but there it always returned
+#  newest Python on the entire PATH. We want to use the first one.
+if (CMAKE_VERSION VERSION_LESS "3.15.0")
+    if (DEFINED Python_EXECUTABLE)
+        set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+    endif ()
+
+    find_package (PythonInterp REQUIRED)
+    # forward compatibility with FindPython
+    set(Python_VERSION_STRING "${PYTHON_VERSION_STRING}")
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    # for completeness, these are not actually used now
+    set(Python_VERSION_MAJOR "${PYTHON_VERSION_MAJOR}")
+    set(Python_VERSION_MINOR "${PYTHON_VERSION_MINOR}")
+    set(Python_VERSION_PATCH "${PYTHON_VERSION_PATCH}")
+
+    find_package (PythonLibs ${PYTHON_VERSION_STRING} EXACT REQUIRED)
+    set(Python_Development_FOUND "${PYTHONLIBS_FOUND}")
+    set(Python_INCLUDE_DIRS "${PYTHON_INCLUDE_PATH}")
+    set(Python_LIBRARIES "${PYTHON_LIBRARIES}")
+else ()
+    if (DEFINED PYTHON_EXECUTABLE)
+        set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
+    endif ()
+
+    include(${CMAKE_ROOT}/Modules/FindPython.cmake)
+endif ()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,7 +27,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qpid_dispatch_site.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/qpid_dispatch_site.py)
 
 # Install script for public python modules
-install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} setup.py -v install --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} setup.py -v install --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
 
 install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/qpid_dispatch/management/qdrouter.json

--- a/python/install_python.cmake
+++ b/python/install_python.cmake
@@ -20,11 +20,7 @@
 # Install script to install public python modules.
 # Install with setup.py, add installed files to install manifest.
 
-include(FindPythonInterp)
-
 set(PYTHON_MANIFEST ${CMAKE_BINARY_DIR}/python_manifest.txt)
-
-
 
 file(READ ${PYTHON_MANIFEST} PYTHON_MANIFEST_FILES)
 list(APPEND CMAKE_INSTALL_MANIFEST_FILES ${PYTHON_MANIFEST_FILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ set(GENERATOR_DEPENDS ${GENERATOR_DEPENDS} ${GENERATOR_SRC})
 
 add_custom_command (
   OUTPUT ${GENERATED_SOURCES}
-  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/tests/run.py -s ${CMAKE_CURRENT_SOURCE_DIR}/schema_c.py
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_BINARY_DIR}/tests/run.py -s ${CMAKE_CURRENT_SOURCE_DIR}/schema_c.py
   DEPENDS ${GENERATOR_DEPENDS})
 
 # Build the qpid-dispatch library.
@@ -134,7 +134,7 @@ set(qpid_dispatch_LIBRARIES
   ${CMAKE_THREAD_LIBS_INIT}
   ${rt_lib}
   ${CMAKE_DL_LIBS}
-  ${PYTHON_LIBRARIES}
+  ${Python_LIBRARIES}
   )
 
 # USE_LIBWEBSOCKETS is true only if LIBWEBSOCKETS_FOUND

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,7 +71,7 @@ if(USE_BWRAP)
 else()
   set(BWRAP_ARGS "")
 endif()
-set(TEST_WRAP ${BWRAP_ARGS} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/run.py)
+set(TEST_WRAP ${BWRAP_ARGS} ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/run.py)
 
 add_test(unit_tests_size_10000 ${TEST_WRAP} unit_tests_size 10000)
 add_test(unit_tests_size_512   ${TEST_WRAP} unit_tests_size 512)


### PR DESCRIPTION
The newer module can correctly configure build to use Python virtual environment,
and furthermore the PythonInterp/Libs modules have been deprecated in CMake 3.15