### PR TITLE
DISPATCH-1962 Update qdr_core_subscribe leak fix so it does not cause qdr_delivery_cleanup_t leak

### DIFF
--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -236,6 +236,33 @@ void qdr_core_free(qdr_core_t *core)
         link = DEQ_HEAD(core->open_links);
     }
 
+    // finalize modules while we can still submit new actions
+    // this must happen after qdrc_endpoint_do_cleanup_CT calls
+    qdr_modules_finalize(core);
+
+    // discard any left over actions
+
+    qdr_action_list_t  action_list;
+    DEQ_MOVE(core->action_list, action_list);
+    DEQ_APPEND(action_list, core->action_list_background);
+    qdr_action_t *action = DEQ_HEAD(action_list);
+    while (action) {
+        DEQ_REMOVE_HEAD(action_list);
+        action->action_handler(core, action, true);
+        free_qdr_action_t(action);
+        action = DEQ_HEAD(action_list);
+    }
+
+    // Drain the general work lists
+    qdr_general_handler(core);
+
+    sys_thread_free(core->thread);
+    sys_cond_free(core->action_cond);
+    sys_mutex_free(core->action_lock);
+    sys_mutex_free(core->work_lock);
+    sys_mutex_free(core->id_lock);
+    qd_timer_free(core->work_timer);
+
     //
     // Clean up any qdr_delivery_cleanup_t's that are still left in the core->delivery_cleanup_list
     //
@@ -284,25 +311,6 @@ void qdr_core_free(qdr_core_t *core)
     // at this point all the conn identifiers have been freed
     qd_hash_free(core->conn_id_hash);
 
-    // finalize modules while we can still submit new actions
-    qdr_modules_finalize(core);
-
-    // discard any left over actions
-
-    qdr_action_list_t  action_list;
-    DEQ_MOVE(core->action_list, action_list);
-    DEQ_APPEND(action_list, core->action_list_background);
-    qdr_action_t *action = DEQ_HEAD(action_list);
-    while (action) {
-        DEQ_REMOVE_HEAD(action_list);
-        action->action_handler(core, action, true);
-        free_qdr_action_t(action);
-        action = DEQ_HEAD(action_list);
-    }
-
-    // Drain the general work lists
-    qdr_general_handler(core);
-
     qdr_agent_free(core->mgmt_agent);
 
     if (core->routers_by_mask_bit)       free(core->routers_by_mask_bit);
@@ -310,13 +318,6 @@ void qdr_core_free(qdr_core_t *core)
     if (core->data_links_by_mask_bit)    free(core->data_links_by_mask_bit);
     if (core->neighbor_free_mask)        qd_bitmask_free(core->neighbor_free_mask);
     if (core->rnode_conns_by_mask_bit)   free(core->rnode_conns_by_mask_bit);
-
-    sys_thread_free(core->thread);
-    sys_cond_free(core->action_cond);
-    sys_mutex_free(core->action_lock);
-    sys_mutex_free(core->work_lock);
-    sys_mutex_free(core->id_lock);
-    qd_timer_free(core->work_timer);
 
     free(core);
 }

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -56,6 +56,7 @@ leak:^PyThread_allocate_lock$
 #  https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_python.html#debug-version-of-python-memory-alloc-label
 leak:^PyMem_Malloc$
 leak:^PyMem_Calloc$
+leak:^PyMem_Realloc$
 leak:^_PyObject_GC_Resize$
 # Python uses these alloc functions if you define PYTHONDEVMODE=1
 leak:^_PyMem_DebugRawAlloc$


### PR DESCRIPTION
`qdr_modules_finalize` must run before `Clean up any qdr_delivery_cleanup_t's...`.