### PR TITLE
DISPATCH-1962 Fix leak of qdr_core_subscribe

### DIFF
--- a/src/router_core/modules/mobile_sync/mobile.c
+++ b/src/router_core/modules/mobile_sync/mobile.c
@@ -939,9 +939,8 @@ static void qcm_mobile_sync_final_CT(void *module_context)
     qdrc_event_unsubscribe_CT(msync->core, msync->event_sub);
     qdr_core_timer_free_CT(msync->core, msync->timer);
 
-    //
-    // Don't explicitly unsubscribe the addresses, these are already gone at module-final time.
-    //
+    qdr_core_unsubscribe(msync->message_sub1);
+    qdr_core_unsubscribe(msync->message_sub2);
 
     free(msync);
 }

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -36,10 +36,6 @@ leak:^pni_init_default_logger$
 # DISPATCH-1844 - shutdown leak
 leak:sys_mutex
 
-# expected, not a bug:
-#
-leak:qdr_core_subscribe
-
 # Ubuntu 16.04 (Xenial)
 #
 leak:_ctypes_alloc_format_string


### PR DESCRIPTION
This PR is simply to show that "a solution exists". I have no idea whether I am on the right track here, or not.

The original problem is

```
14: 2021-02-20 20:54:08.332325 +0100 SERVER (info) [C2] Closing connection on shutdown (../src/server.c:1377)
14: 
14: <<<<
14: 
14: Router QDR.A output file:
14: >>>>
14: 
14: =================================================================
14: ==28365==ERROR: LeakSanitizer: detected memory leaks
14: 
14: Direct leak of 56 byte(s) in 1 object(s) allocated from:
14:     #0 0x7f8503a7ce8f in __interceptor_malloc (/nix/store/g40sl3zh3nv52vj0mrl4iki5iphh5ika-gcc-10.2.0-lib/lib/libasan.so.6+0xace8f)
14:     #1 0x7f85034afd42 in qd_malloc ../include/qpid/dispatch/ctools.h:229
14:     #2 0x7f85034afd42 in qdr_core_subscribe ../src/router_core/route_tables.c:149
14:     #3 0x7f85034f4962 in qcm_mobile_sync_init_CT ../src/router_core/modules/mobile_sync/mobile.c:919
14:     #4 0x7f85034a79d1 in qdr_modules_init ../src/router_core/router_core_thread.c:120
14:     #5 0x7f850348e889 in qdr_core_setup_init ../src/router_core/router_core.c:60
14:     #6 0x7f8503491971 in qdr_core ../src/router_core/router_core.c:116
14:     #7 0x7f8503505949 in qd_router_setup_late ../src/router_node.c:2071
14:     #8 0x7f84fee08abc in ffi_call_unix64 (/nix/store/m8y5mz1f0al3rg3b56rq5bza49jjxnc0-libffi-3.3/lib/libffi.so.7+0x7abc)
14:     #9 0x7fff297a166f  ([stack]+0x1e66f)
14: 
14: Direct leak of 56 byte(s) in 1 object(s) allocated from:
14:     #0 0x7f8503a7ce8f in __interceptor_malloc (/nix/store/g40sl3zh3nv52vj0mrl4iki5iphh5ika-gcc-10.2.0-lib/lib/libasan.so.6+0xace8f)
14:     #1 0x7f85034afd42 in qd_malloc ../include/qpid/dispatch/ctools.h:229
14:     #2 0x7f85034afd42 in qdr_core_subscribe ../src/router_core/route_tables.c:149
14:     #3 0x7f85034f49d3 in qcm_mobile_sync_init_CT ../src/router_core/modules/mobile_sync/mobile.c:921
14:     #4 0x7f85034a79d1 in qdr_modules_init ../src/router_core/router_core_thread.c:120
14:     #5 0x7f850348e889 in qdr_core_setup_init ../src/router_core/router_core.c:60
14:     #6 0x7f8503491971 in qdr_core ../src/router_core/router_core.c:116
14:     #7 0x7f8503505949 in qd_router_setup_late ../src/router_node.c:2071
14:     #8 0x7f84fee08abc in ffi_call_unix64 (/nix/store/m8y5mz1f0al3rg3b56rq5bza49jjxnc0-libffi-3.3/lib/libffi.so.7+0x7abc)
14:     #9 0x7fff297a166f  ([stack]+0x1e66f)
14: 
14: -----------------------------------------------------
14: Suppressions used:
14:   count      bytes template
14:       4        224 ^IoAdapter_init$
14:       4       2560 ^_PyObject_Realloc
14:     558     883628 ^PyObject_Malloc$
14:       1         32 ^PyThread_allocate_lock$
14:       4       9897 ^PyMem_Malloc$
14:       1        840 ^_PyObject_GC_Resize$
14:       1       1184 ^list_append$
14: -----------------------------------------------------
14: 
14: SUMMARY: AddressSanitizer: 112 byte(s) leaked in 2 allocation(s).
```

