### PR TITLE
DISPATCH-1903 Added logic for storage of temporary files.  Added use …

### DIFF
--- a/include/qpid/dispatch/tempstore.h
+++ b/include/qpid/dispatch/tempstore.h
@@ -1,5 +1,5 @@
-#ifndef __policy_spec_h__
-#define __policy_spec_h__
+#ifndef __dispatch_tempstore_h__
+#define __dispatch_tempstore_h__ 1
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,24 +19,25 @@
  * under the License.
  */
 
-typedef struct {
-    int       maxFrameSize;
-    int       maxSessionWindow;
-    int       maxSessions;
-    int       maxSenders;
-    int       maxReceivers;
-    uint64_t  maxMessageSize;
-    bool      allowDynamicSource;
-    bool      allowAnonymousSender;
-    bool      allowUserIdProxy;
-    bool      allowWaypointLinks;
-    bool      allowFallbackLinks;
-    bool      allowDynamicLinkRoutes;
-    bool      allowAdminStatusUpdate;
-    bool      outgoingConnection;
-    bool      allowTempFile;
-    int       maxTempFileSize;
-    int       maxTempFileCount;
-} qd_policy_spec_t;
+/*
+ * qd_temp_is_store_created
+ *
+ * Indicate whether or not the store has been created.
+ *
+ * @return true iff the store has been set up and has at least one file in it.
+ */
+bool qd_temp_is_store_created(void);
+
+/*
+ * qd_temp_get_path
+ *
+ * Given a file name, return the full path to the file in the store.
+ * The returned string is allocated from the heap and must be freed by the caller.
+ *
+ * @param filename Name of the file in the store.  This must not contain '/' or '\' characters.
+ * @return allocated string containing full path iff The file exists, else NULL
+ */
+char *qd_temp_get_path(const char* filename);
 
 #endif
+

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -645,19 +645,19 @@
                 },
                 "caCertFile": {
                     "type": "path",
-                    "description": "The absolute path to the database that contains the public certificates of trusted certificate authorities (CA).",
+                    "description": "The absolute path or 'tmp:<filename>' to the database that contains the public certificates of trusted certificate authorities (CA).  If the 'tmp:' form is used, the file must exist in the router's temporary file store.",
                     "deprecationName": "certDb",
                     "create": true
                 },
                 "certFile": {
                     "type": "path",
-                    "description": "The absolute path to the file containing the PEM-formatted public certificate to be used on the local end of any connections using this profile.",
+                    "description": "The absolute path or 'tmp:<filename>' to the file containing the PEM-formatted public certificate to be used on the local end of any connections using this profile.  If the 'tmp:' form is used, the file must exist in the router's temporary file store.",
                     "create": true
 
                 },
                 "privateKeyFile": {
                     "type": "path",
-                    "description": "The absolute path to the file containing the PEM-formatted private key for the above certificate.",
+                    "description": "The absolute path or 'tmp:<filename>' to the file containing the PEM-formatted private key for the above certificate.  If the 'tmp:' form is used, the file must exist in the router's temporary file store.",
                     "deprecationName": "keyFile",
                     "create": true
 
@@ -671,7 +671,7 @@
                 },
                 "password": {
                     "type": "string",
-                    "description": "The password that unlocks the certificate key. You can specify the password by specifying an environment variable that stores the password, a file that stores the password, or by entering the password in clear text. To use an environment variable, specify 'password: env:<var>'. Use this option with caution, because the environment of other processes is visible on certain platforms (for example, ps on certain Unix OSs). To use a file, specify 'password: file:<absolute-path-to-file>'. This option is the most secure, because permissions can be set on the file that contains the password. To specify the password in clear text, specify 'password: pass:<password>', or 'password: literal:<password>', or 'password: <password>'. This option is insecure, so it should only be used if security is not a concern. If both password and passwordFile are provided, the passwordFile is ignored.",
+                    "description": "The password that unlocks the certificate key. You can specify the password by specifying an environment variable that stores the password, a file that stores the password, or by entering the password in clear text. To use an environment variable, specify 'password: env:<var>'. Use this option with caution, because the environment of other processes is visible on certain platforms (for example, ps on certain Unix OSs). To use a file, specify 'password: file:<absolute-path-to-file>' or 'password: tmp:<temp-store-filename>. These options are the most secure, because permissions can be set on the file that contains the password. To specify the password in clear text, specify 'password: pass:<password>', or 'password: literal:<password>', or 'password: <password>'. This option is insecure, so it should only be used if security is not a concern. If both password and passwordFile are provided, the passwordFile is ignored.",
                     "create": true
 
                 },
@@ -1338,6 +1338,7 @@
                         "PROTOCOL",
                         "TCP_ADAPTOR",
                         "HTTP_ADAPTOR",
+                        "TEMPSTORE",
                         "DEFAULT"
                     ],
                     "required": true,
