### PR TITLE
DISPATCH-2025 Compile using C11 language version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if (DEFINED CMAKE_C_COMPILE_FEATURES)
 else()
     set(C_STANDARD_GNU "-std=gnu11")
     set(C_STANDARD_Clang "-std=gnu11")
-    set(C_STANDARD_SunPro "-xc11")
+    set(C_STANDARD_SunPro "-std=c11")
 
     set(C_STANDARD_FLAGS ${C_STANDARD_${CMAKE_C_COMPILER_ID}})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_STANDARD_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,45 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(qpid-dispatch C CXX)
 
+# This effectively checks for cmake version 3.1 or later
+if (DEFINED CMAKE_C_COMPILE_FEATURES)
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+    set(CMAKE_C_EXTENSIONS ON) # gnu11
+
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+else()
+    set(C_STANDARD_GNU "-std=gnu11")
+    set(C_STANDARD_Clang "-std=gnu11")
+    set(C_STANDARD_SunPro "-xc11")
+
+    set(C_STANDARD_FLAGS ${C_STANDARD_${CMAKE_C_COMPILER_ID}})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_STANDARD_FLAGS}")
+
+    set(CXX_STANDARD_FLAGS "-std=c++11")
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1850174 GCC 4.8 claims to support atomics, but it's missing stdatomic.h
+include(CheckIncludeFile)
+check_include_file("stdatomic.h" HAVE_STDATOMIC_H)
+if (NOT HAVE_STDATOMIC_H)
+    add_definitions(-D__STDC_NO_ATOMICS__)
+endif()
+
+# Set warning compile flags
+set(C_WARNING_GNU -Wall -Wextra -Werror -Wpedantic -pedantic-errors -Wno-empty-body -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers -Wno-sign-compare -Wno-type-limits)
+set(C_WARNING_Clang -Wall -Wextra -Werror -Wpedantic -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers -Wno-sign-compare -Wno-gnu-statement-expression)
+set(C_WARNING_SunPro -errwarn=%all)
+
+set(C_WARNING_FLAGS ${C_WARNING_${CMAKE_C_COMPILER_ID}})
+add_compile_options(${C_WARNING_FLAGS})
 
 # Set default build type. Must use FORCE because project() sets default to ""
 if (NOT CMAKE_BUILD_TYPE)
@@ -90,7 +125,7 @@ CMAKE_DEPENDENT_OPTION(USE_LIBWEBSOCKETS "Use libwebsockets for WebSocket suppor
 set(SKIP_DELETE_HTTP_LISTENER "True")
 if (LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
   # This is a fix for DISPATCH-1513. libwebsockets versions 3.2.0 introduces a new flag called LWS_SERVER_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER
-  # The new flag allows (as the flag says) HTTP pver HTTPS listeners. Since this flag is not available before lws 3.2.0 we need
+  # The new flag allows (as the flag says) HTTP over HTTPS listeners. Since this flag is not available before lws 3.2.0 we need
   # to selectively comment out a test.
   set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "#")
   set(LWS_VERSION_WITH_SSL_FIX "3.2.0")
@@ -161,12 +196,6 @@ endif()
 
 set(QPID_DISPATCH_CONFDIR ${SYSCONF_INSTALL_DIR}/qpid-dispatch)
 
-if (NOT COMMAND add_compile_options)
-  macro (add_compile_options option)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${option}")
-  endmacro (add_compile_options)
-endif (NOT COMMAND add_compile_options)
-
 # Set up runtime checks (valgrind, sanitizers etc.)
 include(cmake/RuntimeChecks.cmake)
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZE_FLAGS}")
@@ -208,38 +237,22 @@ if(QD_ENABLE_ASSERTIONS)
     endif()
 endif()
 
-if (NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
- add_compile_options(-Werror)
- add_compile_options(-Wall)
- include(CheckCCompilerFlag)
- check_c_compiler_flag(-Wpedantic HAS_PEDANTIC_FLAG)
- if (HAS_PEDANTIC_FLAG)
-    add_compile_options(-Wpedantic)
- endif(HAS_PEDANTIC_FLAG)
- set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
- if (CMAKE_BUILD_TYPE MATCHES "Coverage")
-   set (CMAKE_C_FLAGS_COVERAGE "-g -O0 --coverage")
-   set (CMAKE_EXE_LINKER_FLAGS_COVERAGE "--coverage")
-   set (CMAKE_MODULE_LINKER_FLAGS_COVERAGE "--coverage")
-   set (CMAKE_SHARED_LINKER_FLAGS_COVERAGE "--coverage")
-   mark_as_advanced(
-     CMAKE_C_FLAGS_COVERAGE
-     CMAKE_EXE_LINKER_FLAGS_COVERAGE
-     CMAKE_MODULE_LINKER_FLAGS_COVERAGE
-     CMAKE_SHARED_LINKER_FLAGS_COVERAGE)
-   make_directory(${CMAKE_BINARY_DIR}/coverage_results)
-   add_custom_target(coverage
-     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_results
-     COMMAND ${CMAKE_SOURCE_DIR}/bin/record-coverage.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
- endif(CMAKE_BUILD_TYPE MATCHES "Coverage")
-else (NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
- add_compile_options(-xc99)
- add_compile_options(-errwarn=%all)
-endif (NOT CMAKE_SYSTEM_NAME STREQUAL SunOS)
-
-if (CMAKE_C_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-gnu-statement-expression)
-endif()
+# Set up extra coverage analysis options for gcc and clang
+if (CMAKE_BUILD_TYPE MATCHES "Coverage")
+ set (CMAKE_C_FLAGS_COVERAGE "-g -O0 --coverage")
+ set (CMAKE_EXE_LINKER_FLAGS_COVERAGE "--coverage")
+ set (CMAKE_MODULE_LINKER_FLAGS_COVERAGE "--coverage")
+ set (CMAKE_SHARED_LINKER_FLAGS_COVERAGE "--coverage")
+ mark_as_advanced(
+   CMAKE_C_FLAGS_COVERAGE
+   CMAKE_EXE_LINKER_FLAGS_COVERAGE
+   CMAKE_MODULE_LINKER_FLAGS_COVERAGE
+   CMAKE_SHARED_LINKER_FLAGS_COVERAGE)
+ make_directory(${CMAKE_BINARY_DIR}/coverage_results)
+ add_custom_target(coverage
+   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_results
+   COMMAND ${CMAKE_SOURCE_DIR}/bin/record-coverage.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+endif(CMAKE_BUILD_TYPE MATCHES "Coverage")
 
 ##
 ## Header file installation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -256,6 +256,4 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/config-2
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ssl_certs
         DESTINATION ${QPID_DISPATCH_HOME_INSTALLED}/tests)
 
-if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8.5"))
-  add_subdirectory(c_unittests)
-endif()
+add_subdirectory(c_unittests)

--- a/tests/c_unittests/CMakeLists.txt
+++ b/tests/c_unittests/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB unittest_SOURCES
     "*.cpp"
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD_FLAGS} ${SANITIZE_FLAGS}")
 add_executable(c_unittests ${unittest_SOURCES})
 target_link_libraries(c_unittests pthread qpid-dispatch)
 


### PR DESCRIPTION
I thought about this more and I see no downside in doing this change now. C11 is well supported, with the exceptions of those atomics in GCC 4.8.5, which I already took care of, and C99 -> C11 is not a huge change.