### PR TITLE
DISPATCH-1962 Fix leak from libwebsockets.so in unit_tests

### DIFF
--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -746,9 +746,9 @@ static int callback_healthz(struct lws *wsi, enum lws_callback_reasons reason,
         ZERO(stats->context);
         stats->context->wsi = wsi;
         stats->context->server = hs;
-        //make dummy request for stats (pass in null ptr); this still excercises the
+        //make dummy request for stats (pass in null ptr); this still exercises the
         //path through core thread and back through callback on io thread which is
-        //a resonable initial liveness check
+        //a reasonable initial liveness check
         qdr_request_global_stats(hs->core, 0, handle_stats_results, (void*) stats->context);
         return 0;
     }

--- a/src/server.c
+++ b/src/server.c
@@ -1372,6 +1372,10 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
 void qd_server_free(qd_server_t *qd_server)
 {
     if (!qd_server) return;
+
+    qd_http_server_stop(qd_server->http); /* Stop HTTP threads immediately */
+    qd_http_server_free(qd_server->http);
+
     qd_connection_t *ctx = DEQ_HEAD(qd_server->conn_list);
     while (ctx) {
         qd_log(qd_server->log_source, QD_LOG_INFO,
@@ -1487,8 +1491,6 @@ void qd_server_run(qd_dispatch_t *qd)
         sys_thread_free(threads[i]);
     }
     free(threads);
-    qd_http_server_stop(qd_server->http); /* Stop HTTP threads immediately */
-    qd_http_server_free(qd_server->http);
 
     qd_log(qd_server->log_source, QD_LOG_NOTICE, "Shut Down");
 }

--- a/src/server.c
+++ b/src/server.c
@@ -1373,7 +1373,6 @@ void qd_server_free(qd_server_t *qd_server)
 {
     if (!qd_server) return;
 
-    qd_http_server_stop(qd_server->http); /* Stop HTTP threads immediately */
     qd_http_server_free(qd_server->http);
 
     qd_connection_t *ctx = DEQ_HEAD(qd_server->conn_list);

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -10,9 +10,6 @@ leak:qd_policy_c_counts_alloc
 leak:qd_policy_open_fetch_settings
 leak:qdr_error_description
 
-# to be triaged; unit_tests
-leak:http-libwebsockets.c
-
 # to be triaged; pretty much all tests
 leak:^IoAdapter_init$
 

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -92,8 +92,4 @@ leak:^pn_object_new$
 leak:^pn_list$
 leak:^pni_record_create$
 
-### libwebsockets
-
-leak:/libwebsockets.so
-
 ### CMake will append .so 3rd party suppressions here, unless disabled:


### PR DESCRIPTION
This was a silly test issue. There was no good way for the test to stop the libwebsockets server, because of how the shutdown code was structured previously. All that's needed is to stop it, and the leak disappears.

This may not be the best of fixes for it, I am open to better suggestions.

```
9: Test Case thread_tests.test_condition: PASS
9: 
9: =================================================================
9: ==10641==ERROR: LeakSanitizer: detected memory leaks
9: 
9: Indirect leak of 8397696 byte(s) in 5 object(s) allocated from:
9:     #0 0x7fb6364ee1f8 in __interceptor_realloc (/nix/store/g40sl3zh3nv52vj0mrl4iki5iphh5ika-gcc-10.2.0-lib/lib/libasan.so.6+0xad1f8)
9:     #1 0x7fb6353ebde5 in _realloc (/nix/store/yf2b40nmyhyyhlzjjniwg9a6g4w99k4s-libwebsockets-3.2.2/lib/libwebsockets.so.15+0x10de5)
9: 
9: -----------------------------------------------------
9: Suppressions used:
9:   count      bytes template
9:       2        280 http-libwebsockets.c
9:       1       1160 run_unit_tests.c
9:       1         64 sys_mutex
9:       1         56 qdr_core_subscribe
9:       5       3096 ^_PyObject_Realloc
9:     580     908616 ^PyObject_Malloc$
9:       1         32 ^PyThread_allocate_lock$
9:       5      11945 ^PyMem_Malloc$
9:       1        840 ^_PyObject_GC_Resize$
9:       1        319 ^_PyBytes_Resize$
9: -----------------------------------------------------
9: 
9: SUMMARY: AddressSanitizer: 8397696 byte(s) leaked in 5 allocation(s).
 9/73 Test  #9: unit_tests ........................................***Failed    1.47 sec
```