@@ -2397,6 +2398,27 @@
                     "type": "boolean",
                     "description": "Whether this connection is allowed to claim 'qd.fallback' capability for attached links.  This allows endpoints to act as fallback destinations for addresses that have fallback capability enabled.",
                     "default": true,
+                    "required": false,
+                    "create": true
+                },
+                "allowTempFile": {
+                    "type": "boolean",
+                    "description": "Whether this connection is allowed to transfer files to the temporary file store.",
+                    "default": true,
+                    "required": false,
+                    "create": true
+                },
+                "maxTempFileSize": {
+                    "type": "integer",
+                    "description": "The maximum payload size permitted for a transferred temporary file.",
+                    "default": 32768,
+                    "required": false,
+                    "create": true
+                },
+                "maxTempFileCount": {
+                    "type": "integer",
+                    "description": "The maximum number of files permitted for transfer to the temporary store.",
+                    "default": 128,
                     "required": false,
                     "create": true
                 },

--- a/python/qpid_dispatch_internal/policy/policy_local.py
+++ b/python/qpid_dispatch_internal/policy/policy_local.py
@@ -75,6 +75,9 @@ class PolicyKeys(object):
     KW_ALLOW_FALLBACK_LINKS      = "allowFallbackLinks"
     KW_ALLOW_DYNAMIC_LINK_ROUTES = "allowDynamicLinkRoutes"
     KW_ALLOW_ADMIN_STATUS_UPDATE = "allowAdminStatusUpdate"
+    KW_ALLOW_TEMP_FILE           = "allowTempFile"
+    KW_MAX_TEMP_FILE_SIZE        = "maxTempFileSize"
+    KW_MAX_TEMP_FILE_COUNT       = "maxTempFileCount"
     KW_SOURCES                   = "sources"
     KW_TARGETS                   = "targets"
     KW_SOURCE_PATTERN            = "sourcePattern"
@@ -159,6 +162,9 @@ class PolicyCompiler(object):
         PolicyKeys.KW_ALLOW_FALLBACK_LINKS,
         PolicyKeys.KW_ALLOW_DYNAMIC_LINK_ROUTES,
         PolicyKeys.KW_ALLOW_ADMIN_STATUS_UPDATE,
+        PolicyKeys.KW_ALLOW_TEMP_FILE,
+        PolicyKeys.KW_MAX_TEMP_FILE_SIZE,
+        PolicyKeys.KW_MAX_TEMP_FILE_COUNT,
         PolicyKeys.KW_SOURCES,
         PolicyKeys.KW_TARGETS,
         PolicyKeys.KW_SOURCE_PATTERN,
@@ -264,6 +270,9 @@ class PolicyCompiler(object):
         policy_out[PolicyKeys.KW_ALLOW_FALLBACK_LINKS] = True
         policy_out[PolicyKeys.KW_ALLOW_DYNAMIC_LINK_ROUTES] = True
         policy_out[PolicyKeys.KW_ALLOW_ADMIN_STATUS_UPDATE] = True
+        policy_out[PolicyKeys.KW_ALLOW_TEMP_FILE] = True
+        policy_out[PolicyKeys.KW_MAX_TEMP_FILE_SIZE] = 32768
+        policy_out[PolicyKeys.KW_MAX_TEMP_FILE_COUNT] = 128
         policy_out[PolicyKeys.KW_SOURCES] = ''
         policy_out[PolicyKeys.KW_TARGETS] = ''
         policy_out[PolicyKeys.KW_SOURCE_PATTERN] = ''
@@ -290,11 +299,13 @@ class PolicyCompiler(object):
                     return False
                 policy_out[key] = int(val)
             elif key in [PolicyKeys.KW_MAX_FRAME_SIZE,
-                       PolicyKeys.KW_MAX_MESSAGE_SIZE,
-                       PolicyKeys.KW_MAX_RECEIVERS,
-                       PolicyKeys.KW_MAX_SENDERS,
-                       PolicyKeys.KW_MAX_SESSION_WINDOW,
-                       PolicyKeys.KW_MAX_SESSIONS
+                         PolicyKeys.KW_MAX_MESSAGE_SIZE,
+                         PolicyKeys.KW_MAX_RECEIVERS,
+                         PolicyKeys.KW_MAX_SENDERS,
+                         PolicyKeys.KW_MAX_SESSION_WINDOW,
+                         PolicyKeys.KW_MAX_SESSIONS,
+                         PolicyKeys.KW_MAX_TEMP_FILE_SIZE,
+                         PolicyKeys.KW_MAX_TEMP_FILE_COUNT
                        ]:
                 if not self.validateNumber(val, 0, 0, cerror):
                     errors.append("Policy vhost '%s' user group '%s' option '%s' has error '%s'." %
@@ -314,7 +325,8 @@ class PolicyCompiler(object):
                          PolicyKeys.KW_ALLOW_WAYPOINT_LINKS,
                          PolicyKeys.KW_ALLOW_FALLBACK_LINKS,
                          PolicyKeys.KW_ALLOW_DYNAMIC_LINK_ROUTES,
-                         PolicyKeys.KW_ALLOW_ADMIN_STATUS_UPDATE
+                         PolicyKeys.KW_ALLOW_ADMIN_STATUS_UPDATE,
+                         PolicyKeys.KW_ALLOW_TEMP_FILE
                          ]:
                 if isinstance(val, (PY_STRING_TYPE, PY_TEXT_TYPE)) and val.lower() in ['true', 'false']:
                     val = True if val == 'true' else False
