### PR TITLE
DISPATCH-2000: Experimental 4K internal buffer size is switch selectable

### DIFF
--- a/include/qpid/dispatch/dispatch.h
+++ b/include/qpid/dispatch/dispatch.h
@@ -38,7 +38,7 @@ typedef struct qd_dispatch_t qd_dispatch_t;
  * @param test_hooks Iff true, enable internal system testing features
  * @return A handle to be used in API calls for this instance.
  */
-qd_dispatch_t *qd_dispatch(const char *python_pkgdir, bool test_hooks);
+qd_dispatch_t *qd_dispatch(const char *python_pkgdir, bool test_hooks, bool buf4k);
 
 
 /**

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -70,7 +70,7 @@ qd_dispatch_t *qd_dispatch_get_dispatch()
     return qd;
 }
 
-qd_dispatch_t *qd_dispatch(const char *python_pkgdir, bool test_hooks)
+qd_dispatch_t *qd_dispatch(const char *python_pkgdir, bool test_hooks, bool buf4k)
 {
     //
     // Seed the random number generator
@@ -83,6 +83,9 @@ qd_dispatch_t *qd_dispatch(const char *python_pkgdir, bool test_hooks)
     ZERO(qd);
 
     qd_entity_cache_initialize();   /* Must be first */
+    if (buf4k) {
+        qd_buffer_set_size(4096);
+    }
     qd_alloc_initialize();
     qd_log_initialize();
     qd_error_initialize();

--- a/tests/run_unit_tests.c
+++ b/tests/run_unit_tests.c
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     int result = 0;
 
     // Call qd_dispatch() first initialize allocator used by other tests.
-    qd_dispatch_t *qd = qd_dispatch(0, false);
+    qd_dispatch_t *qd = qd_dispatch(0, false, false);
 
     qd_dispatch_validate_config(argv[1]);
     if (qd_error_code()) {


### PR DESCRIPTION
Add a "--4k-buffer" CLI switch to use 4k-byte internal buffers.
This is EXPERIMENTAL and not intended to be committed to the main branch.
On my laptop running iperf3 through the TCP Adaptor with two routers between the iperf server and client results in significant improvement in throughput.

Running the DISPATCH-2000 without and with the 4k switch

Iperf3 without

[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-60.00  sec  1.93 GBytes   276 Mbits/sec    0             sender
[  5]   0.00-60.00  sec   851 MBytes   119 Mbits/sec                  receiver

Iperf3 with

[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-60.00  sec  7.57 GBytes  1.08 Gbits/sec   45             sender
[  5]   0.00-99.53  sec  7.56 GBytes   652 Mbits/sec                  receiver
