### PR TITLE
DISPATCH-1981: Self test to force Q2 flow control

### DIFF
--- a/tests/TCP_echo_server.py
+++ b/tests/TCP_echo_server.py
@@ -48,7 +48,6 @@ class ClientRecord(object):
     the inbound and outbound data list buffers for this
     socket's payload.
     """
-
     def __init__(self, address):
         self.addr = address
         self.inb = b''
@@ -89,7 +88,8 @@ def split_chunk_for_display(raw_bytes):
 
 class TcpEchoServer:
 
-    def __init__(self, prefix="ECHO_SERVER", port="0", echo_count=0, timeout=0.0, logger=None):
+    def __init__(self, prefix="ECHO_SERVER", port="0", echo_count=0, timeout=0.0, logger=None,
+                 conn_stall=0.0, close_on_conn=False, close_on_data=False):
         """
         Start echo server in separate thread
 
@@ -106,6 +106,9 @@ class TcpEchoServer:
         self.echo_count = echo_count
         self.timeout = timeout
         self.logger = logger
+        self.conn_stall = conn_stall
+        self.close_on_conn = close_on_conn
+        self.close_on_data = close_on_data
         self.keep_running = True
         self.HOST = '127.0.0.1'
         self.is_running = False
@@ -117,7 +120,12 @@ class TcpEchoServer:
 
     def run(self):
         """
-        Run server in daemon thread
+        Run server in daemon thread.
+        A single thread runs multiple sockets through selectors.
+        Note that timeouts and such are done in line and processing stops for
+        all sockets when one socket is timing out. If you plan on using many
+        busy connections this strategy is not that great but it works for
+        the intended one-at-a-time test cases.
         :return:
         """
         try:
@@ -162,11 +170,12 @@ class TcpEchoServer:
                     for key, mask in events:
                         if key.data is None:
                             if key.fileobj is self.sock:
-                                self.do_accept(key.fileobj, sel, self.logger)
+                                self.do_accept(key.fileobj, sel, self.logger, self.conn_stall, self.close_on_conn)
                             else:
                                 pass  # Only listener 'sock' has None in opaque data field
                         else:
-                            total_echoed += self.do_service(key, mask, sel, self.logger)
+                            n_echoed = self.do_service(key, mask, sel, self.logger, self.close_on_data)
+                            total_echoed += n_echoed if n_echoed > 0 else 0
                 else:
                     pass   # select timeout. probably.
 
@@ -178,14 +187,22 @@ class TcpEchoServer:
 
         self.is_running = False
 
-    def do_accept(self, sock, sel, logger):
+    def do_accept(self, sock, sel, logger, conn_stall, close_on_conn):
         conn, addr = sock.accept()
         logger.log('%s Accepted connection from %s:%d' % (self.prefix, addr[0], addr[1]))
+        if conn_stall > 0.0:
+            logger.log('%s Connection from %s:%d stall start' % (self.prefix, addr[0], addr[1]))
+            time.sleep(conn_stall)
+            logger.log('%s Connection from %s:%d stall end' % (self.prefix, addr[0], addr[1]))
+        if close_on_conn:
+            logger.log('%s Connection from %s:%d closing due to close_on_conn' % (self.prefix, addr[0], addr[1]))
+            conn.close()
+            return
         conn.setblocking(False)
         events = selectors.EVENT_READ | selectors.EVENT_WRITE
         sel.register(conn, events, data=ClientRecord(addr))
 
-    def do_service(self, key, mask, sel, logger):
+    def do_service(self, key, mask, sel, logger, close_on_data):
         retval = 0
         sock = key.fileobj
         data = key.data
@@ -207,6 +224,11 @@ class TcpEchoServer:
                 return 1
             if recv_data:
                 data.outb += recv_data
+                if close_on_data:
+                    logger.log('%s Connection to %s:%d closed due to close_on_data' % (self.prefix, data.addr[0], data.addr[1]))
+                    sel.unregister(sock)
+                    sock.close()
+                    return 0
                 logger.log('%s read from: %s:%d len:%d: %s' % (self.prefix, data.addr[0], data.addr[1], len(recv_data),
                                                                split_chunk_for_display(recv_data)))
                 sel.modify(sock, selectors.EVENT_READ | selectors.EVENT_WRITE, data=data)
