### PR TITLE
Make lsan  suppressions more specific and fix revealed leaks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,7 +121,7 @@ jobs:
             "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" \
             "-DCMAKE_BUILD_TYPE=${BuildType}" \
             "-GNinja" \
-            ${ProtonCMakeExtraArgs}
+            ${{env.ProtonCMakeExtraArgs}}
 
       - name: qpid-proton cmake build/install
         run: cmake --build "${ProtonBuildDir}" --config ${BuildType} -t install
@@ -137,7 +137,7 @@ jobs:
             "-DCMAKE_BUILD_TYPE=${BuildType}" \
             "-DPYTHON_TEST_COMMAND='-m;pytest;-vs;--junit-prefix=pytest.\${py_test_module};--junit-xml=junitxmls/\${py_test_module}.xml;--pyargs;\${py_test_module}'" \
             "-GNinja" \
-            ${DispatchCMakeExtraArgs}
+            ${{env.DispatchCMakeExtraArgs}}
 
       - name: qpid-dispatch cmake build/install
         run: cmake --build "${DispatchBuildDir}" --config ${BuildType} -t install

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -2169,12 +2169,12 @@ void qd_router_free(qd_router_t *router)
 
     qd_container_set_default_node_type(router->qd, 0, 0, QD_DIST_BOTH);
 
+    qd_router_python_free(router);
     qdr_core_free(router->router_core);
     qd_tracemask_free(router->tracemask);
     qd_timer_free(router->timer);
     sys_mutex_free(router->lock);
     qd_router_configure_free(router);
-    qd_router_python_free(router);
 
     free(router);
     qd_router_id_finalize();

--- a/src/router_pynode.c
+++ b/src/router_pynode.c
@@ -308,11 +308,12 @@ static PyMethodDef RouterAdapter_methods[] = {
 
 static PyTypeObject RouterAdapterType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "dispatch.RouterAdapter",  /* tp_name*/
-    .tp_basicsize = sizeof(RouterAdapter),     /* tp_basicsize*/
-    .tp_flags = Py_TPFLAGS_DEFAULT,        /* tp_flags*/
-    .tp_doc = "Dispatch Router Adapter", /* tp_doc */
-    .tp_methods = RouterAdapter_methods,     /* tp_methods */
+    .tp_name = "dispatch.RouterAdapter",
+    .tp_basicsize = sizeof(RouterAdapter),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Dispatch Router Adapter",
+    .tp_methods = RouterAdapter_methods,
+    .tp_new = PyType_GenericNew,
 };
 
 
@@ -393,7 +394,6 @@ qd_error_t qd_router_python_setup(qd_router_t *router)
         return QD_ERROR_NONE;
 
     PyObject *pDispatchModule = qd_python_module();
-    RouterAdapterType.tp_new = PyType_GenericNew;
     PyType_Ready(&RouterAdapterType);
     QD_ERROR_PY_RET();
 
@@ -443,6 +443,7 @@ qd_error_t qd_router_python_setup(qd_router_t *router)
     // Instantiate the router
     //
     pyRouter = PyObject_CallObject(pClass, pArgs);
+    Py_DECREF(pClass);
     Py_DECREF(pArgs);
     Py_DECREF(adapterType);
     QD_ERROR_PY_RET();
@@ -455,7 +456,12 @@ qd_error_t qd_router_python_setup(qd_router_t *router)
 }
 
 void qd_router_python_free(qd_router_t *router) {
-    // empty
+    Py_XDECREF(pyRouter);
+    Py_XDECREF(pyTick);
+    Py_XDECREF(pySetMobileSeq);
+    Py_XDECREF(pySetMyMobileSeq);
+    Py_XDECREF(pyLinkLost);
+//    qd_python_finalize();
 }
 
 

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -3,9 +3,6 @@
 #
 
 # to be triaged; pretty much all tests
-leak:^IoAdapter_init$
-
-# to be triaged; pretty much all tests
 leak:^load_server_config$
 
 # to be triaged; system_tests_autolinks


### PR DESCRIPTION
I did not finish with making this leak free yet. It is quite difficult for me to predict what happens as I make (pretty significant :( changes all around... Currently, my biggest problem is that after I allow Python to collect the circular object subgraph including IoAdapter, the collection is happening too late in the shutdown, where I cannot no longer schedule actions:

```
14: ==30770==ERROR: AddressSanitizer: heap-use-after-free on address 0x61a00003a8f0 at pc 0x7f321b4e7dae bp 0x7ffd94518bd0 sp 0x7ffd94518bc8
14: READ of size 8 at 0x61a00003a8f0 thread T0
14:     #0 0x7f321b4e7dad in qdr_action_enqueue ../src/router_core/router_core.c:399
14:     #1 0x7f321b5043db in qdr_core_unsubscribe ../src/router_core/route_tables.c:173
14:     #2 0x7f321b453b0c in IoAdapter_dealloc ../src/python_embedded.c:737
14:     #3 0x7f321ac861ad in list_dealloc (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x1371ad)
14:     #4 0x7f321ac9e59a in dict_dealloc (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x14f59a)
14:     #5 0x7f321acb8138 in subtype_clear (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x169138)
14:     #6 0x7f321ad115d0 in collect.constprop.0 (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x1c25d0)
14:     #7 0x7f321ad72670 in collect_with_callback.constprop.0 (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x223670)
14:     #8 0x7f321ad7275d in PyGC_Collect (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x22375d)
14:     #9 0x7f321ad68d0b in Py_FinalizeEx (/nix/store/0yhk4sk4x9s9hsrf3p1skbfy1pwd1rbf-python3-3.8.5/lib/libpython3.8.so.1.0+0x219d0b)
14:     #10 0x7f321b454cc6 in qd_python_finalize ../src/python_embedded.c:73
14:     #11 0x7f321b3fb0f1 in qd_dispatch_free ../src/dispatch.c:388
14:     #12 0x402625 in main_process ../router/src/main.c:117
14:     #13 0x403f4b in main ../router/src/main.c:367
14:     #14 0x7f321a047cbc in __libc_start_main (/nix/store/q53f5birhik4dxg3q3r2g5f324n7r5mc-glibc-2.31-74/lib/libc.so.6+0x23cbc)
14:     #15 0x402419 in _start (/home/jdanek/repos/qpid/qpid-dispatch/cmake-build-debug/router/qdrouterd+0x402419)
```

I could not figure out what is keeping the object subgraph alive so that it does not get collected sooner, when I want it to be destroyed.

Also, the suppressions need to be tried on all supported platforms, because each Python version, etc. can leak differently. And as the Jira shows, suppressing all leaky traces that include Python is not a good solution, because it suppresses too much (incl. the IoAdapter leak; admittedly not super-serious, but this is a matter of principle! `)