### PR TITLE
DISPATCH-1844 Leak of sys_mutex

### DIFF
--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -33,9 +33,6 @@ leak:^pgetaddrinfo$
 # to be triaged; system_tests_link_routes
 leak:^pni_init_default_logger$
 
-# DISPATCH-1844 - shutdown leak
-leak:sys_mutex
-
 # expected, not a bug:
 #
 leak:qdr_core_subscribe


### PR DESCRIPTION
```
69: ../src/router_core/core_link_endpoint.c:124:24: runtime error: store to misaligned address 0x616000147d9c for type 'uint64_t', which requires 8 byte alignment
69: 0x616000147d9c: note: pointer points here
69:   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
69:               ^ 
69: 
69: =================================================================
69: ==3434==ERROR: LeakSanitizer: detected memory leaks
69: 
69: Direct leak of 64 byte(s) in 1 object(s) allocated from:
69:     #0 0x7f9b999adaa5 in posix_memalign (/lib/x86_64-linux-gnu/libasan.so.5+0x10eaa5)
69:     #1 0x7f9b991917f4 in sys_mutex ../src/posix/threading.c:41
69:     #2 0x7f9b9914e927 in qd_message ../src/message.c:1012
69:     #3 0x7f9b992fdbbf in create_http2_stream_data ../src/adaptors/http2/http2_adaptor.c:399
69:     #4 0x7f9b993197f0 in qdr_http_deliver ../src/adaptors/http2/http2_adaptor.c:1816
69:     #5 0x7f9b9926e866 in qdr_link_process_deliveries ../src/router_core/transfer.c:175
69:     #6 0x7f9b991c7d91 in qdr_connection_process ../src/router_core/connections.c:412
69:     #7 0x7f9b9931ab70 in handle_connection_event ../src/adaptors/http2/http2_adaptor.c:2293
69:     #8 0x7f9b992ce085 in handle_event_with_context ../src/server.c:804
69:     #9 0x7f9b992ce085 in do_handle_raw_connection_event ../src/server.c:810
69:     #10 0x7f9b992ce085 in handle ../src/server.c:1090
69:     #11 0x7f9b992d65b5 in thread_run ../src/server.c:1122
69:     #12 0x7f9b992d8aca in qd_server_run ../src/server.c:1484
69:     #13 0x55c9b5e061bc in main_process ../router/src/main.c:113
69:     #14 0x55c9b5e05ce0 in main ../router/src/main.c:367
69:     #15 0x7f9b9802a0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
69: 
69: -----------------------------------------------------
69: Suppressions used:
69:   count      bytes template
69:       7        465 qd_dispatch_configure_connector
69:       7         65 load_server_config
69:       1         64 qd_message_receive
69:       1         24 ^pn_condition$
69:       1       1536 ^pn_raw_connection$
69:       1         56 qdr_core_subscribe
69:      10       5656 ^_PyObject_Realloc
69:     541     863651 ^PyObject_Malloc$
69:       1         32 ^PyThread_allocate_lock$
69:       4       9897 ^PyMem_Malloc$
69:       1        856 ^_PyObject_GC_Resize$
69:       5        248 ^pn_object_new$
69:       1        128 ^pn_list$
69:       2         48 ^pni_record_create$
69: -----------------------------------------------------
69: 
69: SUMMARY: AddressSanitizer: 64 byte(s) leaked in 1 allocation(s).
69: 
69: <<<<
69: 
69: Router EDGE.A command file:
69: >>>>
69: qdrouterd -c edge-router.conf -I /home/runner/work/qpid-dispatch/qpid-dispatch/qpid-dispatch/python
69: pid=3434
```


```
69: 0x616000147d9c: note: pointer points here
69:   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
69:               ^ 
69: 
69: =================================================================
69: ==3434==ERROR: LeakSanitizer: detected memory leaks
69: 
69: Direct leak of 64 byte(s) in 1 object(s) allocated from:
69:     #0 0x7f9b999adaa5 in posix_memalign (/lib/x86_64-linux-gnu/libasan.so.5+0x10eaa5)
69:     #1 0x7f9b991917f4 in sys_mutex ../src/posix/threading.c:41
69:     #2 0x7f9b9914e927 in qd_message ../src/message.c:1012
69:     #3 0x7f9b992fdbbf in create_http2_stream_data ../src/adaptors/http2/http2_adaptor.c:399
69:     #4 0x7f9b993197f0 in qdr_http_deliver ../src/adaptors/http2/http2_adaptor.c:1816
69:     #5 0x7f9b9926e866 in qdr_link_process_deliveries ../src/router_core/transfer.c:175
69:     #6 0x7f9b991c7d91 in qdr_connection_process ../src/router_core/connections.c:412
69:     #7 0x7f9b9931ab70 in handle_connection_event ../src/adaptors/http2/http2_adaptor.c:2293
69:     #8 0x7f9b992ce085 in handle_event_with_context ../src/server.c:804
69:     #9 0x7f9b992ce085 in do_handle_raw_connection_event ../src/server.c:810
69:     #10 0x7f9b992ce085 in handle ../src/server.c:1090
69:     #11 0x7f9b992d65b5 in thread_run ../src/server.c:1122
69:     #12 0x7f9b992d8aca in qd_server_run ../src/server.c:1484
69:     #13 0x55c9b5e061bc in main_process ../router/src/main.c:113
69:     #14 0x55c9b5e05ce0 in main ../router/src/main.c:367
69:     #15 0x7f9b9802a0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
69: 
69: -----------------------------------------------------
69: Suppressions used:
69:   count      bytes template
69:       7        465 qd_dispatch_configure_connector
69:       7         65 load_server_config
69:       1         64 qd_message_receive
69:       1         24 ^pn_condition$
69:       1       1536 ^pn_raw_connection$
69:       1         56 qdr_core_subscribe
69:      10       5656 ^_PyObject_Realloc
69:     541     863651 ^PyObject_Malloc$
69:       1         32 ^PyThread_allocate_lock$
69:       4       9897 ^PyMem_Malloc$
69:       1        856 ^_PyObject_GC_Resize$
69:       5        248 ^pn_object_new$
69:       1        128 ^pn_list$
69:       2         48 ^pni_record_create$
69: -----------------------------------------------------
69: 
69: SUMMARY: AddressSanitizer: 64 byte(s) leaked in 1 allocation(s).
69: <<<<
69: 
69: ----------------------------------------------------------------------
69: Ran 77 tests in 93.566s
69: 
69: FAILED (errors=1)
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
69: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
35/37 Test #69: system_tests_http2 .............................***Failed   98.74 sec
```