### PR TITLE
DISPATCH-2091: Ignore RX window when raw connection is write_closed

### DIFF
--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -231,7 +231,7 @@ static int handle_incoming_raw_read(qdr_tcp_connection_t *conn, qd_buffer_list_t
     int free_count = 0;
     const bool was_open = conn->bytes_unacked < TCP_MAX_CAPACITY;
 
-    while ((count + conn->bytes_unacked < TCP_MAX_CAPACITY)
+    while ((conn->raw_closed_write || count + conn->bytes_unacked < TCP_MAX_CAPACITY)
            && (n = pn_raw_connection_take_read_buffers(conn->pn_raw_conn, raw_buffers, READ_BUFFERS)) ) {
 
         for (size_t i = 0; i < n && raw_buffers[i].bytes; ++i) {


### PR DESCRIPTION
If the adaptor receives an EOS then it calls pn_raw_write_close. This
sends a FIN to the raw connection peer.

If the adaptor then continues to honor the RX window closure then it
never reads data from the raw connection. Further, when the incoming
TCP window is full then the TCP connection never returns the client's
FIN and the connection is stuck open.

This patch causes the adaptor to keep reading from an connection after
a write_close has been effected.