If I want to free this, I have to reorder things in `qdr_core_free` so that the finalizers don't try to use something that was already freed:

If I don't move `qdr_modules_finalize` before the `discard any left over actions` block, I get the following, because the lock is already freed

```
16: qdrouterd: ../src/posix/threading.c:58: sys_mutex_lock: Assertion `result == 0' failed.
```

And if I run `qcm_edge_router_final_CT` (`src/router_core/modules/edge_router/module.c:59`} before `qdrc_endpoint_do_cleanup_CT` (`src/router_core/core_link_endpoint.c:241`), I get

```
16: ==16076==ERROR: AddressSanitizer: heap-use-after-free on address 0x60c0000035f0 at pc 0x7ff5117d60bc bp 0x7fffd457e1f0 sp 0x7fffd457e1e8
16: READ of size 8 at 0x60c0000035f0 thread T0
16:     #0 0x7ff5117d60bb in qdrc_endpoint_do_cleanup_CT ../src/router_core/core_link_endpoint.c:241
16:     #1 0x7ff51182e3ea in qdr_core_free ../src/router_core/router_core.c:230
16:     #2 0x7ff511891ecb in qd_router_free ../src/router_node.c:2108
16:     #3 0x7ff511732229 in qd_dispatch_free ../src/dispatch.c:368
16:     #4 0x402625 in main_process ../router/src/main.c:117
16:     #5 0x403f4b in main ../router/src/main.c:367
16:     #6 0x7ff510382cbc in __libc_start_main (/nix/store/q53f5birhik4dxg3q3r2g5f324n7r5mc-glibc-2.31-74/lib/libc.so.6+0x23cbc)
16:     #7 0x402419 in _start (/home/jdanek/repos/qpid/qpid-dispatch/cmake-build-debug/router/qdrouterd+0x402419)
16: 
16: 0x60c0000035f0 is located 112 bytes inside of 120-byte region [0x60c000003580,0x60c0000035f8)
16: freed by thread T0 here:
16:     #0 0x7ff511e08b6f in __interceptor_free (/nix/store/g40sl3zh3nv52vj0mrl4iki5iphh5ika-gcc-10.2.0-lib/lib/libasan.so.6+0xacb6f)
16:     #1 0x7ff51185abe9 in qcm_edge_addr_proxy_final ../src/router_core/modules/edge_router/addr_proxy.c:593
16:     #2 0x7ff511856fcd in qcm_edge_router_final_CT ../src/router_core/modules/edge_router/module.c:59
16:     #3 0x7ff511833d61 in qdr_modules_finalize ../src/router_core/router_core_thread.c:139
16:     #4 0x7ff51182c3ff in qdr_core_free ../src/router_core/router_core.c:146
16:     #5 0x7ff511891ecb in qd_router_free ../src/router_node.c:2108
16:     #6 0x7ff511732229 in qd_dispatch_free ../src/dispatch.c:368
16:     #7 0x402625 in main_process ../router/src/main.c:117
16:     #8 0x403f4b in main ../router/src/main.c:367
16:     #9 0x7ff510382cbc in __libc_start_main (/nix/store/q53f5birhik4dxg3q3r2g5f324n7r5mc-glibc-2.31-74/lib/libc.so.6+0x23cbc)
16: 
16: previously allocated by thread T0 here:
16:     #0 0x7ff511e08e8f in __interceptor_malloc (/nix/store/g40sl3zh3nv52vj0mrl4iki5iphh5ika-gcc-10.2.0-lib/lib/libasan.so.6+0xace8f)
16:     #1 0x7ff51185a75b in qd_malloc ../include/qpid/dispatch/ctools.h:229
16:     #2 0x7ff51185a75b in qcm_edge_addr_proxy ../src/router_core/modules/edge_router/addr_proxy.c:545
16:     #3 0x7ff511857164 in qcm_edge_router_init_CT ../src/router_core/modules/edge_router/module.c:46
16:     #4 0x7ff5118339d1 in qdr_modules_init ../src/router_core/router_core_thread.c:120
16:     #5 0x7ff51181a889 in qdr_core_setup_init ../src/router_core/router_core.c:60
16:     #6 0x7ff51181d971 in qdr_core ../src/router_core/router_core.c:116
16:     #7 0x7ff511891a29 in qd_router_setup_late ../src/router_node.c:2071
16:     #8 0x7ff50d10eabc in ffi_call_unix64 (/nix/store/m8y5mz1f0al3rg3b56rq5bza49jjxnc0-libffi-3.3/lib/libffi.so.7+0x7abc)
16:     #9 0x7fffd457dd1f  ([stack]+0x1ed1f)
```