@@ -261,10 +283,22 @@ def main(argv):
     p.add_argument('--echo', '-e', type=int, default=0, const=1, nargs="?",
                    help='Exit after echoing this many bytes. Default value "0" disables exiting on byte count.')
     p.add_argument('--timeout', '-t', type=float, default=0.0, const=1, nargs="?",
-                   help='Timeout in seconds. Default value "0" disables timeouts')
+                   help='Timeout in seconds. Default value "0.0" disables timeouts')
     p.add_argument('--log', '-l',
                    action='store_true',
                    help='Write activity log to console')
+    # Add controlled server misbehavior for testing conditions seen in the field
+    # Stall required to trigger Q2 testing for DISPATCH-1947 and improving test DISPATCH-1981
+    p.add_argument('--connect-stall', type=float, default=0.0, const=1, nargs="?",
+                   help='Accept connections but wait this many seconds before reading from socket. Default value "0.0" disables stall')
+    # Close on connect - exercises control paths scrutinized under DISPATCH-1968
+    p.add_argument('--close-on-connect',
+                   action='store_true',
+                   help='Close client connection without reading from socket when listener connects. If stall is specified then stall before closing.')
+    # Close on data - exercises control paths scrutinized under DISPATCH-1968
+    p.add_argument('--close-on-data',
+                   action='store_true',
+                   help='Close client connection as soon as data arrives.')
     del argv[0]
     args = p.parse_args(argv)
 
@@ -284,6 +318,10 @@ def main(argv):
     if args.timeout < 0.0:
         raise Exception("Timeout must be greater than or equal to zero")
 
+    # timeout
+    if args.connect_stall < 0.0:
+        raise Exception("Connect-stall must be greater than or equal to zero")
+
     signaller = GracefulExitSignaler()
     server = None
 
@@ -293,7 +331,8 @@ def main(argv):
                         print_to_console=args.log,
                         save_for_dump=False)
 
-        server = TcpEchoServer(prefix, port, args.echo, args.timeout, logger)
+        server = TcpEchoServer(prefix, port, args.echo, args.timeout, logger,
+                               args.connect_stall, args.close_on_connect, args.close_on_data)
 
         keep_running = True
         while keep_running:

--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -517,7 +517,7 @@ class TcpAdaptor(TestCase):
 
             # Each router has a listener for the echo server attached to every router
             self.listener_port = TcpAdaptor.tcp_client_listener_ports[self.client][self.server] \
-                                 if port_override is None else port_override
+                if port_override is None else port_override
 
             self.name = "%s_%s_%s_%s" % (self.test_name, self.client_n, self.size, self.count)
             self.client_prefix = "ECHO_CLIENT %s" % self.name
@@ -673,7 +673,6 @@ class TcpAdaptor(TestCase):
 
         return result
 
-
     def do_tcp_echo_singleton(self, test_name, client, server, size, count, echo_port):
         """
         Launch a single echo client to the echo_port
@@ -773,9 +772,8 @@ class TcpAdaptor(TestCase):
 
         return result
 
-
     #
-    # A series of 1-byte messsages, one at a time, to prove general connectivity
+    # Tests run by ctest
     #
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
     def test_01_tcp_basic_connectivity(self):

--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -204,6 +204,9 @@ class TcpAdaptor(TestCase):
     # Each router has an echo server to which it connects
     echo_servers = {}
 
+    # Special echo servers
+    echo_server_NS_CONN_STALL = None
+
     @classmethod
     def setUpClass(cls):
         """Start a router"""


### PR DESCRIPTION
The echo server is rewritten to generate Q2 holdoff more reliably.

The self test uses the connection-stall feature of the the echo
server. The server does not read the message content, beyond normal
TCP window and python prefetch, so that the router gets into a
Q2 block state.