### PR TITLE
DISPATCH-2022 In a test, do not fail to wait for router to fail

### DIFF
--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -1996,7 +1996,8 @@ class ConnectionLinkRouteTest(TestCase):
 
         cfg = Qdrouterd.Config(config)
         # we expect the router to fail
-        router = self.tester.qdrouterd("X", cfg, wait=False, expect=Process.EXIT_FAIL)
+        router = self.tester.qdrouterd("X", cfg, wait=False, expect=Process.EXIT_FAIL)  # type: Qdrouterd
+        self.assertEqual(router.wait(TIMEOUT), Process.EXIT_FAIL)
 
     def test_mgmt(self):
         # test create, delete, and query


### PR DESCRIPTION
This should take care of the error

```
14: Process 2203 error: still running
```

If anyone has suggestions to what file I should move the test, I can do that too.