### PR TITLE
DISPATCH-1969 Render and archive Dispatch docu book PDF in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -295,7 +295,7 @@ jobs:
           path: ${{env.DispatchBuildDir}}/docs/man/*.html
 
       - name: Build the PDF version of the Dispatch book
-        run: asciidoctor-pdf ${{github.workspace}}/docs/books/user-guide/book.adoc
+        run: asciidoctor-pdf --failure-level INFO ${{github.workspace}}/docs/books/user-guide/book.adoc
 
       - name: Store the rendered Dispatch book PDF
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -270,7 +270,7 @@ jobs:
       - name: Install Linux docs dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt install -y asciidoc asciidoctor dblatex
+          sudo apt install -y asciidoc asciidoctor ruby-asciidoctor-pdf dblatex
 
       - name: qpid-dispatch cmake configure
         working-directory: ${{env.DispatchBuildDir}}
@@ -293,6 +293,15 @@ jobs:
         with:
           name: Manpages
           path: ${{env.DispatchBuildDir}}/docs/man/*.html
+
+      - name: Build the PDF version of the Dispatch book
+        run: asciidoctor-pdf ${{github.workspace}}/docs/books/user-guide/book.adoc
+
+      - name: Store the rendered Dispatch book PDF
+        uses: actions/upload-artifact@v2
+        with:
+          name: book.pdf
+          path: ${{github.workspace}}/docs/books/user-guide/book.pdf
 
   console-test:
     name: Console Tests


### PR DESCRIPTION
CC @pwright Thanks for your suggestion, the command works. It prints the following warning, as can be seen in the GHA run

```
Failed to parse formatted text: Routers transfer messages between producers and consumers, but unlike message brokers, they do not take responsibility for messages. Instead, routers propagate message settlement and disposition across a network such that delivery guarantees are met. That is, the router network will deliver the message &ndash; possibly through several intermediate routers &ndash; and then route the consumer&#8217;s acknowledgement of that message back across the same path. The responsibility for the message is transferred from the producer to the consumer as if they were directly connected.
```

I tried to make it exit with !=0 in this situation but I could not do it. The PDF this renders can be downloaded from the job too (when all subjobs complete), or it's liked here [book.pdf](https://github.com/apache/qpid-dispatch/files/6258306/book.pdf).
