### PR TITLE
DISPATCH-1878: Handle half-closed TCP connections - DO NOT MERGE

### DIFF
--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -810,13 +810,6 @@ static void handle_connection_event(pn_event_t *e, qd_server_t *qd_server, void 
         sys_mutex_lock(conn->activation_lock);
         conn->raw_closed_write = true;
         sys_mutex_unlock(conn->activation_lock);
-        if (conn->ingress) {
-            // connection from client is no longer writable
-            qd_log(log, QD_LOG_DEBUG,
-                   "[C%"PRIu64"] PN_RAW_CONNECTION_CLOSED_WRITE call pn_raw_connection_close(). client no longer writable",
-                   conn->conn_id);
-            pn_raw_connection_close(conn->pn_raw_conn);
-        }
         break;
     }
     case PN_RAW_CONNECTION_DISCONNECTED: {

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -129,15 +129,15 @@ static inline const char * qdr_link_direction_name(const qdr_link_t *link)
 static inline const char * qdr_tcp_connection_role_name(const qdr_tcp_connection_t *tc)
 {
     assert(tc);
-    return tc->ingress ? "client" : "server";
+    return tc->ingress ? "listener" : "connector";
 }
 
 static const char * qdr_tcp_quadrant_id(const qdr_tcp_connection_t *tc, const qdr_link_t *link)
 {
     if (tc->ingress)
-        return link->link_direction == QD_INCOMING ? "(client raw-to-rtr)" : "(client rtr-to-raw)";
+        return link->link_direction == QD_INCOMING ? "(listener incoming)" : "(listener outgoing)";
     else
-        return link->link_direction == QD_INCOMING ? "(server raw-to-rtr)" : "(server rtr-to-raw)";
+        return link->link_direction == QD_INCOMING ? "(connector outgoing)" : "(connector outgoing)";
 }
 
 static void on_activate(void *context)

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -137,7 +137,7 @@ static const char * qdr_tcp_quadrant_id(const qdr_tcp_connection_t *tc, const qd
     if (tc->ingress)
         return link->link_direction == QD_INCOMING ? "(listener incoming)" : "(listener outgoing)";
     else
-        return link->link_direction == QD_INCOMING ? "(connector outgoing)" : "(connector outgoing)";
+        return link->link_direction == QD_INCOMING ? "(connector incoming)" : "(connector outgoing)";
 }
 
 static void on_activate(void *context)

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -1333,10 +1333,6 @@ static void qdr_tcp_flow(void *context, qdr_link_t *link, int credit)
             qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
                    "[C%"PRIu64"][L%"PRIu64"] qdr_tcp_flow: Flow enabled, credit=%d",
                    conn->conn_id, conn->outgoing_id, credit);
-            // TODO: This call to handle_incoming may satisfy the prerequesites to
-            // opening the stream message. This gets a bytes to flow from the
-            // TCP in but it does not account for them as a PN_RAW_CONNECTION_READ
-            // event nor does it loop on qdr_connection_process().
             handle_incoming(conn, "qdr_tcp_flow");
         } else {
             qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -978,11 +978,9 @@ static void qdr_tcp_open_server_side_connection(qdr_tcp_connection_t* tc)
     // to the adaptor-side outgoing connection and link.
     uint64_t i_conn_id = 0;
     uint64_t i_link_id = 0;
-    uint64_t i_dlv_id = 0;
     if (!!tc->initial_delivery) {
         i_conn_id = tc->initial_delivery->conn_id;
         i_link_id = tc->initial_delivery->link_id;
-        i_dlv_id = tc->initial_delivery->delivery_id;
     }
     tc->outgoing = qdr_link_first_attach(conn,
                                          QD_OUTGOING,
@@ -996,7 +994,7 @@ static void qdr_tcp_open_server_side_connection(qdr_tcp_connection_t* tc)
     if (!!tc->initial_delivery) {
         qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
                DLV_FMT" initial_delivery ownership passed to "DLV_FMT,
-               i_conn_id, i_link_id, i_dlv_id,
+               i_conn_id, i_link_id, tc->initial_delivery->delivery_id,
                tc->outgoing->conn_id, tc->outgoing->identity, tc->initial_delivery->delivery_id);
         qdr_delivery_decref(tcp_adaptor->core, tc->initial_delivery, "tcp-adaptor - passing initial_delivery into new link");
         tc->initial_delivery = 0;


### PR DESCRIPTION
DISPATCH-2043: Various TCP Adaptor logging improvements

* monitor and control sequence of half closed events
* raw read caches data if read_close before stream message created
* raw write defers EOS write_close until stream message created

This version leaks buffers at the rate of about 15 per connection pair.
The suspect is that proton never emits a PN_RAW_CONNECTION_READ after
emitting CLOSED_READ and this code never gets to reclaim the buffers.
That said, this code could have a bug in that area as well.