### PR TITLE
NO-JIRA: Skip the GHA Docs job until Proton 0.34.0 Ubuntu package is published

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,7 +239,7 @@ jobs:
   docs:
     name: 'Docs (${{ matrix.os }})'
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    if: ${{ false }}  # disabled until Proton 0.34.0 Ubuntu package is published
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,6 +239,7 @@ jobs:
   docs:
     name: 'Docs (${{ matrix.os }})'
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]


### PR DESCRIPTION
Ubuntu packages with required Proton 0.34.0 are not yet built. So the job is now failing.