### PR TITLE
DISPATCH-2098 - Stop HTTP server before the AMQP server

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -363,6 +363,10 @@ static void qd_dispatch_set_router_area(qd_dispatch_t *qd, char *_area) {
 void qd_dispatch_free(qd_dispatch_t *qd)
 {
     if (!qd) return;
+
+    /* Stop HTTP threads immediately */
+    qd_http_server_free(qd_server_http(qd->server));
+
     free(qd->sasl_config_path);
     free(qd->sasl_config_name);
     qd_connection_manager_free(qd->connection_manager);

--- a/src/server.c
+++ b/src/server.c
@@ -1375,12 +1375,13 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
     return qd_server;
 }
 
+qd_http_server_t *qd_server_http(qd_server_t *qd_server) {
+    return qd_server->http;
+}
 
 void qd_server_free(qd_server_t *qd_server)
 {
     if (!qd_server) return;
-
-    qd_http_server_free(qd_server->http);
 
     qd_connection_t *ctx = DEQ_HEAD(qd_server->conn_list);
     while (ctx) {

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -93,6 +93,8 @@ DEQ_DECLARE(qd_pn_free_link_session_t, qd_pn_free_link_session_list_t);
 
 pn_proactor_t* qd_server_proactor(qd_server_t *s);
 
+qd_http_server_t *qd_server_http(qd_server_t *server);
+
 typedef void (*qd_server_event_handler_t) (pn_event_t *e, qd_server_t *qd_server, void *context);
 
 typedef struct qd_handler_context_t {


### PR DESCRIPTION
The HTTP server is weird, I can't find an ideal place where to stop it. It is somewhat like the adapter modules, but it is implemented differently. This here survives the Ctrl+C without a crash. I'll try to add a test. Worst case, the commit that broke this can be reverted; that would solve the problem too.