### PR TITLE
DISPATCH-1927

### DIFF
--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -1854,6 +1854,7 @@ static uint64_t qdr_http_deliver(void *context, qdr_link_t *link, qdr_delivery_t
                                                      0,
                                                      &(stream_data->incoming_id));
         qdr_link_set_context(stream_data->in_link, stream_data);
+        return QD_DELIVERY_MOVED_TO_NEW_LINK;
     }
     else if (stream_data) {
         if (conn->ingress) {


### PR DESCRIPTION
DISPATCH-1927 - Lock link when removing the initial delivery and handle the related link_work object.

DISPATCH-1927 - Expand the scope of the lock in qdr_delivery_continue