### PR TITLE
NO-JIRA Use last working PROTON_VERSION on macOS TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
   - os: osx
     osx_image: xcode11
     env:
-    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=0.32.0
+    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=e4f3c34396c798529b35fadf93ba57b771aadebf
     before_install:
     - bash ./macports.sh
     - export COLUMNS=80

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
   - os: osx
     osx_image: xcode11
     env:
-    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=master
+    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=0.33.0
     before_install:
     - bash ./macports.sh
     - export COLUMNS=80

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
   - os: osx
     osx_image: xcode11
     env:
-    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=e4f3c34396c798529b35fadf93ba57b771aadebf
+    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=jd_e4f3c34396c798529b35fadf93ba57b771aadebf
     before_install:
     - bash ./macports.sh
     - export COLUMNS=80

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
   - os: osx
     osx_image: xcode11
     env:
-    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=0.33.0
+    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=0.32.0
     before_install:
     - bash ./macports.sh
     - export COLUMNS=80


### PR DESCRIPTION
The macOS build got completely broken. Probably due to changes in Proton master. Lets try Proton 0.33.0.