@@ -436,6 +448,9 @@ class PolicyCompiler(object):
         policy_out[PolicyKeys.KW_GROUPS] = {}
         policy_out[PolicyKeys.KW_MAX_MESSAGE_SIZE] = None
         policy_out[PolicyKeys.KW_VHOST_ALIASES] = []
+        policy_out[PolicyKeys.KW_MAX_TEMP_FILE_SIZE] = 32768
+        policy_out[PolicyKeys.KW_MAX_TEMP_FILE_COUNT] = 128
+
 
         # validate the options
         for key, val in dict_iteritems(policy_in):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ set(qpid_dispatch_SOURCES
   router_pynode.c
   schema_enum.c
   server.c
+  tempstore-posix.c
   timer.c
   trace_mask.c
   python_utils.c

--- a/src/policy.c
+++ b/src/policy.c
@@ -566,6 +566,10 @@ bool qd_policy_open_fetch_settings(
                         settings->spec.allowFallbackLinks     = qd_entity_opt_bool((qd_entity_t*)upolicy, "allowFallbackLinks", true);
                         settings->spec.allowDynamicLinkRoutes = qd_entity_opt_bool((qd_entity_t*)upolicy, "allowDynamicLinkRoutes", true);
 
+                        settings->spec.allowTempFile          = qd_entity_opt_bool((qd_entity_t*)upolicy, "allowTempFile", true);
+                        settings->spec.maxTempFileSize        = qd_entity_opt_long((qd_entity_t*)upolicy, "maxTempFileSize", 32768);
+                        settings->spec.maxTempFileCount       = qd_entity_opt_long((qd_entity_t*)upolicy, "maxTempFileCount", 128);
+
                         //
                         // By default, deleting connections are enabled. To disable, set the allowAdminStatusUpdate to false in a policy.
                         //

--- a/src/tempstore-posix.c
+++ b/src/tempstore-posix.c
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "qpid/dispatch/ctools.h"
+#include "qpid/dispatch/log.h"
+#include "qpid/dispatch/tempstore.h"
+#include "qpid/dispatch/router_core.h"
+#include "qpid/dispatch/protocol_adaptor.h"
+
+typedef struct qdts_state_t qdts_state_t;
+typedef struct qdts_file_t qdts_file_t;
+
+struct qdts_file_t {
+    DEQ_LINKS(qdts_file_t);
+    char *file_path;
+    int   write_count;
+};
+
+DEQ_DECLARE(qdts_file_t, qdts_file_list_t);
+
+#define MAX_TEMPLATE 500
+
+struct qdts_state_t {
+    qdr_core_t         *core;
+    qd_log_source_t    *log;
+    char               *address;
+    bool                initialized;
+    bool                failed;
+    qdr_subscription_t *subscription;
+    char                template[MAX_TEMPLATE];
+    char               *path;
+    qdts_file_list_t    files;
+};
+
+static qdts_state_t qdts_state;
+
+
+bool qd_temp_is_store_created(void)
+{
+    return qdts_state.initialized;
+}
+
+
+char* qd_temp_get_path(const char* filename)
+{
+    qdts_state_t *state = &qdts_state;
+
+    if (!state->initialized)
+        return false;
+
+    size_t path_len = strlen(state->path) + strlen(filename) + 2;
+    char *full_path = (char*) malloc(path_len);
+    strcpy(full_path, state->path);
+    strcat(full_path, "/");
+    strcat(full_path, filename);
+
+    qdts_file_t *file = DEQ_HEAD(state->files);
+    while (!!file) {
+        if (strcmp(file->file_path, full_path) == 0) {
+            return full_path;
+        }
+        file = DEQ_NEXT(file);
+    }
+
+    free(full_path);
+    return 0;
+}
+
+
+static void qdts_init_storage(qdts_state_t *state)
+{
+    char *temp_dir;
+    char *template = "qdrouterd-filestore.XXXXXX";
+
+    //
+    // If the TMPDIR environment variable is set, use that as the prefix path for
+    // the temporary directory.  Otherwise, use "/tmp".
+    //
+    temp_dir = getenv("TMPDIR");
+    if (!temp_dir)
+        temp_dir = "/tmp";
+
+    if (strlen(temp_dir) + strlen(template) + 2 > MAX_TEMPLATE) {
+        qd_log(state->log, QD_LOG_CRITICAL, "Path from environment variable TMPDIR is too long - using '/tmp'");
+        temp_dir = "/tmp";
+    }
+    
+    strcpy(state->template, temp_dir);
+    strcat(state->template, "/");
+    strcat(state->template, template);
+
+    state->path = mkdtemp(state->template);
+    if (!state->path) {
+        qd_log(state->log, QD_LOG_CRITICAL, "Failed to create temporary directory: %s (%s)",
+               state->template, strerror(errno));
+        state->failed = true;
+        return;
+    }
+
+    state->initialized = true;
+    qd_log(state->log, QD_LOG_INFO, "Store initialized, path: %s", state->path);
+}
+
+
+static bool qdts_write_file(qdts_state_t *state, const char *filename, const char *body, int limit)
+{
+    char *full_path = (char*) malloc(strlen(state->path) + strlen(filename) + 2);
+
+    strcpy(full_path, state->path);
+    strcat(full_path, "/");
+    strcat(full_path, filename);
+
+    qdts_file_t *file = DEQ_HEAD(state->files);
+    while (!!file && strcmp(file->file_path, full_path) != 0) {
+        file = DEQ_NEXT(file);
+    }
+
+    if (!file && DEQ_SIZE(state->files) >= limit && limit != 0) {
+        free(full_path);
+        return false;
+    }
+
+    int fd = open(full_path, O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR);
+    if (fd > 0) {
+        ssize_t written = write(fd, body, strlen(body));
+        if (written < 0) {
+            qd_log(state->log, QD_LOG_ERROR, "Failed to write file '%s' (%s)", full_path, strerror(errno));
+            free(full_path);
+            return true;
+        }
+        close(fd);
+    } else {
+        qd_log(state->log, QD_LOG_ERROR, "Failed to open file '%s' (%s)", full_path, strerror(errno));
+        free(full_path);
+        return true;
+    }
+
+    if (!!file) {
+        file->write_count++;
+        free(full_path);
+    } else {
+        file = NEW(qdts_file_t);
+        DEQ_ITEM_INIT(file);
+        file->file_path   = full_path;
+        file->write_count = 1;
+        DEQ_INSERT_TAIL(state->files, file);
+    }
+
+    qd_log(state->log, QD_LOG_INFO, "Temporary file stored: %s", filename);
+    return true;
+}
+
+
+static uint64_t qdts_on_message(void *context, qd_message_t *msg, int link_maskbit, int inter_router_cost,
+                                uint64_t conn_id, const qd_policy_spec_t *policy_spec, qdr_error_t **error)
+{
+    qdts_state_t *state = (qdts_state_t*) context;
+
+    if (!!policy_spec && !policy_spec->allowTempFile) {
+        qd_log(state->log, QD_LOG_ERROR, "[C%"PRIu64"] Policy violation - temp file store not permitted", conn_id);
+        *error = qdr_error(QD_AMQP_COND_UNAUTHORIZED_ACCESS, "File store access forbidden");
+        return PN_REJECTED;
+    }
+
+    if (state->failed) {
+        *error = qdr_error(QD_AMQP_COND_INTERNAL_ERROR, "File store initialization failed");
+        return PN_REJECTED;
+    }
+
+    if (qd_message_check_depth(msg, QD_DEPTH_BODY) != QD_MESSAGE_DEPTH_OK) {
+        qd_log(state->log, QD_LOG_ERROR, "Invalid message received");
+        *error = qdr_error(QD_AMQP_COND_DECODE_ERROR, "Parse error in message");
+        return PN_REJECTED;
+    }
+
+    qd_iterator_t *subject_iter = qd_message_field_iterator(msg, QD_FIELD_SUBJECT);
+    if (!subject_iter) {
+        qd_log(state->log, QD_LOG_ERROR, "Invalid message received - No Subject");
+        *error = qdr_error(QD_AMQP_COND_INVALID_FIELD, "Invalid request - no subject header");
+        return PN_REJECTED;
+    }
+
+    char *filename = (char*) qd_iterator_copy(subject_iter);
+    qd_iterator_free(subject_iter);
+
+    if (!!strchr(filename, '/') || !!strchr(filename, '\\') || !!strstr(filename, "..")) {
+        qd_log(state->log, QD_LOG_ERROR, "Invalid message received - File name with path traversal characters");
+        free(filename);
+        *error = qdr_error(QD_AMQP_COND_INVALID_FIELD, "File name contains path traversal characters");
+        return PN_REJECTED;
+    }
+
+    qd_iterator_t *body_iter = qd_message_field_iterator(msg, QD_FIELD_BODY);
+    char          *body      = 0;
+
+    if (!!body_iter) {
+        //
+        // Check the body size
+        //
+        if (!!policy_spec) {
+            int length = qd_iterator_length(body_iter);
+            if (length > policy_spec->maxTempFileSize) {
+                qd_log(state->log, QD_LOG_ERROR, "[C%"PRIu64"] Policy violation - temp file larger than max size: %d", conn_id, length);
+                free(filename);
+                qd_iterator_free(body_iter);
+                *error = qdr_error(QD_AMQP_COND_UNAUTHORIZED_ACCESS, "File larger than maximum allowed size");
+                return PN_REJECTED;
+            }
+        }
+
+        qd_parsed_field_t *field = qd_parse(body_iter);
+        if (qd_parse_ok(field)) {
+            uint8_t tag = qd_parse_tag(field);
+            if (tag == QD_AMQP_STR8_UTF8 || tag == QD_AMQP_STR32_UTF8) {
+                body = (char*) qd_iterator_copy(qd_parse_raw(field));
+            }
+        }
+        qd_parse_free(field);
+        qd_iterator_free(body_iter);
+    }
+
+    if (!state->initialized)
+        qdts_init_storage(state);
+
+    if (state->initialized) {
+        bool success = qdts_write_file(state, filename, body, !!policy_spec ? policy_spec->maxTempFileCount : 0);
+        if (!success) {
+            free(filename);
+            free(body);
+            qd_log(state->log, QD_LOG_ERROR, "[C%"PRIu64"] Policy violation - too many files in the temporary store", conn_id);
+            *error = qdr_error(QD_AMQP_COND_UNAUTHORIZED_ACCESS, "Too many files in file store");
+            return PN_REJECTED;
+        }
+    }
+
+    free(filename);
+    free(body);
+    return PN_ACCEPTED;
+}
+
+
+static void qd_tempstore_init(qdr_core_t *core, void **adaptor_context)
+{
+    qdts_state_t *state = &qdts_state;
+
+    ZERO(state);
+    state->core         = core;
+    state->address      = "_$qd.store_file";
+    state->initialized  = false;
+    state->subscription = qdr_core_subscribe(core, state->address, QD_ITER_HASH_PREFIX_MOBILE, '0',
+                                             QD_TREATMENT_ANYCAST_CLOSEST, false, qdts_on_message, state);
+
+    state->log = qd_log_source("TEMPSTORE");
+
+    *adaptor_context = state;
+}
+
+
+static void qd_tempstore_final(void *adaptor_context)
+{
+    qdts_state_t *state = (qdts_state_t*) adaptor_context;
+    qdr_core_unsubscribe(state->subscription);
+    if (state->initialized) {
+        qdts_file_t *file = DEQ_HEAD(state->files);
+        while (file) {
+            DEQ_REMOVE_HEAD(state->files);
+            remove(file->file_path);
+            free(file->file_path);
+            free(file);
+            file = DEQ_HEAD(state->files);
+        }
+        remove(state->path);
+        qd_log(state->log, QD_LOG_INFO, "Temporary store deleted");
+    }
+}
+
+
+//
+// Even though this is not technically a protocol adaptor, we will use the
+// adaptor declaration facility because it will initialize this module at
+// the right time.
+//
+QDR_CORE_ADAPTOR_DECLARE("tempstore", qd_tempstore_init, qd_tempstore_final)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,6 +163,7 @@ foreach(py_test_module
     ${SYSTEM_TESTS_HTTP2}
     system_tests_http1_adaptor
     system_tests_tcp_adaptor
+    system_tests_temp_file
     )
 
   add_test(${py_test_module} ${TEST_WRAP} ${PYTHON_TEST_COMMAND} -v ${py_test_module})

--- a/tests/policy-tempfile/allowed.json
+++ b/tests/policy-tempfile/allowed.json
@@ -1,0 +1,42 @@
+##
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License
+##
+
+[
+    ["vhost", {
+        "hostname": "allowed",
+        "maxConnections": 50,
+        "maxConnectionsPerUser": 5,
+        "maxConnectionsPerHost": 20,
+        "allowUnknownUser": true,
+        "groups": {
+            "$default" : {
+                "users":            "*",
+                "remoteHosts":      "*",
+                "allowDynamicSource":   true,
+                "allowAnonymousSender": false,
+                "allowTempFile": true,
+                "maxTempFileSize": 900,
+                "maxTempFileCount": 15,
+                "sources": "",
+                "targets": "$management,_$qd.store_file"
+            }
+        }
+    }
+    ]
+]

--- a/tests/policy-tempfile/blocked.json
+++ b/tests/policy-tempfile/blocked.json
@@ -1,0 +1,40 @@
+##
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License
+##
+
+[
+    ["vhost", {
+        "hostname": "blocked",
+        "maxConnections": 50,
+        "maxConnectionsPerUser": 5,
+        "maxConnectionsPerHost": 20,
+        "allowUnknownUser": true,
+        "groups": {
+            "$default" : {
+                "users":            "*",
+                "remoteHosts":      "*",
+                "allowDynamicSource":   true,
+                "allowAnonymousSender": false,
+                "allowTempFile": false,
+                "sources": "",
+                "targets": "$management,_$qd.store_file"
+            }
+        }
+    }
+    ]
+]

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -137,13 +137,13 @@ class QdstatTest(system_test.TestCase):
         out = self.run_qdstat(['--address'], r'QDR.A')
         out = self.run_qdstat(['--address'], r'\$management')
         parts = out.split("\n")
-        self.assertEqual(len(parts), 11)
+        self.assertEqual(len(parts), 12)
 
     def test_address_csv(self):
         out = self.run_qdstat(['--address'], r'QDR.A')
         out = self.run_qdstat(['--address'], r'\$management')
         parts = out.split("\n")
-        self.assertEqual(len(parts), 11)
+        self.assertEqual(len(parts), 12)
 
     def test_qdstat_no_args(self):
         outs = self.run_qdstat(args=None)

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -27,9 +27,9 @@ import re
 import time
 from subprocess import Popen, PIPE
 from qpid_dispatch.management.client import Node
-from system_test import TestCase, main_module, Qdrouterd, DIR, SkipIfNeeded
+from system_test import TestCase, main_module, Qdrouterd, QdManager, DIR, SkipIfNeeded
 from system_test import unittest
-from proton import SASL, Url, SSLDomain, SSLUnavailable
+from proton import SASL, Url, SSLDomain, SSLUnavailable, Message
 from proton.utils import BlockingConnection
 from distutils.version import StrictVersion
 import proton
@@ -87,6 +87,7 @@ class RouterTestSslClient(RouterTestSslBase):
     are being accepted through the related listener.
     """
     # Listener ports for each TLS protocol definition
+    PORT_CLEAR = 0
     PORT_TLS1 = 0
     PORT_TLS11 = 0
     PORT_TLS12 = 0
@@ -96,6 +97,7 @@ class RouterTestSslClient(RouterTestSslBase):
     PORT_TLS11_TLS12 = 0
     PORT_TLS_ALL = 0
     PORT_TLS_SASL = 0
+    PORT_TLS_LIVE = 0
     PORT_SSL3 = 0
     TIMEOUT = 3
 
@@ -198,6 +200,7 @@ class RouterTestSslClient(RouterTestSslBase):
                                  'mode': 'interior'})
 
         # Saving listener ports for each TLS definition
+        cls.PORT_CLEAR = cls.tester.get_port()
         cls.PORT_TLS1 = cls.tester.get_port()
         cls.PORT_TLS11 = cls.tester.get_port()
         cls.PORT_TLS12 = cls.tester.get_port()
@@ -207,10 +210,13 @@ class RouterTestSslClient(RouterTestSslBase):
         cls.PORT_TLS11_TLS12 = cls.tester.get_port()
         cls.PORT_TLS_ALL = cls.tester.get_port()
         cls.PORT_TLS_SASL = cls.tester.get_port()
+        cls.PORT_TLS_LIVE = cls.tester.get_port()
         cls.PORT_SSL3 = cls.tester.get_port()
 
         conf = [
             router,
+            # enclair
+            ('listener', {'host': '0.0.0.0', 'role': 'normal', 'port': cls.PORT_CLEAR, 'authenticatePeer': 'no'}),
             # TLSv1 only
             ('listener', {'host': '0.0.0.0', 'role': 'normal', 'port': cls.PORT_TLS1,
                           'authenticatePeer': 'no',
@@ -452,6 +458,76 @@ class RouterTestSslClient(RouterTestSslBase):
                 self.OPENSSL_ALLOW_TLSV1_2 and tlsv1_2,
                 self.OPENSSL_ALLOW_TLSV1_3 and tlsv1_3]
 
+    def inject_file(self, source_file, dest_file):
+        source_path = self.ssl_file(source_file)
+        url         = Url("amqp://0.0.0.0:%d" % self.PORT_CLEAR)
+        try:
+            connection = BlockingConnection(url, sasl_enabled=False, timeout=self.TIMEOUT)
+            sender     = connection.create_sender('_$qd.store_file')
+            fd         = open(source_path, "r")
+            body       = fd.read()
+            fd.close()
+            sender.send(Message(subject=dest_file, body=body))
+            connection.close()
+        except proton.Timeout:
+            return False
+        except proton.ConnectionException:
+            return False
+        except Exception as e:
+            print("Exception: %r" % e)
+            return False
+        return True
+
+    def create_ssl_profile(self, name, args):
+        url = Url("amqp://0.0.0.0:%d" % self.PORT_CLEAR)
+        try:
+            connection = BlockingConnection(url, sasl_enabled=False, timeout=self.TIMEOUT)
+            receiver   = connection.create_receiver(None, dynamic=True)
+            sender     = connection.create_sender('$management')
+            sender.send(Message(properties={'operation': 'CREATE',
+                                            'type': 'org.apache.qpid.dispatch.sslProfile',
+                                            'name': name},
+                                reply_to=receiver.remote_source.address,
+                                body=args))
+            reply = receiver.receive()
+            connection.close()
+            if reply.properties['statusCode'] > 299:
+                print("Create error: %d %s" % (reply.properties['statusCode'], reply.properties['statusDescription']))
+                return False
+        except proton.Timeout:
+            return False
+        except proton.ConnectionException:
+            return False
+        except Exception as e:
+            print("Exception: %r" % e)
+            return False
+        return True
+
+    def create_listener(self, name, args):
+        url = Url("amqp://0.0.0.0:%d" % self.PORT_CLEAR)
+        try:
+            connection = BlockingConnection(url, sasl_enabled=False, timeout=self.TIMEOUT)
+            receiver   = connection.create_receiver(None, dynamic=True)
+            sender     = connection.create_sender('$management')
+            sender.send(Message(properties={'operation': 'CREATE',
+                                            'type': 'org.apache.qpid.dispatch.listener',
+                                            'name': name},
+                                reply_to=receiver.remote_source.address,
+                                body=args))
+            reply = receiver.receive()
+            connection.close()
+            if reply.properties['statusCode'] > 299:
+                print("Create error: %d %s" % (reply.properties['statusCode'], reply.properties['statusDescription']))
+                return False
+        except proton.Timeout:
+            return False
+        except proton.ConnectionException:
+            return False
+        except Exception as e:
+            print("Exception: %r" % e)
+            return False
+        return True
+
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
     def test_tls1_only(self):
         """
@@ -515,6 +591,29 @@ class RouterTestSslClient(RouterTestSslBase):
         """
         self.assertEqual(self.get_expected_tls_result([True, True, True, True]),
                           self.get_allowed_protocols(self.PORT_TLS_ALL))
+
+    @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
+    def test_tls_live(self):
+        """
+        Expects all supported versions: TLSv1, TLSv1.1, TLSv1.2 and TLSv1.3 to be allowed
+        Uses a live-created listener and profile with injected certificate files.
+        """
+        self.inject_file("ca-certificate.pem",       "live-ca.pem")
+        self.inject_file("server-certificate.pem",   "live-server.pem")
+        self.inject_file("server-private-key.pem",   "live-key.pem")
+        self.inject_file("server-password-file.txt", "live-password.txt")
+        self.create_ssl_profile('ssl-profile-live',
+                                {'caCertFile': 'tmp:live-ca.pem',
+                                 'certFile': 'tmp:live-server.pem',
+                                 'privateKeyFile': 'tmp:live-key.pem',
+                                 'ciphers': 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:' \
+                                 'DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS',
+                                 'password': 'tmp:live-password.txt'})
+        self.create_listener('0.0.0.0/%s' % self.PORT_TLS_LIVE,
+                             {'host': '0.0.0.0', 'role': 'normal', 'port': self.PORT_TLS_LIVE,
+                              'authenticatePeer': 'no', 'sslProfile': 'ssl-profile-live'})
+        self.assertEqual(self.get_expected_tls_result([True, True, True, True]),
+                         self.get_allowed_protocols(self.PORT_TLS_LIVE))
 
     @SkipIfNeeded(RouterTestSslBase.DISABLE_SSL_TESTING, RouterTestSslBase.DISABLE_REASON)
     def test_ssl_invalid(self):

--- a/tests/system_tests_temp_file.py
+++ b/tests/system_tests_temp_file.py
@@ -1,0 +1,186 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+from time import sleep
+from threading import Event
+from threading import Timer
+
+from proton import Message, symbol
+from system_test import TestCase, Qdrouterd, main_module, TIMEOUT, DIR, MgmtMsgProxy, unittest, TestTimeout
+from proton.handlers import MessagingHandler
+from proton.reactor import Container
+
+class AddrTimer(object):
+    def __init__(self, parent):
+        self.parent = parent
+
+    def on_timer_task(self, event):
+        self.parent.check_address()
+
+
+class RouterTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Start a router"""
+        super(RouterTest, cls).setUpClass()
+
+        policy_config_path = os.path.join(DIR, 'policy-tempfile')
+
+        def router(name, mode, connection, extra=None):
+            config = [
+                ('router', {'mode': mode, 'id': name}),
+                connection
+            ]
+
+            if extra:
+                config.append(extra)
+            config = Qdrouterd.Config(config)
+            cls.routers.append(cls.tester.qdrouterd(name, config, wait=True))
+
+        cls.routers = []
+
+        router('OPEN', 'standalone', ('listener', {'port': cls.tester.get_port()}))
+        router('BLOCKED', 'standalone', ('listener', {'port': cls.tester.get_port(), 'policyVhost':'blocked'}),
+               ('policy', {'enableVhostPolicy':True, 'policyDir':policy_config_path}))
+        router('ALLOWED', 'standalone', ('listener', {'port': cls.tester.get_port(), 'policyVhost':'allowed'}),
+               ('policy', {'enableVhostPolicy':True, 'policyDir':policy_config_path}))
+        router('COUNT_TEST', 'standalone', ('listener', {'port': cls.tester.get_port(), 'policyVhost':'allowed'}),
+               ('policy', {'enableVhostPolicy':True, 'policyDir':policy_config_path}))
+
+
+    def test_01_temp_file_normal(self):
+        test = TempFileTest(self.routers[0].addresses[0], 'test.01', 100, 1, True)
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_02_no_subject(self):
+        test = TempFileTest(self.routers[0].addresses[0], None, 100, 1, False, 'amqp:invalid-field')
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_03_illegal_path_traversal(self):
+        test = TempFileTest(self.routers[0].addresses[0], '../test.03', 100, 1, False, 'amqp:invalid-field')
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_04_blocked_by_policy(self):
+        test = TempFileTest(self.routers[1].addresses[0], 'test.04', 100, 1, False, 'amqp:unauthorized-access')
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_05_allowed_by_policy(self):
+        test = TempFileTest(self.routers[2].addresses[0], 'test.05', 100, 1, True)
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_06_file_too_large(self):
+        test = TempFileTest(self.routers[2].addresses[0], 'test.06', 1000, 1, False, 'amqp:unauthorized-access')
+        test.run()
+        self.assertEqual(None, test.error)
+
+    def test_07_too_many_files(self):
+        test = TempFileTest(self.routers[3].addresses[0], 'test.07', 100, 20, False, 'amqp:unauthorized-access')
+        test.run()
+        self.assertEqual(None, test.error)
+
+
+class TempFileTest(MessagingHandler):
+    def __init__(self, host, filename, content_size, file_count, expect_pass, expect_error=None):
+        super(TempFileTest, self).__init__()
+        self.host         = host
+        self.filename     = filename
+        self.content_size = content_size
+        self.file_count   = file_count;
+        self.expect_pass  = expect_pass
+        self.expect_error = expect_error
+
+        self.error      = None
+        self.n_sent     = 0
+        self.n_settled  = 0
+        self.n_rejected = 0
+        self.condition  = None
+        self.conn       = None
+        self.sender     = None
+
+    def timeout(self):
+        self.error = "Timeout Expired - n_sent=%d n_settled=%d n_rejected=%d" % (self.n_sent, self.n_settled, self.n_rejected)
+        self.conn.close()
+
+    def fail(self, error):
+        self.error = error
+        self.conn.close()
+        self.timer.cancel()
+
+    def complete(self):
+        if self.expect_pass:
+            if self.n_rejected == 0:
+                self.fail(None)
+            else:
+                self.fail("Expected successful transfer - error: %r" % self.condition)
+        else:
+            if self.n_rejected == 0:
+                self.fail("Expected failed transfer - no rejections")
+            else:
+                if self.condition.name == self.expect_error:
+                    self.fail(None)
+                else:
+                    self.fail("Expected condition: %s Got %s" % (self.expect_error, self.condition.name))
+
+    def on_start(self, event):
+        self.timer   = event.reactor.schedule(TIMEOUT, TestTimeout(self))
+        self.conn    = event.container.connect(self.host)
+        self.sender  = event.container.create_sender(self.conn, '_$qd.store_file')
+
+    def on_sendable(self, event):
+        if event.sender == self.sender:
+            while self.sender.credit > 0 and self.n_sent < self.file_count:
+                chars   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                content = "".join(chars[c % len(chars)] for c in os.urandom(self.content_size))
+                subject = None
+                if self.filename:
+                    subject = "%s.%d" % (self.filename, self.n_sent)
+                msg = Message(subject=subject, body=content)
+                self.sender.send(msg)
+                self.n_sent += 1
+
+    def on_accepted(self, event):
+        self.n_settled += 1
+        if self.n_settled == self.n_sent:
+            self.complete()
+
+    def on_rejected(self, event):
+        self.n_settled  += 1
+        self.n_rejected += 1
+        self.condition = event.delivery.remote.condition
+        if self.n_settled == self.n_sent:
+            self.complete()
+
+    def run(self):
+        Container(self).run()
+
+
+if __name__== '__main__':
+    unittest.main(main_module())


### PR DESCRIPTION
…of temp files for SSL profiles.

Added policy and policy enforcement for the temporary file store.
Return appropriate disposition for messages handled.
Added a test for file transfer and the all the error/policy-reject cases.  This tests the disposition return path introduced in DISPATCH-1911.
Use "tmp:" prefix to refer to temporary files in sslProfile.