### PR TITLE
DISPATCH-1952: fix qd_bitmask_t message streaming leak

### DIFF
--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -102,7 +102,6 @@ static const char *leaking_types[] = {
     "qdr_field_t",
     "qdr_link_work_t",
     "qd_buffer_t",
-    "qd_bitmask_t",
 
     "qd_parsed_field_t",  // DISPATCH-1701
     "qdr_delivery_ref_t", // DISPATCH-1702


### PR DESCRIPTION
This patch moves the point where the message annotations are updated
to after the check for Q2/streaming.  Not only does this fix the leak,
but it avoids potentially doing the annotation computation multiple
times for the same message.