### PR TITLE
DISPATCH-2030 Add additional sanitizer checks and surface router output better in tests

### DIFF
--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -141,7 +141,7 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
     set(DETECT_LEAKS true)
   endif()
   # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
-  set(RUNTIME_ASAN_ENV_OPTIONS "strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_leaks=${DETECT_LEAKS} suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
+  set(RUNTIME_ASAN_ENV_OPTIONS "strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_invalid_pointer_pairs=2 detect_leaks=${DETECT_LEAKS} suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
   set(RUNTIME_LSAN_ENV_OPTIONS "suppressions=${CMAKE_BINARY_DIR}/tests/lsan.supp")
   set(RUNTIME_UBSAN_ENV_OPTIONS "print_stacktrace=1 print_summary=1")
 

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -140,8 +140,10 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
   else (APPLE)
     set(DETECT_LEAKS true)
   endif()
-  set(RUNTIME_ASAN_ENV_OPTIONS "detect_leaks=${DETECT_LEAKS} suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
+  # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
+  set(RUNTIME_ASAN_ENV_OPTIONS "strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_leaks=${DETECT_LEAKS} suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
   set(RUNTIME_LSAN_ENV_OPTIONS "suppressions=${CMAKE_BINARY_DIR}/tests/lsan.supp")
+  set(RUNTIME_UBSAN_ENV_OPTIONS "print_stacktrace=1 print_summary=1 halt_on_error=1 abort_on_error=1")
 
 elseif(RUNTIME_CHECK STREQUAL "tsan")
   assert_has_sanitizers()

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -143,7 +143,7 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
   # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
   set(RUNTIME_ASAN_ENV_OPTIONS "strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_leaks=${DETECT_LEAKS} suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
   set(RUNTIME_LSAN_ENV_OPTIONS "suppressions=${CMAKE_BINARY_DIR}/tests/lsan.supp")
-  set(RUNTIME_UBSAN_ENV_OPTIONS "print_stacktrace=1 print_summary=1 halt_on_error=1 abort_on_error=1")
+  set(RUNTIME_UBSAN_ENV_OPTIONS "print_stacktrace=1 print_summary=1")
 
 elseif(RUNTIME_CHECK STREQUAL "tsan")
   assert_has_sanitizers()

--- a/run.py.in
+++ b/run.py.in
@@ -93,6 +93,7 @@ env_vars = {
     'TSAN_OPTIONS': "${RUNTIME_TSAN_ENV_OPTIONS}",
     'ASAN_OPTIONS': "${RUNTIME_ASAN_ENV_OPTIONS}",
     'LSAN_OPTIONS': "${RUNTIME_LSAN_ENV_OPTIONS}",
+    'UBSAN_OPTIONS': "${RUNTIME_UBSAN_ENV_OPTIONS}",
 }
 os.environ.update(env_vars)
 


### PR DESCRIPTION
1. UBSAN is not killing the process the moment undefined behavior is detected. This is easily fixed by doing `set(RUNTIME_UBSAN_ENV_OPTIONS "halt_on_error=1 abort_on_error=1")`, but then the tests timeout all the time. Not useful.
2. UBSAN is not printing diagnostics. That is fixed by doing `set(RUNTIME_UBSAN_ENV_OPTIONS "print_stacktrace=1 print_summary=1")`
3. ASAN has extra checks that can be enabled. Enabling them does not find any new issues, so far. But it sounds like a sensible thing to turn on, for the future. `set(RUNTIME_ASAN_ENV_OPTIONS "strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1")`
4. System tests don't print `.out` files produced by running routers, even if there are messages from sanitizers in them. Let's fix that. This means that tests become _quite_ chatty. Maybe not something that should be turned on forever, but now it's good to see the UBSAN messages.