### PR TITLE
DISPATCH-1962 Fix qdr_core_t leak in run_unit_tests.c

### DIFF
--- a/tests/core_timer_test.c
+++ b/tests/core_timer_test.c
@@ -170,6 +170,7 @@ static char* test_core_timer(void *context)
     //
     for (long i = 0; i < 5; i++)
         qdr_core_timer_free_CT(core, timers[i]);
+    free(core);
 
     return 0;
 }

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -28,9 +28,6 @@ leak:^pgetaddrinfo$
 # to be triaged; system_tests_link_routes
 leak:^pni_init_default_logger$
 
-# Ignore test code
-leak:run_unit_tests.c
-
 # DISPATCH-1844 - shutdown leak
 leak:sys_mutex
 


### PR DESCRIPTION
As explained on the Jira, suppressing all leaks from unittests is kind of silly, because it can hide leaks in production code which would be otherwise easy to diagnose, if unittests could reveal them. The leak here is only in test code and it is easy to fix.

```
9: Test Case thread_tests.test_condition: PASS
9: 
9: =================================================================
9: ==19457==ERROR: LeakSanitizer: detected memory leaks
9: 
9: Direct leak of 1160 byte(s) in 1 object(s) allocated from:
9:     #0 0x7fe6d5751e8f in __interceptor_malloc (/nix/store/g40sl3zh3nv52vj0mrl4iki5iphh5ika-gcc-10.2.0-lib/lib/libasan.so.6+0xace8f)
9:     #1 0x40d9fe in qd_malloc ../include/qpid/dispatch/ctools.h:229
9:     #2 0x40d9fe in test_core_timer ../tests/core_timer_test.c:37
9:     #3 0x40e4b2 in core_timer_tests ../tests/core_timer_test.c:183
9:     #4 0x406c83 in main ../tests/run_unit_tests.c:69
9:     #5 0x7fe6d3ccbcbc in __libc_start_main (/nix/store/q53f5birhik4dxg3q3r2g5f324n7r5mc-glibc-2.31-74/lib/libc.so.6+0x23cbc)
9: 
9: -----------------------------------------------------
9: Suppressions used:
9:   count      bytes template
9:       1         56 qdr_core_subscribe
9:     572     916269 ^_PyMem_DebugRawAlloc$
9:       5       3296 ^_PyMem_DebugRawRealloc$
9: -----------------------------------------------------
9: 
9: SUMMARY: AddressSanitizer: 1160 byte(s) leaked in 1 allocation(s).
```