### PR TITLE
WIP do not merge: DISPATCH-1968: tcp self test echo server exits when data comes in

### DIFF
--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -374,7 +374,7 @@ class TcpAdaptor(TestCase):
             cls.logger.log("TCP_TEST Launching echo server '%s'" % server_prefix)
             server = TcpEchoServer(prefix=server_prefix,
                                    port=cls.tcp_server_listener_ports[rtr],
-                                   logger=server_logger)
+                                   logger=server_logger, d1968=True)
             assert server.is_running
             cls.echo_servers[rtr] = server
 


### PR DESCRIPTION
This patch is for testing DISPATCH-1968 only.

In this patch the tcp echo server used in system_tests_tcp_adaptor is modified to close the connection to the tcp connector as soon as any data is received.

The tcp tests normally close the tcpListener's connection from the echo client and the closure propagates through dispatch so that the connection through the tcpConnector is initiated from the dispatch side. Normal self tests never close the tcpConnector's connection from the network side.

This self test patch provides an easy test bed for investigating what goes wrong when a server disconnects.