### PR TITLE
DISPATCH-1962 Make LSan suppressions more targeted and specific

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,7 @@ jobs:
         -DCONSOLE_INSTALL=OFF
         -DUSE_BWRAP=ON
         -DRUNTIME_CHECK=${{matrix.runtimeCheck}}
+        -DSANITIZE_3RD_PARTY=ON
 
       CCACHE_BASEDIR: ${{github.workspace}}
       CCACHE_DIR: ${{github.workspace}}/.ccache

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -106,9 +106,17 @@ elseif(RUNTIME_CHECK STREQUAL "asan")
     message(FATAL_ERROR "libubsan not installed - address sanitizer not available")
   endif(UBSAN_LIBRARY-NOTFOUND)
   message(STATUS "Runtime memory checker: gcc/clang address sanitizers")
+  option(SANITIZE_3RD_PARTY "Detect leaks in 3rd party libraries used by Dispatch while running tests" OFF)
+  file (COPY "${CMAKE_SOURCE_DIR}/tests/lsan.supp" DESTINATION "${CMAKE_BINARY_DIR}/tests")
+  if (NOT SANITIZE_3RD_PARTY)
+    # Append wholesale library suppressions
+    #  this is necessary if target system does not have debug symbols for these libraries installed
+    #  and therefore the more specific suppressions do not match
+    file(APPEND "${CMAKE_BINARY_DIR}/tests/lsan.supp" "\nleak:/libpython2.*.so\nleak:/libpython3.*.so\n")
+  endif ()
   set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -fsanitize=address,undefined")
   set(RUNTIME_ASAN_ENV_OPTIONS "detect_leaks=true suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
-  set(RUNTIME_LSAN_ENV_OPTIONS "suppressions=${CMAKE_SOURCE_DIR}/tests/lsan.supp")
+  set(RUNTIME_LSAN_ENV_OPTIONS "suppressions=${CMAKE_BINARY_DIR}/tests/lsan.supp")
 
 elseif(RUNTIME_CHECK STREQUAL "tsan")
   assert_has_sanitizers()

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
                       <exclude>**/tsan.supp</exclude>
                       <exclude>**/asan.supp</exclude>
                       <exclude>**/lsan.supp</exclude>
+                      <exclude>**/lsan_3rdparty.supp</exclude>
                       <exclude>**/*.json.in</exclude>
                       <exclude>**/*.json</exclude>
                       <exclude>**/*.svg</exclude>

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -10,6 +10,27 @@ leak:qd_policy_c_counts_alloc
 leak:qd_policy_open_fetch_settings
 leak:qdr_error_description
 
+# to be triaged; unit_tests
+leak:http-libwebsockets.c
+
+# to be triaged; pretty much all tests
+leak:^IoAdapter_init$
+
+# to be triaged; system_tests_http
+leak:^callback_healthz$
+leak:^callback_metrics$
+
+# to be triaged; system_tests_http1_adaptor
+leak:^pn_condition$
+leak:^pn_raw_connection$
+leak:^pgetaddrinfo$
+
+# to be triaged; system_tests_link_routes
+leak:^pni_init_default_logger$
+
+# Ignore test code
+leak:run_unit_tests.c
+
 # DISPATCH-1844 - shutdown leak
 leak:sys_mutex
 
@@ -23,15 +44,56 @@ leak:_ctypes_alloc_format_string
 leak:__strdup
 
 ####
-#### Miscellaneous 3rd party libraries, test code, etc:
+#### Miscellaneous 3rd party libraries:
 ####
 
-leak:*libpython*
-leak:*libwebsockets*
-leak:*python2*
+### Python
 
-# We should be able to uncomment these once all known dispatch leaks have been fixed
-leak:*libqpid-proton*
+# these Python leaks happen even after simple Py_Initialize(); Py_Finalize();
+#  https://bugs.python.org/issue1635741
+leak:^_PyObject_Realloc
+leak:^PyObject_Malloc$
+leak:^PyThread_allocate_lock$
 
-# Ignore test code
-leak:run_unit_tests.c
+# the PyMalloc mechanism is incompatible with Valgrind, it must be disabled or reported "leaks" must be suppressed
+#  https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_python.html#debug-version-of-python-memory-alloc-label
+leak:^PyMem_Malloc$
+leak:^PyMem_Calloc$
+leak:^_PyObject_GC_Resize$
+# Python uses these alloc functions if you define PYTHONDEVMODE=1
+leak:^_PyMem_DebugRawAlloc$
+leak:^_PyMem_DebugRawRealloc$
+# All the rest
+leak:^list_append$
+leak:^list_resize$
+leak:^_PyBytes_Resize$
+leak:^resize_compact$
+leak:^unicode_resize$
+# Python 2.7
+leak:^PyString_FromStringAndSize$
+leak:^PyString_FromString$
+leak:^PyObject_Realloc$
+leak:^_PyObject_GC_Malloc$
+leak:^_PyString_Resize$
+leak:^PyUnicodeUCS4_FromUnicode$
+leak:^PyList_Append$
+leak:^PyList_New$
+
+### Qpid Proton
+
+# Proton suppressions taken from Proton's lsan.supp
+#  this appears in system_tests_open_properties:
+leak:^pni_data_grow$
+leak:^pn_buffer$
+leak:^pn_buffer_ensure$
+#  this appears in system_tests_http1_adaptor:
+leak:^pn_string_grow$
+leak:^pn_object_new$
+leak:^pn_list$
+leak:^pni_record_create$
+
+### libwebsockets
+
+leak:/libwebsockets.so
+
+### CMake will append .so 3rd party suppressions here, unless disabled:

--- a/tests/lsan_3rdparty.supp
+++ b/tests/lsan_3rdparty.supp
@@ -1,0 +1,4 @@
+# 3rd party lsan suppressions
+
+leak:/libpython2.*.so
+leak:/libpython3.*.so


### PR DESCRIPTION
This introduces build option -DSANITIZE_3RD_PARTY, defaulted to OFF. The reason is that targeted suppressions only work when the .so libraries are installed with debug symbols, which is not always the case.

Leaks are suppressed more granularly. I have already ideas about fixing some of them, but I wanted to make their suppressions explicit in this way first.