### PR TITLE
DISPATCH 2021, DISPATCH-2049: report the entire client error string in assertion message

### DIFF
--- a/tests/system_tests_auth_service_plugin.py
+++ b/tests/system_tests_auth_service_plugin.py
@@ -97,7 +97,7 @@ sql_select: dummy select
         test = SimpleConnect("127.0.0.1:%d" % self.router_port, 'test@domain.com', 'password')
         test.run()
         self.assertEqual(True, test.connected)
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(not SASL.extended(), "Cyrus library not available. skipping test")
     def test_invalid_credentials(self):

--- a/tests/system_tests_auth_service_plugin.py
+++ b/tests/system_tests_auth_service_plugin.py
@@ -97,7 +97,7 @@ sql_select: dummy select
         test = SimpleConnect("127.0.0.1:%d" % self.router_port, 'test@domain.com', 'password')
         test.run()
         self.assertEqual(True, test.connected)
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(not SASL.extended(), "Cyrus library not available. skipping test")
     def test_invalid_credentials(self):

--- a/tests/system_tests_authz_service_plugin.py.in
+++ b/tests/system_tests_authz_service_plugin.py.in
@@ -138,7 +138,7 @@ mech_list: SCRAM-SHA-1 PLAIN
         container.run()
         self.assertEqual(0, client.accepted)
         self.assertEqual(1, client.rejected)
-        self.assertIsNone(client.message, msg=client.message)
+        self.assertIsNone(client.message)
 
 
 class AuthServicePluginAuthzDeprecatedTest(AuthServicePluginAuthzTest):

--- a/tests/system_tests_authz_service_plugin.py.in
+++ b/tests/system_tests_authz_service_plugin.py.in
@@ -138,7 +138,7 @@ mech_list: SCRAM-SHA-1 PLAIN
         container.run()
         self.assertEqual(0, client.accepted)
         self.assertEqual(1, client.rejected)
-        self.assertEqual(None, client.message)
+        self.assertIsNone(client.message, msg=client.message)
 
 
 class AuthServicePluginAuthzDeprecatedTest(AuthServicePluginAuthzTest):

--- a/tests/system_tests_autolinks.py
+++ b/tests/system_tests_autolinks.py
@@ -236,7 +236,7 @@ class DetachAfterAttachTest(TestCase):
     def test_auto_link_attach_detach_reattch(self):
         test = AutoLinkDetachAfterAttachTest(self.route_address, 'myListener.1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class AutoLinkRetryTest(TestCase):
@@ -410,7 +410,7 @@ class WaypointReceiverPhaseTest(TestCase):
         """
         test = WaypointTest(self.routers[0].addresses[0], self.routers[1].addresses[0], "0.0.0.0/queue.ext")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class WaypointTest(MessagingHandler):
@@ -567,7 +567,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkAttachTest('container.1', self.route_address, 'node.1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_autolink_credit(self):
         """
@@ -576,7 +576,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkCreditTest(self.normal_address, self.route_address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
         self.assertTrue(test.autolink_count_ok)
 
     def test_03_autolink_sender(self):
@@ -586,7 +586,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkSenderTest('container.1', self.normal_address, self.route_address, 'node.1', 'node.1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
         long_type = 'org.apache.qpid.dispatch.router'
         query_command = 'QUERY --type=' + long_type
@@ -605,7 +605,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkReceiverTest('container.1', self.normal_address, self.route_address, 'node.1', 'node.1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
         long_type = 'org.apache.qpid.dispatch.router'
         query_command = 'QUERY --type=' + long_type
@@ -624,7 +624,7 @@ class AutolinkTest(TestCase):
         """
         test = InterContainerTransferTest(self.normal_address, self.route_address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_manage_autolinks(self):
         """
@@ -634,7 +634,7 @@ class AutolinkTest(TestCase):
         """
         test = ManageAutolinksTest(self.normal_address, self.route_address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_autolink_attach_with_ext_addr(self):
         """
@@ -644,7 +644,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkAttachTest('container.4', self.route_address, 'ext.2')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_autolink_sender_with_ext_addr(self):
         """
@@ -653,7 +653,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkSenderTest('container.4', self.normal_address, self.route_address, 'node.2', 'ext.2')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_autolink_receiver_with_ext_addr(self):
         """
@@ -662,7 +662,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkReceiverTest('container.4', self.normal_address, self.route_address, 'node.2', 'ext.2')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_autolink_attach_to_listener(self):
         """
@@ -671,7 +671,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkAttachTestWithListenerName(self.ls_route_address, 'myListener.1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_autolink_multiple_receivers_on_listener(self):
         """
@@ -681,7 +681,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkMultipleReceiverUsingMyListenerTest(self.normal_address, self.ls_route_address, 'myListener.1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class AutolinkAttachTestWithListenerName(MessagingHandler):

--- a/tests/system_tests_autolinks.py
+++ b/tests/system_tests_autolinks.py
@@ -236,7 +236,7 @@ class DetachAfterAttachTest(TestCase):
     def test_auto_link_attach_detach_reattch(self):
         test = AutoLinkDetachAfterAttachTest(self.route_address, 'myListener.1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class AutoLinkRetryTest(TestCase):
@@ -410,7 +410,7 @@ class WaypointReceiverPhaseTest(TestCase):
         """
         test = WaypointTest(self.routers[0].addresses[0], self.routers[1].addresses[0], "0.0.0.0/queue.ext")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class WaypointTest(MessagingHandler):
@@ -567,7 +567,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkAttachTest('container.1', self.route_address, 'node.1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_autolink_credit(self):
         """
@@ -576,7 +576,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkCreditTest(self.normal_address, self.route_address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
         self.assertTrue(test.autolink_count_ok)
 
     def test_03_autolink_sender(self):
@@ -586,7 +586,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkSenderTest('container.1', self.normal_address, self.route_address, 'node.1', 'node.1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
         long_type = 'org.apache.qpid.dispatch.router'
         query_command = 'QUERY --type=' + long_type
@@ -605,7 +605,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkReceiverTest('container.1', self.normal_address, self.route_address, 'node.1', 'node.1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
         long_type = 'org.apache.qpid.dispatch.router'
         query_command = 'QUERY --type=' + long_type
@@ -624,7 +624,7 @@ class AutolinkTest(TestCase):
         """
         test = InterContainerTransferTest(self.normal_address, self.route_address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_manage_autolinks(self):
         """
@@ -634,7 +634,7 @@ class AutolinkTest(TestCase):
         """
         test = ManageAutolinksTest(self.normal_address, self.route_address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_autolink_attach_with_ext_addr(self):
         """
@@ -644,7 +644,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkAttachTest('container.4', self.route_address, 'ext.2')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_autolink_sender_with_ext_addr(self):
         """
@@ -653,7 +653,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkSenderTest('container.4', self.normal_address, self.route_address, 'node.2', 'ext.2')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_autolink_receiver_with_ext_addr(self):
         """
@@ -662,7 +662,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkReceiverTest('container.4', self.normal_address, self.route_address, 'node.2', 'ext.2')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_autolink_attach_to_listener(self):
         """
@@ -671,7 +671,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkAttachTestWithListenerName(self.ls_route_address, 'myListener.1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_autolink_multiple_receivers_on_listener(self):
         """
@@ -681,7 +681,7 @@ class AutolinkTest(TestCase):
         """
         test = AutolinkMultipleReceiverUsingMyListenerTest(self.normal_address, self.ls_route_address, 'myListener.1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class AutolinkAttachTestWithListenerName(MessagingHandler):

--- a/tests/system_tests_core_endpoint.py
+++ b/tests/system_tests_core_endpoint.py
@@ -63,27 +63,27 @@ class RouterTest(TestCase):
     def test_01_denied_link(self):
         test = DenyLinkTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/deny")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_discard_deliveries(self):
         test = DiscardTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/discard")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_presettled_source(self):
         test = SourceTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/source_ps", 300, 300)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_unsettled_source(self):
         test = SourceTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/source", 300, 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_echo_attach_detach(self):
         test = EchoTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/echo")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class DenyLinkTest(MessagingHandler):

--- a/tests/system_tests_core_endpoint.py
+++ b/tests/system_tests_core_endpoint.py
@@ -63,27 +63,27 @@ class RouterTest(TestCase):
     def test_01_denied_link(self):
         test = DenyLinkTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/deny")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_discard_deliveries(self):
         test = DiscardTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/discard")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_presettled_source(self):
         test = SourceTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/source_ps", 300, 300)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_unsettled_source(self):
         test = SourceTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/source", 300, 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_echo_attach_detach(self):
         test = EchoTest(self.routers[0].addresses[0], "org.apache.qpid.dispatch.router/test/echo")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class DenyLinkTest(MessagingHandler):

--- a/tests/system_tests_delivery_abort.py
+++ b/tests/system_tests_delivery_abort.py
@@ -71,14 +71,14 @@ class RouterTest(TestCase):
                                         self.routers[0].addresses[0],
                                         "addr_01")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_message_route_truncated_two_routers(self):
         test = MessageRouteTruncateTest(self.routers[0].addresses[0],
                                         self.routers[1].addresses[0],
                                         "addr_02")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_link_route_truncated_one_router(self):
         test = LinkRouteTruncateTest(self.routers[0].addresses[0],
@@ -86,7 +86,7 @@ class RouterTest(TestCase):
                                      "link.addr_03",
                                      self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_link_route_truncated_two_routers(self):
         test = LinkRouteTruncateTest(self.routers[1].addresses[0],
@@ -94,7 +94,7 @@ class RouterTest(TestCase):
                                      "link.addr_04",
                                      self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_message_route_abort_one_router(self):
         test = MessageRouteAbortTest(self.routers[0].addresses[0],
@@ -103,7 +103,7 @@ class RouterTest(TestCase):
         test.run()
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_message_route_abort_two_routers(self):
         test = MessageRouteAbortTest(self.routers[0].addresses[0],
@@ -112,7 +112,7 @@ class RouterTest(TestCase):
         test.run()
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_multicast_truncate_one_router(self):
         test = MulticastTruncateTest(self.routers[0].addresses[0],
@@ -120,7 +120,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      "multicast.addr_07")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_delivery_abort.py
+++ b/tests/system_tests_delivery_abort.py
@@ -71,14 +71,14 @@ class RouterTest(TestCase):
                                         self.routers[0].addresses[0],
                                         "addr_01")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_message_route_truncated_two_routers(self):
         test = MessageRouteTruncateTest(self.routers[0].addresses[0],
                                         self.routers[1].addresses[0],
                                         "addr_02")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_link_route_truncated_one_router(self):
         test = LinkRouteTruncateTest(self.routers[0].addresses[0],
@@ -86,7 +86,7 @@ class RouterTest(TestCase):
                                      "link.addr_03",
                                      self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_link_route_truncated_two_routers(self):
         test = LinkRouteTruncateTest(self.routers[1].addresses[0],
@@ -94,7 +94,7 @@ class RouterTest(TestCase):
                                      "link.addr_04",
                                      self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_message_route_abort_one_router(self):
         test = MessageRouteAbortTest(self.routers[0].addresses[0],
@@ -103,7 +103,7 @@ class RouterTest(TestCase):
         test.run()
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_message_route_abort_two_routers(self):
         test = MessageRouteAbortTest(self.routers[0].addresses[0],
@@ -112,7 +112,7 @@ class RouterTest(TestCase):
         test.run()
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_multicast_truncate_one_router(self):
         test = MulticastTruncateTest(self.routers[0].addresses[0],
@@ -120,7 +120,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      "multicast.addr_07")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_distribution.py
+++ b/tests/system_tests_distribution.py
@@ -507,42 +507,42 @@ class DistributionTests (TestCase):
         name = 'test_01'
         test = TargetedSenderTest(name, self.A_addr, self.C_addr, "closest/01")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_02'], 'Test skipped during development.')
     def test_02_targeted_sender_DC(self):
         name = 'test_02'
         test = TargetedSenderTest(name, self.D_addr, self.C_addr, "closest/02")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_03'], 'Test skipped during development.')
     def test_03_anonymous_sender_AC(self):
         name = 'test_03'
         test = AnonymousSenderTest(name, self.A_addr, self.C_addr)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_04'], 'Test skipped during development.')
     def test_04_anonymous_sender_DC(self):
         name = 'test_04'
         test = AnonymousSenderTest(name, self.D_addr, self.C_addr)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_05'], 'Test skipped during development.')
     def test_05_dynamic_reply_to_AC(self):
         name = 'test_05'
         test = DynamicReplyTo(name, self.A_addr, self.C_addr)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_06'], 'Test skipped during development.')
     def test_06_dynamic_reply_to_DC(self):
         name = 'test_06'
         test = DynamicReplyTo(name, self.D_addr, self.C_addr)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_07'], 'Test skipped during development.')
     def test_07_linkroute(self):
@@ -555,7 +555,7 @@ class DistributionTests (TestCase):
                                  "addr_07"
                                  )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_08'], 'Test skipped during development.')
     def test_08_linkroute_check_only(self):
@@ -568,7 +568,7 @@ class DistributionTests (TestCase):
                                           "addr_08"
                                           )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_09'], 'Test skipped during development.')
     def test_09_closest_linear(self):
@@ -581,7 +581,7 @@ class DistributionTests (TestCase):
                            print_debug=False
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_10'], 'Test skipped during development.')
     def test_10_closest_mesh(self):
@@ -593,7 +593,7 @@ class DistributionTests (TestCase):
                            "addr_10"
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
         #
         #     Cost picture for balanced distribution tests.
@@ -692,7 +692,7 @@ class DistributionTests (TestCase):
                             omit_middle_receiver
                             )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_12'], 'Test skipped during development.')
     def test_12_balanced_linear_omit_middle_receiver(self):
@@ -731,7 +731,7 @@ class DistributionTests (TestCase):
                             omit_middle_receiver
                             )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
         #     Reasoning for the triangular balanced case:
         #
@@ -812,7 +812,7 @@ class DistributionTests (TestCase):
                             omit_middle_receiver
                             )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_14'], 'Test skipped during development.')
     def test_14_multicast_linear(self):
@@ -824,7 +824,7 @@ class DistributionTests (TestCase):
                              "addr_14"
                              )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_15'], 'Test skipped during development.')
     def test_15_multicast_mesh(self):
@@ -836,7 +836,7 @@ class DistributionTests (TestCase):
                              "addr_15"
                              )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_16'], 'Test skipped during development.')
     def test_16_linkroute_linear_all_local(self) :
@@ -923,7 +923,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_17'], 'Test skipped during development.')
     def test_17_linkroute_linear_all_B(self) :
@@ -1010,7 +1010,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_18'], 'Test skipped during development.')
     def test_18_linkroute_linear_all_C(self) :
@@ -1097,7 +1097,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_19'], 'Test skipped during development.')
     def test_19_linkroute_linear_kill(self) :
@@ -1244,7 +1244,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_20'], 'Test skipped during development.')
     def test_20_linkroute_mesh_all_local(self) :
@@ -1344,7 +1344,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_21'], 'Test skipped during development.')
     def test_21_linkroute_mesh_nonlocal(self) :
@@ -1444,7 +1444,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_22'], 'Test skipped during development.')
     def test_22_linkroute_mesh_kill(self) :
@@ -1599,7 +1599,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_23'], 'Test skipped during development.')
     def test_23_waypoint(self) :
@@ -1612,7 +1612,7 @@ class DistributionTests (TestCase):
                             self.waypoint_prefix_1 + '.waypoint'
                             )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_24'], 'Test skipped during development.')
     def test_24_serial_waypoint_test(self):
@@ -1625,7 +1625,7 @@ class DistributionTests (TestCase):
                                   self.waypoint_prefix_2 + '.waypoint'
                                   )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_25'], 'Test skipped during development.')
     def test_25_parallel_waypoint_test(self):
@@ -1638,7 +1638,7 @@ class DistributionTests (TestCase):
                                     self.waypoint_prefix_3 + '.waypoint'
                                     )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 # ================================================================

--- a/tests/system_tests_distribution.py
+++ b/tests/system_tests_distribution.py
@@ -507,42 +507,42 @@ class DistributionTests (TestCase):
         name = 'test_01'
         test = TargetedSenderTest(name, self.A_addr, self.C_addr, "closest/01")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_02'], 'Test skipped during development.')
     def test_02_targeted_sender_DC(self):
         name = 'test_02'
         test = TargetedSenderTest(name, self.D_addr, self.C_addr, "closest/02")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_03'], 'Test skipped during development.')
     def test_03_anonymous_sender_AC(self):
         name = 'test_03'
         test = AnonymousSenderTest(name, self.A_addr, self.C_addr)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_04'], 'Test skipped during development.')
     def test_04_anonymous_sender_DC(self):
         name = 'test_04'
         test = AnonymousSenderTest(name, self.D_addr, self.C_addr)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_05'], 'Test skipped during development.')
     def test_05_dynamic_reply_to_AC(self):
         name = 'test_05'
         test = DynamicReplyTo(name, self.A_addr, self.C_addr)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_06'], 'Test skipped during development.')
     def test_06_dynamic_reply_to_DC(self):
         name = 'test_06'
         test = DynamicReplyTo(name, self.D_addr, self.C_addr)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_07'], 'Test skipped during development.')
     def test_07_linkroute(self):
@@ -555,7 +555,7 @@ class DistributionTests (TestCase):
                                  "addr_07"
                                  )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_08'], 'Test skipped during development.')
     def test_08_linkroute_check_only(self):
@@ -568,7 +568,7 @@ class DistributionTests (TestCase):
                                           "addr_08"
                                           )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_09'], 'Test skipped during development.')
     def test_09_closest_linear(self):
@@ -581,7 +581,7 @@ class DistributionTests (TestCase):
                            print_debug=False
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_10'], 'Test skipped during development.')
     def test_10_closest_mesh(self):
@@ -593,7 +593,7 @@ class DistributionTests (TestCase):
                            "addr_10"
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
         #
         #     Cost picture for balanced distribution tests.
@@ -692,7 +692,7 @@ class DistributionTests (TestCase):
                             omit_middle_receiver
                             )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_12'], 'Test skipped during development.')
     def test_12_balanced_linear_omit_middle_receiver(self):
@@ -731,7 +731,7 @@ class DistributionTests (TestCase):
                             omit_middle_receiver
                             )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
         #     Reasoning for the triangular balanced case:
         #
@@ -812,7 +812,7 @@ class DistributionTests (TestCase):
                             omit_middle_receiver
                             )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_14'], 'Test skipped during development.')
     def test_14_multicast_linear(self):
@@ -824,7 +824,7 @@ class DistributionTests (TestCase):
                              "addr_14"
                              )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_15'], 'Test skipped during development.')
     def test_15_multicast_mesh(self):
@@ -836,7 +836,7 @@ class DistributionTests (TestCase):
                              "addr_15"
                              )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_16'], 'Test skipped during development.')
     def test_16_linkroute_linear_all_local(self) :
@@ -923,7 +923,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_17'], 'Test skipped during development.')
     def test_17_linkroute_linear_all_B(self) :
@@ -1010,7 +1010,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_18'], 'Test skipped during development.')
     def test_18_linkroute_linear_all_C(self) :
@@ -1097,7 +1097,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_19'], 'Test skipped during development.')
     def test_19_linkroute_linear_kill(self) :
@@ -1244,7 +1244,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_20'], 'Test skipped during development.')
     def test_20_linkroute_mesh_all_local(self) :
@@ -1344,7 +1344,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_21'], 'Test skipped during development.')
     def test_21_linkroute_mesh_nonlocal(self) :
@@ -1444,7 +1444,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_22'], 'Test skipped during development.')
     def test_22_linkroute_mesh_kill(self) :
@@ -1599,7 +1599,7 @@ class DistributionTests (TestCase):
                            n_remote_routers
                            )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_23'], 'Test skipped during development.')
     def test_23_waypoint(self) :
@@ -1612,7 +1612,7 @@ class DistributionTests (TestCase):
                             self.waypoint_prefix_1 + '.waypoint'
                             )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_24'], 'Test skipped during development.')
     def test_24_serial_waypoint_test(self):
@@ -1625,7 +1625,7 @@ class DistributionTests (TestCase):
                                   self.waypoint_prefix_2 + '.waypoint'
                                   )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     @SkipIfNeeded(DistributionSkipMapper.skip['test_25'], 'Test skipped during development.')
     def test_25_parallel_waypoint_test(self):
@@ -1638,7 +1638,7 @@ class DistributionTests (TestCase):
                                     self.waypoint_prefix_3 + '.waypoint'
                                     )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 # ================================================================

--- a/tests/system_tests_drain.py
+++ b/tests/system_tests_drain.py
@@ -129,7 +129,7 @@ class ReceiverDropsOffDrainTest(TestCase):
     def test_receiver_drops_off_sender_receives_drain(self):
         test = ReceiverDropsOffSenderDrain(self.address, "examples")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class ReceiverDropsOffSenderDrain(MessagingHandler):

--- a/tests/system_tests_drain.py
+++ b/tests/system_tests_drain.py
@@ -129,7 +129,7 @@ class ReceiverDropsOffDrainTest(TestCase):
     def test_receiver_drops_off_sender_receives_drain(self):
         test = ReceiverDropsOffSenderDrain(self.address, "examples")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class ReceiverDropsOffSenderDrain(MessagingHandler):

--- a/tests/system_tests_dynamic_terminus.py
+++ b/tests/system_tests_dynamic_terminus.py
@@ -66,21 +66,21 @@ class RouterTest(TestCase):
     def test_01_dynamic_source_test(self):
         test = DynamicSourceTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_dynamic_target_one_router_test(self):
         test = DynamicTargetTest(self.routers[0].addresses[0], self.routers[0].addresses[0])
         test.run()
         if test.skip:
             self.skipTest(test.skip)
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_dynamic_target_two_router_test(self):
         test = DynamicTargetTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
         if test.skip:
             self.skipTest(test.skip)
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class DynamicSourceTest(MessagingHandler):

--- a/tests/system_tests_dynamic_terminus.py
+++ b/tests/system_tests_dynamic_terminus.py
@@ -66,21 +66,21 @@ class RouterTest(TestCase):
     def test_01_dynamic_source_test(self):
         test = DynamicSourceTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_dynamic_target_one_router_test(self):
         test = DynamicTargetTest(self.routers[0].addresses[0], self.routers[0].addresses[0])
         test.run()
         if test.skip:
             self.skipTest(test.skip)
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_dynamic_target_two_router_test(self):
         test = DynamicTargetTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
         if test.skip:
             self.skipTest(test.skip)
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class DynamicSourceTest(MessagingHandler):

--- a/tests/system_tests_edge_router.py
+++ b/tests/system_tests_edge_router.py
@@ -374,7 +374,7 @@ class RouterTest(TestCase):
                                 self.routers[2].addresses[0],
                                 'EA1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_connectivity_INTA_EA2(self):
         if self.skip['test_02'] :
@@ -384,7 +384,7 @@ class RouterTest(TestCase):
                                 self.routers[3].addresses[0],
                                 'EA2')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_connectivity_INTB_EB1(self):
         if self.skip['test_03'] :
@@ -394,7 +394,7 @@ class RouterTest(TestCase):
                                 self.routers[4].addresses[0],
                                 'EB1')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_connectivity_INTB_EB2(self):
         if self.skip['test_04'] :
@@ -404,7 +404,7 @@ class RouterTest(TestCase):
                                 self.routers[5].addresses[0],
                                 'EB2')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_dynamic_address_same_edge(self):
         if self.skip['test_05'] :
@@ -413,7 +413,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[2].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_dynamic_address_interior_to_edge(self):
         if self.skip['test_06'] :
@@ -422,7 +422,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_dynamic_address_edge_to_interior(self):
         if self.skip['test_07'] :
@@ -431,7 +431,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[0].addresses[0],
                                   self.routers[2].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_dynamic_address_edge_to_edge_one_interior(self):
         if self.skip['test_08'] :
@@ -440,7 +440,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[3].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_dynamic_address_edge_to_edge_two_interior(self):
         if self.skip['test_09'] :
@@ -449,7 +449,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[4].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_mobile_address_same_edge(self):
         if self.skip['test_10'] :
@@ -459,7 +459,7 @@ class RouterTest(TestCase):
                                  self.routers[2].addresses[0],
                                  "test_10")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_mobile_address_interior_to_edge(self):
         if self.skip['test_11'] :
@@ -469,7 +469,7 @@ class RouterTest(TestCase):
                                  self.routers[0].addresses[0],
                                  "test_11")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_12_mobile_address_edge_to_interior(self):
         if self.skip['test_12'] :
@@ -481,7 +481,7 @@ class RouterTest(TestCase):
         test.run()
         if test.error is not None:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_13_mobile_address_edge_to_edge_one_interior(self):
         if self.skip['test_13'] :
@@ -491,7 +491,7 @@ class RouterTest(TestCase):
                                  self.routers[3].addresses[0],
                                  "test_13")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_14_mobile_address_edge_to_edge_two_interior(self):
         if self.skip['test_14'] :
@@ -501,7 +501,7 @@ class RouterTest(TestCase):
                                  self.routers[4].addresses[0],
                                  "test_14")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # One sender two receiver tests.
     # One sender and two receivers on the same edge
@@ -514,7 +514,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_15")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # One sender and two receivers on the different edges. The edges are
     #  hanging off the  same interior router.
@@ -527,7 +527,7 @@ class RouterTest(TestCase):
                                                       self.routers[3].addresses[0],
                                                       "test_16")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on the interior and sender on the edge
     def test_17_mobile_address_edge_to_interior(self):
@@ -539,7 +539,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_17")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on the edge and the sender on the interior
     def test_18_mobile_address_interior_to_edge(self):
@@ -551,7 +551,7 @@ class RouterTest(TestCase):
                                                       self.routers[0].addresses[0],
                                                       "test_18")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on the edge and the sender on the 'other' interior
     def test_19_mobile_address_other_interior_to_edge(self):
@@ -563,7 +563,7 @@ class RouterTest(TestCase):
                                                       self.routers[1].addresses[0],
                                                       "test_19")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on the edge and the sender on the edge of
     # the 'other' interior
@@ -576,7 +576,7 @@ class RouterTest(TestCase):
                                                       self.routers[5].addresses[0],
                                                       "test_20")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # One receiver in an edge, another one in interior and the sender
     # is on the edge of another interior
@@ -589,7 +589,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_21")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers one on each interior router and and an edge sender
     # connectoed to the first interior
@@ -602,7 +602,7 @@ class RouterTest(TestCase):
                                                       self.routers[3].addresses[0],
                                                       "test_22")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_23_mobile_address_edge_sender_two_edge_receivers(self):
         if self.skip['test_23'] :
@@ -613,7 +613,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_23")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # 1 Sender and 3 receivers all on the same edge
     def test_24_multicast_mobile_address_same_edge(self):
@@ -628,7 +628,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # 1 Sender and receiver on one edge and 2 receivers on another edge
     # all in the same  interior
@@ -644,7 +644,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -660,7 +660,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on the interior
     def test_27_multicast_mobile_address_interior_to_edge(self):
@@ -675,7 +675,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -691,7 +691,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_29_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -706,7 +706,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_30_multicast_mobile_address_all_edges(self):
         if self.skip['test_30'] :
@@ -720,7 +720,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     ######### Multicast Large message tests ######################
 
@@ -739,7 +739,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # 1 Sender on one edge and 3 receivers on another edge all in the same
     # interior
@@ -756,7 +756,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -773,7 +773,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on the interior
     def test_34_multicast_mobile_address_interior_to_edge(self):
@@ -789,7 +789,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -806,7 +806,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_36_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -822,7 +822,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_37_multicast_mobile_address_all_edges(self):
         if self.skip['test_37'] :
@@ -837,7 +837,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_38_mobile_addr_event_three_receivers_same_interior(self):
         if self.skip['test_38'] :
@@ -851,7 +851,7 @@ class RouterTest(TestCase):
                                       "test_38")
 
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_39_mobile_addr_event_three_receivers_diff_interior(self):
         if self.skip['test_39'] :
@@ -866,7 +866,7 @@ class RouterTest(TestCase):
                                       "test_39", check_remote=True)
 
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_40_drop_rx_client_multicast_large_message(self):
         if self.skip['test_40'] :
@@ -880,7 +880,7 @@ class RouterTest(TestCase):
                                             self.routers[2].addresses[0],
                                             "multicast.40")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_41_drop_rx_client_multicast_small_message(self):
         if self.skip['test_41'] :
@@ -894,7 +894,7 @@ class RouterTest(TestCase):
                                             self.routers[2].addresses[0],
                                             "multicast.40", large_msg=False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_42_anon_sender_mobile_address_same_edge(self):
         if self.skip['test_42'] :
@@ -904,7 +904,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_42")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_43_anon_sender_mobile_address_interior_to_edge(self):
         if self.skip['test_43'] :
@@ -914,7 +914,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           "test_43")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_44_anon_sender_mobile_address_edge_to_interior(self):
         if self.skip['test_44'] :
@@ -924,7 +924,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_44")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_45_anon_sender_mobile_address_edge_to_edge_one_interior(self):
         if self.skip['test_45'] :
@@ -934,7 +934,7 @@ class RouterTest(TestCase):
                                           self.routers[3].addresses[0],
                                           "test_45")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_46_anon_sender_mobile_address_edge_to_edge_two_interior(self):
         if self.skip['test_46'] :
@@ -944,7 +944,7 @@ class RouterTest(TestCase):
                                           self.routers[4].addresses[0],
                                           "test_46")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_47_anon_sender_mobile_address_large_msg_same_edge(self):
         if self.skip['test_47'] :
@@ -954,7 +954,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_47", True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_48_anon_sender_mobile_address_large_msg_interior_to_edge(self):
         if self.skip['test_48'] :
@@ -964,7 +964,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           "test_48", True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_49_anon_sender_mobile_address_large_msg_edge_to_interior(self):
         if self.skip['test_49'] :
@@ -974,7 +974,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_49", True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_50_anon_sender_mobile_address_large_msg_edge_to_edge_one_interior(self):
         if self.skip['test_50'] :
@@ -984,7 +984,7 @@ class RouterTest(TestCase):
                                           self.routers[3].addresses[0],
                                           "test_50", True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_51_anon_sender_mobile_address_large_msg_edge_to_edge_two_interior(self):
         if self.skip['test_51'] :
@@ -994,7 +994,7 @@ class RouterTest(TestCase):
                                           self.routers[4].addresses[0],
                                           "test_51", True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # 1 Sender and 3 receivers all on the same edge
     def test_52_anon_sender_multicast_mobile_address_same_edge(self):
@@ -1010,7 +1010,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # 1 Sender and receiver on one edge and 2 receivers on another edge
     # all in the same  interior
@@ -1027,7 +1027,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -1044,7 +1044,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on the interior
     def test_55_anon_sender_multicast_mobile_address_interior_to_edge(self):
@@ -1060,7 +1060,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -1077,7 +1077,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_57_anon_sender_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -1093,7 +1093,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_58_anon_sender_multicast_mobile_address_all_edges(self):
         if self.skip['test_58'] :
@@ -1108,7 +1108,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     ######### Multicast Large message anon sender tests ####################
 
@@ -1128,7 +1128,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # 1 Sender on one edge and 3 receivers on another edge all in the same
     # interior
@@ -1146,7 +1146,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -1164,7 +1164,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on the interior
     def test_62_anon_sender_multicast_mobile_address_interior_to_edge(self):
@@ -1181,7 +1181,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -1199,7 +1199,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_64_anon_sender_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -1216,7 +1216,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_65_anon_sender_multicast_mobile_address_all_edges(self):
         if self.skip['test_65'] :
@@ -1232,7 +1232,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_66_anon_sender_drop_rx_client_multicast_large_message(self):
         # test what happens if some multicast receivers close in the middle of
@@ -1246,7 +1246,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "multicast.66")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_67_drop_rx_client_multicast_small_message(self):
         # test what happens if some multicast receivers close in the middle of
@@ -1261,7 +1261,7 @@ class RouterTest(TestCase):
                                                       "multicast.67",
                                                       large_msg=False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def run_qdstat(self, args, regexp=None, address=None):
         if args:

--- a/tests/system_tests_edge_router.py
+++ b/tests/system_tests_edge_router.py
@@ -374,7 +374,7 @@ class RouterTest(TestCase):
                                 self.routers[2].addresses[0],
                                 'EA1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_connectivity_INTA_EA2(self):
         if self.skip['test_02'] :
@@ -384,7 +384,7 @@ class RouterTest(TestCase):
                                 self.routers[3].addresses[0],
                                 'EA2')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_connectivity_INTB_EB1(self):
         if self.skip['test_03'] :
@@ -394,7 +394,7 @@ class RouterTest(TestCase):
                                 self.routers[4].addresses[0],
                                 'EB1')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_connectivity_INTB_EB2(self):
         if self.skip['test_04'] :
@@ -404,7 +404,7 @@ class RouterTest(TestCase):
                                 self.routers[5].addresses[0],
                                 'EB2')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_dynamic_address_same_edge(self):
         if self.skip['test_05'] :
@@ -413,7 +413,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[2].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_dynamic_address_interior_to_edge(self):
         if self.skip['test_06'] :
@@ -422,7 +422,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_dynamic_address_edge_to_interior(self):
         if self.skip['test_07'] :
@@ -431,7 +431,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[0].addresses[0],
                                   self.routers[2].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_dynamic_address_edge_to_edge_one_interior(self):
         if self.skip['test_08'] :
@@ -440,7 +440,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[3].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_dynamic_address_edge_to_edge_two_interior(self):
         if self.skip['test_09'] :
@@ -449,7 +449,7 @@ class RouterTest(TestCase):
         test = DynamicAddressTest(self.routers[2].addresses[0],
                                   self.routers[4].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_mobile_address_same_edge(self):
         if self.skip['test_10'] :
@@ -459,7 +459,7 @@ class RouterTest(TestCase):
                                  self.routers[2].addresses[0],
                                  "test_10")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_mobile_address_interior_to_edge(self):
         if self.skip['test_11'] :
@@ -469,7 +469,7 @@ class RouterTest(TestCase):
                                  self.routers[0].addresses[0],
                                  "test_11")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_12_mobile_address_edge_to_interior(self):
         if self.skip['test_12'] :
@@ -481,7 +481,7 @@ class RouterTest(TestCase):
         test.run()
         if test.error is not None:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_13_mobile_address_edge_to_edge_one_interior(self):
         if self.skip['test_13'] :
@@ -491,7 +491,7 @@ class RouterTest(TestCase):
                                  self.routers[3].addresses[0],
                                  "test_13")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_14_mobile_address_edge_to_edge_two_interior(self):
         if self.skip['test_14'] :
@@ -501,7 +501,7 @@ class RouterTest(TestCase):
                                  self.routers[4].addresses[0],
                                  "test_14")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # One sender two receiver tests.
     # One sender and two receivers on the same edge
@@ -514,7 +514,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_15")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # One sender and two receivers on the different edges. The edges are
     #  hanging off the  same interior router.
@@ -527,7 +527,7 @@ class RouterTest(TestCase):
                                                       self.routers[3].addresses[0],
                                                       "test_16")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on the interior and sender on the edge
     def test_17_mobile_address_edge_to_interior(self):
@@ -539,7 +539,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_17")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on the edge and the sender on the interior
     def test_18_mobile_address_interior_to_edge(self):
@@ -551,7 +551,7 @@ class RouterTest(TestCase):
                                                       self.routers[0].addresses[0],
                                                       "test_18")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on the edge and the sender on the 'other' interior
     def test_19_mobile_address_other_interior_to_edge(self):
@@ -563,7 +563,7 @@ class RouterTest(TestCase):
                                                       self.routers[1].addresses[0],
                                                       "test_19")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on the edge and the sender on the edge of
     # the 'other' interior
@@ -576,7 +576,7 @@ class RouterTest(TestCase):
                                                       self.routers[5].addresses[0],
                                                       "test_20")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # One receiver in an edge, another one in interior and the sender
     # is on the edge of another interior
@@ -589,7 +589,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_21")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers one on each interior router and and an edge sender
     # connectoed to the first interior
@@ -602,7 +602,7 @@ class RouterTest(TestCase):
                                                       self.routers[3].addresses[0],
                                                       "test_22")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_23_mobile_address_edge_sender_two_edge_receivers(self):
         if self.skip['test_23'] :
@@ -613,7 +613,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "test_23")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # 1 Sender and 3 receivers all on the same edge
     def test_24_multicast_mobile_address_same_edge(self):
@@ -628,7 +628,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # 1 Sender and receiver on one edge and 2 receivers on another edge
     # all in the same  interior
@@ -644,7 +644,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -660,7 +660,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on the interior
     def test_27_multicast_mobile_address_interior_to_edge(self):
@@ -675,7 +675,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -691,7 +691,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_29_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -706,7 +706,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_30_multicast_mobile_address_all_edges(self):
         if self.skip['test_30'] :
@@ -720,7 +720,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     ######### Multicast Large message tests ######################
 
@@ -739,7 +739,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # 1 Sender on one edge and 3 receivers on another edge all in the same
     # interior
@@ -756,7 +756,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -773,7 +773,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on the interior
     def test_34_multicast_mobile_address_interior_to_edge(self):
@@ -789,7 +789,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -806,7 +806,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_36_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -822,7 +822,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_37_multicast_mobile_address_all_edges(self):
         if self.skip['test_37'] :
@@ -837,7 +837,7 @@ class RouterTest(TestCase):
                                           large_msg=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_38_mobile_addr_event_three_receivers_same_interior(self):
         if self.skip['test_38'] :
@@ -851,7 +851,7 @@ class RouterTest(TestCase):
                                       "test_38")
 
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_39_mobile_addr_event_three_receivers_diff_interior(self):
         if self.skip['test_39'] :
@@ -866,7 +866,7 @@ class RouterTest(TestCase):
                                       "test_39", check_remote=True)
 
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_40_drop_rx_client_multicast_large_message(self):
         if self.skip['test_40'] :
@@ -880,7 +880,7 @@ class RouterTest(TestCase):
                                             self.routers[2].addresses[0],
                                             "multicast.40")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_41_drop_rx_client_multicast_small_message(self):
         if self.skip['test_41'] :
@@ -894,7 +894,7 @@ class RouterTest(TestCase):
                                             self.routers[2].addresses[0],
                                             "multicast.40", large_msg=False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_42_anon_sender_mobile_address_same_edge(self):
         if self.skip['test_42'] :
@@ -904,7 +904,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_42")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_43_anon_sender_mobile_address_interior_to_edge(self):
         if self.skip['test_43'] :
@@ -914,7 +914,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           "test_43")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_44_anon_sender_mobile_address_edge_to_interior(self):
         if self.skip['test_44'] :
@@ -924,7 +924,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_44")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_45_anon_sender_mobile_address_edge_to_edge_one_interior(self):
         if self.skip['test_45'] :
@@ -934,7 +934,7 @@ class RouterTest(TestCase):
                                           self.routers[3].addresses[0],
                                           "test_45")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_46_anon_sender_mobile_address_edge_to_edge_two_interior(self):
         if self.skip['test_46'] :
@@ -944,7 +944,7 @@ class RouterTest(TestCase):
                                           self.routers[4].addresses[0],
                                           "test_46")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_47_anon_sender_mobile_address_large_msg_same_edge(self):
         if self.skip['test_47'] :
@@ -954,7 +954,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_47", True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_48_anon_sender_mobile_address_large_msg_interior_to_edge(self):
         if self.skip['test_48'] :
@@ -964,7 +964,7 @@ class RouterTest(TestCase):
                                           self.routers[0].addresses[0],
                                           "test_48", True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_49_anon_sender_mobile_address_large_msg_edge_to_interior(self):
         if self.skip['test_49'] :
@@ -974,7 +974,7 @@ class RouterTest(TestCase):
                                           self.routers[2].addresses[0],
                                           "test_49", True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_50_anon_sender_mobile_address_large_msg_edge_to_edge_one_interior(self):
         if self.skip['test_50'] :
@@ -984,7 +984,7 @@ class RouterTest(TestCase):
                                           self.routers[3].addresses[0],
                                           "test_50", True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_51_anon_sender_mobile_address_large_msg_edge_to_edge_two_interior(self):
         if self.skip['test_51'] :
@@ -994,7 +994,7 @@ class RouterTest(TestCase):
                                           self.routers[4].addresses[0],
                                           "test_51", True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # 1 Sender and 3 receivers all on the same edge
     def test_52_anon_sender_multicast_mobile_address_same_edge(self):
@@ -1010,7 +1010,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # 1 Sender and receiver on one edge and 2 receivers on another edge
     # all in the same  interior
@@ -1027,7 +1027,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -1044,7 +1044,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on the interior
     def test_55_anon_sender_multicast_mobile_address_interior_to_edge(self):
@@ -1060,7 +1060,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -1077,7 +1077,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_57_anon_sender_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -1093,7 +1093,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_58_anon_sender_multicast_mobile_address_all_edges(self):
         if self.skip['test_58'] :
@@ -1108,7 +1108,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     ######### Multicast Large message anon sender tests ####################
 
@@ -1128,7 +1128,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # 1 Sender on one edge and 3 receivers on another edge all in the same
     # interior
@@ -1146,7 +1146,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Two receivers on each edge, one receiver on interior and sender
     # on the edge
@@ -1164,7 +1164,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on the interior
     def test_62_anon_sender_multicast_mobile_address_interior_to_edge(self):
@@ -1181,7 +1181,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Receivers on the edge and sender on an interior that is not connected
     # to the edges.
@@ -1199,7 +1199,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=2)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Sender on an interior and 3 receivers connected to three different edges
     def test_64_anon_sender_multicast_mobile_address_edge_to_edge_two_interiors(self):
@@ -1216,7 +1216,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_65_anon_sender_multicast_mobile_address_all_edges(self):
         if self.skip['test_65'] :
@@ -1232,7 +1232,7 @@ class RouterTest(TestCase):
                                           anon_sender=True,
                                           subscriber_count=3)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_66_anon_sender_drop_rx_client_multicast_large_message(self):
         # test what happens if some multicast receivers close in the middle of
@@ -1246,7 +1246,7 @@ class RouterTest(TestCase):
                                                       self.routers[2].addresses[0],
                                                       "multicast.66")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_67_drop_rx_client_multicast_small_message(self):
         # test what happens if some multicast receivers close in the middle of
@@ -1261,7 +1261,7 @@ class RouterTest(TestCase):
                                                       "multicast.67",
                                                       large_msg=False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def run_qdstat(self, args, regexp=None, address=None):
         if args:

--- a/tests/system_tests_failover_list.py
+++ b/tests/system_tests_failover_list.py
@@ -57,18 +57,18 @@ class RouterTest(TestCase):
     def test_01_no_failover_list(self):
         test = FailoverTest(self.routers[0].addresses[0], 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_single_failover_host(self):
         test = FailoverTest(self.routers[0].addresses[1], 1, [{'network-host': 'other-host', 'port': '25000'}])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_double_failover_host(self):
         test = FailoverTest(self.routers[0].addresses[2], 2,
                             [{'network-host': 'second-host', 'port': '25000'}, {'scheme': 'amqps', 'network-host': 'third-host', 'port': '5671'}])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class FailoverTest(MessagingHandler):

--- a/tests/system_tests_failover_list.py
+++ b/tests/system_tests_failover_list.py
@@ -57,18 +57,18 @@ class RouterTest(TestCase):
     def test_01_no_failover_list(self):
         test = FailoverTest(self.routers[0].addresses[0], 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_single_failover_host(self):
         test = FailoverTest(self.routers[0].addresses[1], 1, [{'network-host': 'other-host', 'port': '25000'}])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_double_failover_host(self):
         test = FailoverTest(self.routers[0].addresses[2], 2,
                             [{'network-host': 'second-host', 'port': '25000'}, {'scheme': 'amqps', 'network-host': 'third-host', 'port': '5671'}])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class FailoverTest(MessagingHandler):

--- a/tests/system_tests_fallback_dest.py
+++ b/tests/system_tests_fallback_dest.py
@@ -100,168 +100,168 @@ class RouterTest(TestCase):
                                self.ROUTER_INTA,
                                'dest.01', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_sender_first_fallback_same_interior(self):
         test = SenderFirstTest(self.ROUTER_INTA,
                                self.ROUTER_INTA,
                                'dest.02', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_sender_first_primary_same_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EA1,
                                'dest.03', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_sender_first_fallback_same_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EA1,
                                'dest.04', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_sender_first_primary_interior_interior(self):
         test = SenderFirstTest(self.ROUTER_INTA,
                                self.ROUTER_INTB,
                                'dest.05', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_sender_first_fallback_interior_interior(self):
         test = SenderFirstTest(self.ROUTER_INTA,
                                self.ROUTER_INTB,
                                'dest.06', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_sender_first_primary_edge_interior(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_INTB,
                                'dest.07', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_sender_first_fallback_edge_interior(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_INTB,
                                'dest.08', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_sender_first_primary_interior_edge(self):
         test = SenderFirstTest(self.ROUTER_INTB,
                                self.ROUTER_EA1,
                                'dest.09', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_sender_first_fallback_interior_edge(self):
         test = SenderFirstTest(self.ROUTER_INTB,
                                self.ROUTER_EA1,
                                'dest.10', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_sender_first_primary_edge_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EB1,
                                'dest.11', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_12_sender_first_fallback_edge_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EB1,
                                'dest.12', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_13_receiver_first_primary_same_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTA,
                                  'dest.13', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_14_receiver_first_fallback_same_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTA,
                                  'dest.14', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_15_receiver_first_primary_same_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EA1,
                                  'dest.15', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_16_receiver_first_fallback_same_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EA1,
                                  'dest.16', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_receiver_first_primary_interior_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTB,
                                  'dest.17', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_18_receiver_first_fallback_interior_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTB,
                                  'dest.18', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_19_receiver_first_primary_edge_interior(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_INTB,
                                  'dest.19', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_20_receiver_first_fallback_edge_interior(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_INTB,
                                  'dest.20', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_21_receiver_first_primary_interior_edge(self):
         test = ReceiverFirstTest(self.ROUTER_INTB,
                                  self.ROUTER_EA1,
                                  'dest.21', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_22_receiver_first_fallback_interior_edge(self):
         test = ReceiverFirstTest(self.ROUTER_INTB,
                                  self.ROUTER_EA1,
                                  'dest.22', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_23_receiver_first_primary_edge_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EB1,
                                  'dest.23', False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_24_receiver_first_fallback_edge_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EB1,
                                  'dest.24', True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_25_switchover_same_edge(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -269,7 +269,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.25')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_26_switchover_same_interior(self):
         test = SwitchoverTest(self.ROUTER_INTA,
@@ -277,7 +277,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.26')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_27_switchover_local_edge_alt_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -285,7 +285,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.27')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_28_switchover_local_edge_alt_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -293,7 +293,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.28')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_29_switchover_local_edge_pri_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -301,7 +301,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.29')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_30_switchover_local_interior_pri_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -309,7 +309,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.30')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_31_switchover_local_interior_alt_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -317,7 +317,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTB,
                               'dest.31')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_32_switchover_local_interior_alt_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -325,7 +325,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTB,
                               'dest.32')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_33_switchover_local_interior_pri_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -333,7 +333,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.33')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_34_switchover_local_interior_pri_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -341,7 +341,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.34')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_35_switchover_mix_1(self):
         test = SwitchoverTest(self.ROUTER_INTA,
@@ -349,7 +349,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.35')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_36_switchover_mix_2(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -357,7 +357,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.36')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_37_switchover_mix_3(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -365,7 +365,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.37')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_38_switchover_mix_4(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -373,79 +373,79 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.38')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_39_auto_link_sender_first_fallback_same_interior(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_INTA,
                                        self.ROUTER_INTA_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_40_auto_link_sender_first_fallback_same_edge(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
                                        self.ROUTER_EA1_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_41_auto_link_sender_first_fallback_interior_interior(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_INTA,
                                        self.ROUTER_INTB_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_42_auto_link_sender_first_fallback_edge_interior(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
                                        self.ROUTER_INTA_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_43_auto_link_sender_first_fallback_interior_edge(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_INTB,
                                        self.ROUTER_EA1_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_44_auto_link_sender_first_fallback_edge_edge(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
                                        self.ROUTER_EB1_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_45_auto_link_receiver_first_fallback_same_interior(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_INTA,
                                          self.ROUTER_INTA_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_46_auto_link_receiver_first_fallback_same_edge(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
                                          self.ROUTER_EA1_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_47_auto_link_receiver_first_fallback_interior_interior(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_INTA,
                                          self.ROUTER_INTB_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_48_auto_link_receiver_first_fallback_edge_interior(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
                                          self.ROUTER_INTB_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_49_auto_link_receiver_first_fallback_interior_edge(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_INTB,
                                          self.ROUTER_EA1_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_50_auto_link_receiver_first_fallback_edge_edge(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
                                          self.ROUTER_EB1_WP)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class SenderFirstTest(MessagingHandler):

--- a/tests/system_tests_fallback_dest.py
+++ b/tests/system_tests_fallback_dest.py
@@ -100,168 +100,168 @@ class RouterTest(TestCase):
                                self.ROUTER_INTA,
                                'dest.01', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_sender_first_fallback_same_interior(self):
         test = SenderFirstTest(self.ROUTER_INTA,
                                self.ROUTER_INTA,
                                'dest.02', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_sender_first_primary_same_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EA1,
                                'dest.03', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_sender_first_fallback_same_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EA1,
                                'dest.04', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_sender_first_primary_interior_interior(self):
         test = SenderFirstTest(self.ROUTER_INTA,
                                self.ROUTER_INTB,
                                'dest.05', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_sender_first_fallback_interior_interior(self):
         test = SenderFirstTest(self.ROUTER_INTA,
                                self.ROUTER_INTB,
                                'dest.06', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_sender_first_primary_edge_interior(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_INTB,
                                'dest.07', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_sender_first_fallback_edge_interior(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_INTB,
                                'dest.08', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_sender_first_primary_interior_edge(self):
         test = SenderFirstTest(self.ROUTER_INTB,
                                self.ROUTER_EA1,
                                'dest.09', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_sender_first_fallback_interior_edge(self):
         test = SenderFirstTest(self.ROUTER_INTB,
                                self.ROUTER_EA1,
                                'dest.10', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_sender_first_primary_edge_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EB1,
                                'dest.11', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_12_sender_first_fallback_edge_edge(self):
         test = SenderFirstTest(self.ROUTER_EA1,
                                self.ROUTER_EB1,
                                'dest.12', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_13_receiver_first_primary_same_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTA,
                                  'dest.13', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_14_receiver_first_fallback_same_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTA,
                                  'dest.14', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_15_receiver_first_primary_same_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EA1,
                                  'dest.15', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_16_receiver_first_fallback_same_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EA1,
                                  'dest.16', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_receiver_first_primary_interior_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTB,
                                  'dest.17', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_18_receiver_first_fallback_interior_interior(self):
         test = ReceiverFirstTest(self.ROUTER_INTA,
                                  self.ROUTER_INTB,
                                  'dest.18', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_19_receiver_first_primary_edge_interior(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_INTB,
                                  'dest.19', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_20_receiver_first_fallback_edge_interior(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_INTB,
                                  'dest.20', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_21_receiver_first_primary_interior_edge(self):
         test = ReceiverFirstTest(self.ROUTER_INTB,
                                  self.ROUTER_EA1,
                                  'dest.21', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_22_receiver_first_fallback_interior_edge(self):
         test = ReceiverFirstTest(self.ROUTER_INTB,
                                  self.ROUTER_EA1,
                                  'dest.22', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_23_receiver_first_primary_edge_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EB1,
                                  'dest.23', False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_24_receiver_first_fallback_edge_edge(self):
         test = ReceiverFirstTest(self.ROUTER_EA1,
                                  self.ROUTER_EB1,
                                  'dest.24', True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_25_switchover_same_edge(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -269,7 +269,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.25')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_26_switchover_same_interior(self):
         test = SwitchoverTest(self.ROUTER_INTA,
@@ -277,7 +277,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.26')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_27_switchover_local_edge_alt_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -285,7 +285,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.27')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_28_switchover_local_edge_alt_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -293,7 +293,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.28')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_29_switchover_local_edge_pri_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -301,7 +301,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.29')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_30_switchover_local_interior_pri_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -309,7 +309,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.30')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_31_switchover_local_interior_alt_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -317,7 +317,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTB,
                               'dest.31')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_32_switchover_local_interior_alt_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -325,7 +325,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTB,
                               'dest.32')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_33_switchover_local_interior_pri_remote_interior(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -333,7 +333,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.33')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_34_switchover_local_interior_pri_remote_edge(self):
         test = SwitchoverTest(self.ROUTER_INTB,
@@ -341,7 +341,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.34')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_35_switchover_mix_1(self):
         test = SwitchoverTest(self.ROUTER_INTA,
@@ -349,7 +349,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EA1,
                               'dest.35')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_36_switchover_mix_2(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -357,7 +357,7 @@ class RouterTest(TestCase):
                               self.ROUTER_INTA,
                               'dest.36')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_37_switchover_mix_3(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -365,7 +365,7 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.37')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_38_switchover_mix_4(self):
         test = SwitchoverTest(self.ROUTER_EA1,
@@ -373,79 +373,79 @@ class RouterTest(TestCase):
                               self.ROUTER_EB1,
                               'dest.38')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_39_auto_link_sender_first_fallback_same_interior(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_INTA,
                                        self.ROUTER_INTA_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_40_auto_link_sender_first_fallback_same_edge(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
                                        self.ROUTER_EA1_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_41_auto_link_sender_first_fallback_interior_interior(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_INTA,
                                        self.ROUTER_INTB_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_42_auto_link_sender_first_fallback_edge_interior(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
                                        self.ROUTER_INTA_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_43_auto_link_sender_first_fallback_interior_edge(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_INTB,
                                        self.ROUTER_EA1_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_44_auto_link_sender_first_fallback_edge_edge(self):
         test = SenderFirstAutoLinkTest(self.ROUTER_EA1,
                                        self.ROUTER_EB1_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_45_auto_link_receiver_first_fallback_same_interior(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_INTA,
                                          self.ROUTER_INTA_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_46_auto_link_receiver_first_fallback_same_edge(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
                                          self.ROUTER_EA1_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_47_auto_link_receiver_first_fallback_interior_interior(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_INTA,
                                          self.ROUTER_INTB_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_48_auto_link_receiver_first_fallback_edge_interior(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
                                          self.ROUTER_INTB_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_49_auto_link_receiver_first_fallback_interior_edge(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_INTB,
                                          self.ROUTER_EA1_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_50_auto_link_receiver_first_fallback_edge_edge(self):
         test = ReceiverFirstAutoLinkTest(self.ROUTER_EA1,
                                          self.ROUTER_EB1_WP)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class SenderFirstTest(MessagingHandler):

--- a/tests/system_tests_interior_sync_up.py
+++ b/tests/system_tests_interior_sync_up.py
@@ -77,7 +77,7 @@ class RouterTest(TestCase):
     def test_interior_sync_up(self):
         test = InteriorSyncUpTest(self.routers[0].addresses[0], self.routers[1].addresses[0], self.routers[1].ports[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class DelayTimeout(object):

--- a/tests/system_tests_interior_sync_up.py
+++ b/tests/system_tests_interior_sync_up.py
@@ -77,7 +77,7 @@ class RouterTest(TestCase):
     def test_interior_sync_up(self):
         test = InteriorSyncUpTest(self.routers[0].addresses[0], self.routers[1].addresses[0], self.routers[1].ports[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class DelayTimeout(object):

--- a/tests/system_tests_link_route_credit.py
+++ b/tests/system_tests_link_route_credit.py
@@ -89,7 +89,7 @@ class RouterTest(TestCase):
                                     self.routers[2].addresses[0],
                                     'queue.01', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_dest_sender_same_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -97,7 +97,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.02', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_dest_sender_edge_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -105,7 +105,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.03', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_dest_sender_interior_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -113,7 +113,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.04', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_dest_sender_edge_interior(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -121,7 +121,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.05', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_dest_sender_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -129,7 +129,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.06', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_dest_sender_edge_interior_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -137,7 +137,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.07', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_dest_sender_initial_credit_same_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -145,7 +145,7 @@ class RouterTest(TestCase):
                                     self.routers[2].addresses[0],
                                     'queue.08', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_dest_sender_initial_credit_same_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -153,7 +153,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.09', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_dest_sender_initial_credit_edge_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -161,7 +161,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.10', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_dest_sender_initial_credit_interior_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -169,7 +169,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.11', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_12_dest_sender_initial_credit_edge_interior(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -177,7 +177,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.12', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_13_dest_sender_initial_credit_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -185,7 +185,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.13', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_14_dest_sender_initial_credit_edge_interior_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -193,7 +193,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.14', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_15_dest_receiver_same_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -201,7 +201,7 @@ class RouterTest(TestCase):
                                       self.routers[2].addresses[0],
                                       'queue.15', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_16_dest_receiver_same_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -209,7 +209,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.16', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_dest_receiver_edge_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -217,7 +217,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.17', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_18_dest_receiver_interior_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -225,7 +225,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.18', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_19_dest_receiver_edge_interior(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -233,7 +233,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.19', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_20_dest_receiver_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -241,7 +241,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.20', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_21_dest_receiver_edge_interior_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -249,7 +249,7 @@ class RouterTest(TestCase):
                                       self.routers[1].addresses[0],
                                       'queue.21', 0)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_22_dest_receiver_initial_credit_same_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -257,7 +257,7 @@ class RouterTest(TestCase):
                                       self.routers[2].addresses[0],
                                       'queue.22', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_23_dest_receiver_initial_credit_same_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -265,7 +265,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.23', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_24_dest_receiver_initial_credit_edge_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -273,7 +273,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.24', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_25_dest_receiver_initial_credit_interior_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -281,7 +281,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.25', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_26_dest_receiver_initial_credit_edge_interior(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -289,7 +289,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.26', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_27_dest_receiver_initial_credit_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -297,7 +297,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.27', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_28_dest_receiver_initial_credit_edge_interior_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -305,12 +305,12 @@ class RouterTest(TestCase):
                                       self.routers[1].addresses[0],
                                       'queue.28', 5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_29_fast_teardown_test(self):
         test = LRFastTeardownTest(self.routers[2].addresses[0], "normal.29")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_link_route_credit.py
+++ b/tests/system_tests_link_route_credit.py
@@ -89,7 +89,7 @@ class RouterTest(TestCase):
                                     self.routers[2].addresses[0],
                                     'queue.01', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_dest_sender_same_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -97,7 +97,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.02', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_dest_sender_edge_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -105,7 +105,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.03', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_dest_sender_interior_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -113,7 +113,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.04', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_dest_sender_edge_interior(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -121,7 +121,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.05', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_dest_sender_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -129,7 +129,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.06', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_dest_sender_edge_interior_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -137,7 +137,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.07', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_dest_sender_initial_credit_same_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -145,7 +145,7 @@ class RouterTest(TestCase):
                                     self.routers[2].addresses[0],
                                     'queue.08', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_dest_sender_initial_credit_same_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -153,7 +153,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.09', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_dest_sender_initial_credit_edge_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -161,7 +161,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.10', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_dest_sender_initial_credit_interior_interior(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -169,7 +169,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.11', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_12_dest_sender_initial_credit_edge_interior(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -177,7 +177,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.12', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_13_dest_sender_initial_credit_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[0].addresses[0],
@@ -185,7 +185,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.13', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_14_dest_sender_initial_credit_edge_interior_interior_edge(self):
         test = LRDestSenderFlowTest(self.routers[2].addresses[0],
@@ -193,7 +193,7 @@ class RouterTest(TestCase):
                                     self.routers[0].addresses[0],
                                     'queue.14', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_15_dest_receiver_same_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -201,7 +201,7 @@ class RouterTest(TestCase):
                                       self.routers[2].addresses[0],
                                       'queue.15', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_16_dest_receiver_same_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -209,7 +209,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.16', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_dest_receiver_edge_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -217,7 +217,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.17', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_18_dest_receiver_interior_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -225,7 +225,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.18', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_19_dest_receiver_edge_interior(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -233,7 +233,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.19', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_20_dest_receiver_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -241,7 +241,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.20', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_21_dest_receiver_edge_interior_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -249,7 +249,7 @@ class RouterTest(TestCase):
                                       self.routers[1].addresses[0],
                                       'queue.21', 0)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_22_dest_receiver_initial_credit_same_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -257,7 +257,7 @@ class RouterTest(TestCase):
                                       self.routers[2].addresses[0],
                                       'queue.22', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_23_dest_receiver_initial_credit_same_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -265,7 +265,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.23', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_24_dest_receiver_initial_credit_edge_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -273,7 +273,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.24', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_25_dest_receiver_initial_credit_interior_interior(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -281,7 +281,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.25', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_26_dest_receiver_initial_credit_edge_interior(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -289,7 +289,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.26', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_27_dest_receiver_initial_credit_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[0].addresses[1],
@@ -297,7 +297,7 @@ class RouterTest(TestCase):
                                       self.routers[0].addresses[0],
                                       'queue.27', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_28_dest_receiver_initial_credit_edge_interior_interior_edge(self):
         test = LRDestReceiverFlowTest(self.routers[2].addresses[1],
@@ -305,12 +305,12 @@ class RouterTest(TestCase):
                                       self.routers[1].addresses[0],
                                       'queue.28', 5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_29_fast_teardown_test(self):
         test = LRFastTeardownTest(self.routers[2].addresses[0], "normal.29")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -663,37 +663,37 @@ class LinkRouteTest(TestCase):
         qdstat_address = self.routers[2].addresses[0]
         test = DeliveryTagsTest(sender_address, listening_address, qdstat_address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_yyy_invalid_delivery_tag(self):
         test = InvalidTagTest(self.routers[2].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_close_with_unsettled(self):
         test = CloseWithUnsettledTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_www_drain_support_all_messages(self):
         drain_support = DrainMessagesHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertEqual(None, drain_support.error)
+        self.assertIsNone(drain_support.error, msg=drain_support.error)
 
     def test_www_drain_support_one_message(self):
         drain_support = DrainOneMessageHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertEqual(None, drain_support.error)
+        self.assertIsNone(drain_support.error, msg=drain_support.error)
 
     def test_www_drain_support_no_messages(self):
         drain_support = DrainNoMessagesHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertEqual(None, drain_support.error)
+        self.assertIsNone(drain_support.error, msg=drain_support.error)
 
     def test_www_drain_support_no_more_messages(self):
         drain_support = DrainNoMoreMessagesHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertEqual(None, drain_support.error)
+        self.assertIsNone(drain_support.error, msg=drain_support.error)
 
     def test_link_route_terminus_address(self):
         # The receiver is attaching to router B to a listener that has link route for address 'pulp.task' setup.
@@ -716,29 +716,29 @@ class LinkRouteTest(TestCase):
     def test_dynamic_source(self):
         test = DynamicSourceTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_dynamic_target(self):
         test = DynamicTargetTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_detach_without_close(self):
         test = DetachNoCloseTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_detach_mixed_close(self):
         test = DetachMixedCloseTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def _multi_link_send_receive(self, send_host, receive_host, name):
         senders = ["%s/%s" % (send_host, address) for address in ["org.apache.foo", "org.apache.bar"]]
         receivers = ["%s/%s" % (receive_host, address) for address in ["org.apache.foo", "org.apache.bar"]]
         test = MultiLinkSendReceive(senders, receivers, name)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_same_name_route_receivers_through_B(self):
         self._multi_link_send_receive(self.routers[0].addresses[0], self.routers[1].addresses[0], "recv_through_B")
@@ -762,7 +762,7 @@ class LinkRouteTest(TestCase):
         """
         test = EchoDetachReceived(self.routers[2].addresses[0], self.routers[2].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_bad_link_route_config(self):
         """
@@ -2443,13 +2443,13 @@ class Dispatch1428(TestCase):
 
         first = SendReceive("%s/foo" % self.routers[1].addresses[0], "%s/foo" % self.routers[0].addresses[0])
         first.run()
-        self.assertEqual(None, first.error)
+        self.assertIsNone(first.error, msg=first.error)
         second = SendReceive("%s/bar" % self.routers[1].addresses[0], "%s/bar" % self.routers[0].addresses[0])
         second.run()
-        self.assertEqual(None, second.error)
+        self.assertIsNone(second.error, msg=second.error)
         third = SendReceive("%s/baz" % self.routers[1].addresses[0], "%s/baz" % self.routers[0].addresses[0])
         third.run()
-        self.assertEqual(None, third.error)
+        self.assertIsNone(third.error, msg=third.error)
 
 
 class SendReceive(MessagingHandler):
@@ -2724,7 +2724,7 @@ class LinkRoute3Hop(TestCase):
         sniffer = DispositionSniffer("%s/closest/test-client" %
                                      self.QDR_C.addresses[0])
         sniffer.run()
-        self.assertEqual(None, sniffer.error)
+        self.assertIsNone(sniffer.error, msg=sniffer.error)
         state = sniffer.delivery.remote
         self.assertTrue(state.failed)
         self.assertTrue(state.undeliverable)
@@ -2762,7 +2762,7 @@ class LinkRoute3Hop(TestCase):
         sniffer = DispositionSniffer("%s/closest/test-client" %
                                      self.QDR_C.addresses[0])
         sniffer.run()
-        self.assertEqual(None, sniffer.error)
+        self.assertIsNone(sniffer.error, msg=sniffer.error)
         state = sniffer.delivery.remote
         self.assertTrue(state.condition is not None)
         self.assertEqual("condition-name", state.condition.name)

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -663,37 +663,37 @@ class LinkRouteTest(TestCase):
         qdstat_address = self.routers[2].addresses[0]
         test = DeliveryTagsTest(sender_address, listening_address, qdstat_address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_yyy_invalid_delivery_tag(self):
         test = InvalidTagTest(self.routers[2].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_close_with_unsettled(self):
         test = CloseWithUnsettledTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_www_drain_support_all_messages(self):
         drain_support = DrainMessagesHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertIsNone(drain_support.error, msg=drain_support.error)
+        self.assertIsNone(drain_support.error)
 
     def test_www_drain_support_one_message(self):
         drain_support = DrainOneMessageHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertIsNone(drain_support.error, msg=drain_support.error)
+        self.assertIsNone(drain_support.error)
 
     def test_www_drain_support_no_messages(self):
         drain_support = DrainNoMessagesHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertIsNone(drain_support.error, msg=drain_support.error)
+        self.assertIsNone(drain_support.error)
 
     def test_www_drain_support_no_more_messages(self):
         drain_support = DrainNoMoreMessagesHandler(self.routers[2].addresses[0])
         drain_support.run()
-        self.assertIsNone(drain_support.error, msg=drain_support.error)
+        self.assertIsNone(drain_support.error)
 
     def test_link_route_terminus_address(self):
         # The receiver is attaching to router B to a listener that has link route for address 'pulp.task' setup.
@@ -716,29 +716,29 @@ class LinkRouteTest(TestCase):
     def test_dynamic_source(self):
         test = DynamicSourceTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_dynamic_target(self):
         test = DynamicTargetTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_detach_without_close(self):
         test = DetachNoCloseTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_detach_mixed_close(self):
         test = DetachMixedCloseTest(self.routers[1].addresses[0], self.routers[1].addresses[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def _multi_link_send_receive(self, send_host, receive_host, name):
         senders = ["%s/%s" % (send_host, address) for address in ["org.apache.foo", "org.apache.bar"]]
         receivers = ["%s/%s" % (receive_host, address) for address in ["org.apache.foo", "org.apache.bar"]]
         test = MultiLinkSendReceive(senders, receivers, name)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_same_name_route_receivers_through_B(self):
         self._multi_link_send_receive(self.routers[0].addresses[0], self.routers[1].addresses[0], "recv_through_B")
@@ -762,7 +762,7 @@ class LinkRouteTest(TestCase):
         """
         test = EchoDetachReceived(self.routers[2].addresses[0], self.routers[2].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_bad_link_route_config(self):
         """
@@ -2443,13 +2443,13 @@ class Dispatch1428(TestCase):
 
         first = SendReceive("%s/foo" % self.routers[1].addresses[0], "%s/foo" % self.routers[0].addresses[0])
         first.run()
-        self.assertIsNone(first.error, msg=first.error)
+        self.assertIsNone(first.error)
         second = SendReceive("%s/bar" % self.routers[1].addresses[0], "%s/bar" % self.routers[0].addresses[0])
         second.run()
-        self.assertIsNone(second.error, msg=second.error)
+        self.assertIsNone(second.error)
         third = SendReceive("%s/baz" % self.routers[1].addresses[0], "%s/baz" % self.routers[0].addresses[0])
         third.run()
-        self.assertIsNone(third.error, msg=third.error)
+        self.assertIsNone(third.error)
 
 
 class SendReceive(MessagingHandler):
@@ -2724,7 +2724,7 @@ class LinkRoute3Hop(TestCase):
         sniffer = DispositionSniffer("%s/closest/test-client" %
                                      self.QDR_C.addresses[0])
         sniffer.run()
-        self.assertIsNone(sniffer.error, msg=sniffer.error)
+        self.assertIsNone(sniffer.error)
         state = sniffer.delivery.remote
         self.assertTrue(state.failed)
         self.assertTrue(state.undeliverable)
@@ -2762,7 +2762,7 @@ class LinkRoute3Hop(TestCase):
         sniffer = DispositionSniffer("%s/closest/test-client" %
                                      self.QDR_C.addresses[0])
         sniffer.run()
-        self.assertIsNone(sniffer.error, msg=sniffer.error)
+        self.assertIsNone(sniffer.error)
         state = sniffer.delivery.remote
         self.assertTrue(state.condition is not None)
         self.assertEqual("condition-name", state.condition.name)

--- a/tests/system_tests_link_routes_add_external_prefix.py
+++ b/tests/system_tests_link_routes_add_external_prefix.py
@@ -181,42 +181,42 @@ class LinkRouteTest(TestCase):
     def test_route_sender_add_prefix_on_B(self):
         test = SendReceive("%s/foo" % self.routers[1].addresses[0], "%s/bar.foo" % self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_receiver_add_prefix_on_B(self):
         test = SendReceive("%s/bar.foo" % self.routers[0].addresses[0], "%s/foo" % self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_sender_add_prefix_on_C(self):
         test = SendReceive("%s/foo" % self.routers[2].addresses[0], "%s/bar.foo" % self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_receiver_add_prefix_on_C(self):
         test = SendReceive("%s/bar.foo" % self.routers[0].addresses[0], "%s/foo" % self.routers[2].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_sender_del_prefix_on_B(self):
         test = SendReceive("%s/qdr-a.baz" % self.routers[1].addresses[0], "%s/baz" % self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_receiver_del_prefix_on_B(self):
         test = SendReceive("%s/baz" % self.routers[0].addresses[0], "%s/qdr-a.baz" % self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_sender_del_prefix_on_C(self):
         test = SendReceive("%s/qdr-a.baz" % self.routers[2].addresses[0], "%s/baz" % self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_route_receiver_del_prefix_on_C(self):
         test = SendReceive("%s/baz" % self.routers[0].addresses[0], "%s/qdr-a.baz" % self.routers[2].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class SendReceive(MessagingHandler):

--- a/tests/system_tests_link_routes_add_external_prefix.py
+++ b/tests/system_tests_link_routes_add_external_prefix.py
@@ -181,42 +181,42 @@ class LinkRouteTest(TestCase):
     def test_route_sender_add_prefix_on_B(self):
         test = SendReceive("%s/foo" % self.routers[1].addresses[0], "%s/bar.foo" % self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_receiver_add_prefix_on_B(self):
         test = SendReceive("%s/bar.foo" % self.routers[0].addresses[0], "%s/foo" % self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_sender_add_prefix_on_C(self):
         test = SendReceive("%s/foo" % self.routers[2].addresses[0], "%s/bar.foo" % self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_receiver_add_prefix_on_C(self):
         test = SendReceive("%s/bar.foo" % self.routers[0].addresses[0], "%s/foo" % self.routers[2].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_sender_del_prefix_on_B(self):
         test = SendReceive("%s/qdr-a.baz" % self.routers[1].addresses[0], "%s/baz" % self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_receiver_del_prefix_on_B(self):
         test = SendReceive("%s/baz" % self.routers[0].addresses[0], "%s/qdr-a.baz" % self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_sender_del_prefix_on_C(self):
         test = SendReceive("%s/qdr-a.baz" % self.routers[2].addresses[0], "%s/baz" % self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_route_receiver_del_prefix_on_C(self):
         test = SendReceive("%s/baz" % self.routers[0].addresses[0], "%s/qdr-a.baz" % self.routers[2].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class SendReceive(MessagingHandler):

--- a/tests/system_tests_multi_phase.py
+++ b/tests/system_tests_multi_phase.py
@@ -83,7 +83,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.01')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_waypoint_same_edge(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -91,7 +91,7 @@ class RouterTest(TestCase):
                             self.routers[2].addresses[0],
                             'queue.02')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_waypoint_edge_interior(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -99,7 +99,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.03')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_waypoint_interior_edge(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -107,7 +107,7 @@ class RouterTest(TestCase):
                             self.routers[2].addresses[0],
                             'queue.04')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_waypoint_interior_interior(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -115,7 +115,7 @@ class RouterTest(TestCase):
                             self.routers[1].addresses[0],
                             'queue.05')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_waypoint_edge_edge(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -123,7 +123,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.06')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_waypoint_edge_endpoints_int_1(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -131,7 +131,7 @@ class RouterTest(TestCase):
                             self.routers[2].addresses[0],
                             'queue.07')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_waypoint_edge_endpoints_int_2(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -139,7 +139,7 @@ class RouterTest(TestCase):
                             self.routers[5].addresses[0],
                             'queue.08')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_waypoint_int_endpoints_edge_1(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -147,7 +147,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.09')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_waypoint_int_endpoints_edge_2(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -155,7 +155,7 @@ class RouterTest(TestCase):
                             self.routers[1].addresses[0],
                             'queue.10')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_waypoint_int_endpoints_int_1(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -163,7 +163,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.11')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_12_waypoint_int_endpoints_int_2(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -171,7 +171,7 @@ class RouterTest(TestCase):
                             self.routers[1].addresses[0],
                             'queue.12')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_13_waypoint_edge_endpoints_edge_1(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -179,7 +179,7 @@ class RouterTest(TestCase):
                             self.routers[3].addresses[0],
                             'queue.13')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_14_waypoint_edge_endpoints_edge_2(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -187,7 +187,7 @@ class RouterTest(TestCase):
                             self.routers[4].addresses[0],
                             'queue.14')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_15_multiphase_1(self):
         test = MultiPhaseTest(self.routers[2].addresses[0],
@@ -205,7 +205,7 @@ class RouterTest(TestCase):
         ],
             'multi.15')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_16_multiphase_2(self):
         test = MultiPhaseTest(self.routers[2].addresses[0],
@@ -223,7 +223,7 @@ class RouterTest(TestCase):
         ],
             'multi.16')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_multiphase_3(self):
         test = MultiPhaseTest(self.routers[1].addresses[0],
@@ -241,7 +241,7 @@ class RouterTest(TestCase):
         ],
             'multi.17')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class WaypointTest(MessagingHandler):

--- a/tests/system_tests_multi_phase.py
+++ b/tests/system_tests_multi_phase.py
@@ -83,7 +83,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.01')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_waypoint_same_edge(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -91,7 +91,7 @@ class RouterTest(TestCase):
                             self.routers[2].addresses[0],
                             'queue.02')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_waypoint_edge_interior(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -99,7 +99,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.03')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_waypoint_interior_edge(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -107,7 +107,7 @@ class RouterTest(TestCase):
                             self.routers[2].addresses[0],
                             'queue.04')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_waypoint_interior_interior(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -115,7 +115,7 @@ class RouterTest(TestCase):
                             self.routers[1].addresses[0],
                             'queue.05')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_waypoint_edge_edge(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -123,7 +123,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.06')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_waypoint_edge_endpoints_int_1(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -131,7 +131,7 @@ class RouterTest(TestCase):
                             self.routers[2].addresses[0],
                             'queue.07')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_waypoint_edge_endpoints_int_2(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -139,7 +139,7 @@ class RouterTest(TestCase):
                             self.routers[5].addresses[0],
                             'queue.08')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_waypoint_int_endpoints_edge_1(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -147,7 +147,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.09')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_waypoint_int_endpoints_edge_2(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -155,7 +155,7 @@ class RouterTest(TestCase):
                             self.routers[1].addresses[0],
                             'queue.10')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_waypoint_int_endpoints_int_1(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -163,7 +163,7 @@ class RouterTest(TestCase):
                             self.routers[0].addresses[0],
                             'queue.11')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_12_waypoint_int_endpoints_int_2(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -171,7 +171,7 @@ class RouterTest(TestCase):
                             self.routers[1].addresses[0],
                             'queue.12')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_13_waypoint_edge_endpoints_edge_1(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -179,7 +179,7 @@ class RouterTest(TestCase):
                             self.routers[3].addresses[0],
                             'queue.13')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_14_waypoint_edge_endpoints_edge_2(self):
         test = WaypointTest(self.routers[2].addresses[0],
@@ -187,7 +187,7 @@ class RouterTest(TestCase):
                             self.routers[4].addresses[0],
                             'queue.14')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_15_multiphase_1(self):
         test = MultiPhaseTest(self.routers[2].addresses[0],
@@ -205,7 +205,7 @@ class RouterTest(TestCase):
         ],
             'multi.15')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_16_multiphase_2(self):
         test = MultiPhaseTest(self.routers[2].addresses[0],
@@ -223,7 +223,7 @@ class RouterTest(TestCase):
         ],
             'multi.16')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_multiphase_3(self):
         test = MultiPhaseTest(self.routers[1].addresses[0],
@@ -241,7 +241,7 @@ class RouterTest(TestCase):
         ],
             'multi.17')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class WaypointTest(MessagingHandler):

--- a/tests/system_tests_multi_tenancy.py
+++ b/tests/system_tests_multi_tenancy.py
@@ -80,7 +80,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0anything/addr_01")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_one_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -90,7 +90,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_02")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_one_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -100,7 +100,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_03")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_one_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -110,7 +110,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_04")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_two_router_targeted_sender_no_tenant(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -120,7 +120,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_05")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_two_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -130,7 +130,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_06")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_two_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -140,7 +140,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_07")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_two_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -150,7 +150,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_08")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_one_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -160,7 +160,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_09")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_one_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -170,7 +170,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_10")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_one_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -180,7 +180,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_11")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_12_one_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -190,7 +190,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_12")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_13_two_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -200,7 +200,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_13")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_14_two_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -210,7 +210,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_14")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_15_two_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -220,7 +220,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_15")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_16_two_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -230,7 +230,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_16")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_one_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -240,7 +240,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_18_one_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -250,7 +250,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_19_one_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -260,7 +260,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_20_one_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -270,7 +270,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_21_two_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -280,7 +280,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_22_two_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -290,7 +290,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_23_two_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -300,7 +300,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_24_two_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -310,7 +310,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_25_one_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -320,7 +320,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "Laddr_25")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_26_one_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -330,7 +330,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "Laddr_26")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_27_two_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -340,7 +340,7 @@ class RouterTest(TestCase):
                                        self.routers[1].addresses[0],
                                        "Laddr_27")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_28_two_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -350,7 +350,7 @@ class RouterTest(TestCase):
                                    self.routers[1].addresses[0],
                                    "Laddr_28")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_29_one_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -361,7 +361,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_30_one_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -372,7 +372,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_31_two_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -383,7 +383,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_32_two_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -394,7 +394,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_33_one_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -406,7 +406,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_34_one_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -418,7 +418,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_35_two_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -430,7 +430,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_36_two_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -442,7 +442,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_multi_tenancy.py
+++ b/tests/system_tests_multi_tenancy.py
@@ -80,7 +80,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0anything/addr_01")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_one_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -90,7 +90,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_02")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_one_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -100,7 +100,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_03")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_one_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -110,7 +110,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_04")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_two_router_targeted_sender_no_tenant(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -120,7 +120,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_05")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_two_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -130,7 +130,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_06")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_two_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -140,7 +140,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_07")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_two_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -150,7 +150,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M00.0.0.0/addr_08")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_one_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -160,7 +160,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_09")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_one_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -170,7 +170,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_10")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_one_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -180,7 +180,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_11")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_12_one_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -190,7 +190,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_12")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_13_two_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -200,7 +200,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_13")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_14_two_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -210,7 +210,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_14")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_15_two_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -220,7 +220,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_15")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_16_two_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -230,7 +230,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M00.0.0.0/addr_16")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_one_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -240,7 +240,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_18_one_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -250,7 +250,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_19_one_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -260,7 +260,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_20_one_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -270,7 +270,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_21_two_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -280,7 +280,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_22_two_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -290,7 +290,7 @@ class RouterTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_23_two_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -300,7 +300,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_24_two_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -310,7 +310,7 @@ class RouterTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_25_one_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -320,7 +320,7 @@ class RouterTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "Laddr_25")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_26_one_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -330,7 +330,7 @@ class RouterTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "Laddr_26")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_27_two_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -340,7 +340,7 @@ class RouterTest(TestCase):
                                        self.routers[1].addresses[0],
                                        "Laddr_27")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_28_two_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -350,7 +350,7 @@ class RouterTest(TestCase):
                                    self.routers[1].addresses[0],
                                    "Laddr_28")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_29_one_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -361,7 +361,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_30_one_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -372,7 +372,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_31_two_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -383,7 +383,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_32_two_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -394,7 +394,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_33_one_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -406,7 +406,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_34_one_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -418,7 +418,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_35_two_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -430,7 +430,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_36_two_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -442,7 +442,7 @@ class RouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_multi_tenancy_policy.py
+++ b/tests/system_tests_multi_tenancy_policy.py
@@ -97,7 +97,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0anything/addr_01")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_one_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -107,7 +107,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_02")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_one_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -117,7 +117,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_03")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_one_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -127,7 +127,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_04")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_two_router_targeted_sender_no_tenant(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -137,7 +137,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_05")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_two_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -147,7 +147,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_06")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_two_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -157,7 +157,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_07")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_two_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -167,7 +167,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_08")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_one_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -177,7 +177,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_09")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_one_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -187,7 +187,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_10")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_one_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -197,7 +197,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_11")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_12_one_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -207,7 +207,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_12")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_13_two_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -217,7 +217,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_13")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_14_two_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -227,7 +227,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_14")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_15_two_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -237,7 +237,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_15")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_16_two_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -247,7 +247,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_16")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_one_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -257,7 +257,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_18_one_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -267,7 +267,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_19_one_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -277,7 +277,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_20_one_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -287,7 +287,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_21_two_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -297,7 +297,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_22_two_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -307,7 +307,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_23_two_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -317,7 +317,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_24_two_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -327,7 +327,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_25_one_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -337,7 +337,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "Laddr_25")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_26_one_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -347,7 +347,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "Laddr_26")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_27_two_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -357,7 +357,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[1].addresses[0],
                                        "Laddr_27")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_28_two_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -367,7 +367,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[1].addresses[0],
                                    "Laddr_28")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_29_one_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -378,7 +378,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_30_one_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -389,7 +389,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_31_two_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -400,7 +400,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_32_two_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -411,7 +411,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_33_one_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -423,7 +423,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_34_one_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -435,7 +435,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_35_two_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -447,7 +447,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_36_two_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -459,7 +459,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_multi_tenancy_policy.py
+++ b/tests/system_tests_multi_tenancy_policy.py
@@ -97,7 +97,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0anything/addr_01")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_one_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -107,7 +107,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_02")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_one_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -117,7 +117,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_03")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_one_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -127,7 +127,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_04")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_two_router_targeted_sender_no_tenant(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -137,7 +137,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_05")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_two_router_targeted_sender_tenant_on_sender(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -147,7 +147,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_06")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_two_router_targeted_sender_tenant_on_receiver(self):
         test = MessageTransferTest(self.routers[0].addresses[0],
@@ -157,7 +157,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_07")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_two_router_targeted_sender_tenant_on_both(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -167,7 +167,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "M0hosted-group-1/addr_08")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_one_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -177,7 +177,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_09")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_one_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -187,7 +187,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_10")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_one_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -197,7 +197,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_11")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_12_one_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -207,7 +207,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_12")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_13_two_router_anonymous_sender_no_tenant(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -217,7 +217,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0anything/addr_13")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_14_two_router_anonymous_sender_tenant_on_sender(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -227,7 +227,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_14")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_15_two_router_anonymous_sender_tenant_on_receiver(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[0],
@@ -237,7 +237,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_15")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_16_two_router_anonymous_sender_tenant_on_both(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -247,7 +247,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "M0hosted-group-1/addr_16")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_one_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -257,7 +257,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_18_one_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -267,7 +267,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_19_one_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -277,7 +277,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_20_one_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -287,7 +287,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_21_two_router_link_route_targeted(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -297,7 +297,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_22_two_router_link_route_targeted_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -307,7 +307,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              False,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_23_two_router_link_route_dynamic(self):
         test = LinkRouteTest(self.routers[0].addresses[1],
@@ -317,7 +317,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_24_two_router_link_route_dynamic_no_tenant(self):
         test = LinkRouteTest(self.routers[0].addresses[0],
@@ -327,7 +327,7 @@ class RouterMultitenantPolicyTest(TestCase):
                              True,
                              self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_25_one_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -337,7 +337,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[0].addresses[0],
                                        "Laddr_25")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_26_one_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -347,7 +347,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[0].addresses[0],
                                    "Laddr_26")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_27_two_router_anonymous_sender_non_mobile(self):
         test = MessageTransferAnonTest(self.routers[0].addresses[1],
@@ -357,7 +357,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                        self.routers[1].addresses[0],
                                        "Laddr_27")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_28_two_router_targeted_sender_non_mobile(self):
         test = MessageTransferTest(self.routers[0].addresses[1],
@@ -367,7 +367,7 @@ class RouterMultitenantPolicyTest(TestCase):
                                    self.routers[1].addresses[0],
                                    "Laddr_28")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_29_one_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -378,7 +378,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_30_one_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -389,7 +389,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_31_two_router_waypoint_no_tenant(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -400,7 +400,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_32_two_router_waypoint(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -411,7 +411,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_33_one_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -423,7 +423,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_34_one_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -435,7 +435,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_35_two_router_waypoint_no_tenant_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[0],
@@ -447,7 +447,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_36_two_router_waypoint_external_addr(self):
         test = WaypointTest(self.routers[0].addresses[1],
@@ -459,7 +459,7 @@ class RouterMultitenantPolicyTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class Entity(object):

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -226,7 +226,7 @@ class MulticastLinearTest(TestCase):
                                          detach=True,
                                          body=body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_01_presettled_large_msg_rx_detach(self):
         self._presettled_large_msg_rx_detach(self.config, 10, ['R-EA1-1', 'R-EB1-2'])
@@ -240,7 +240,7 @@ class MulticastLinearTest(TestCase):
                                          detach=False,
                                          body=body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_presettled_large_msg_rx_close(self):
         self._presettled_large_msg_rx_close(self.config, 10, ['R-EA1-2', 'R-EB1-1'])
@@ -251,7 +251,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED LARGE RX DETACH " + LARGE_PAYLOAD
         test = MulticastUnsettledRxFail(self.config, count, drop_clients, detach=True, body=body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_unsettled_large_msg_rx_detach(self):
         self._unsettled_large_msg_rx_detach(self.config, 10, ['R-EA1-1', 'R-EB1-2'])
@@ -262,7 +262,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED LARGE RX CLOSE " + LARGE_PAYLOAD
         test = MulticastUnsettledRxFail(self.config, count, drop_clients, detach=False, body=body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_11_unsettled_large_msg_rx_close(self):
         self._unsettled_large_msg_rx_close(self.config, 10, ['R-EA1-2', 'R-EB1-1', ])
@@ -283,14 +283,14 @@ class MulticastLinearTest(TestCase):
         body = " MCAST MAYBE PRESETTLED LARGE " + LARGE_PAYLOAD
         test = MulticastPresettled(self.config, 11, body, SendMixed())
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_52_presettled_large_msg(self):
         # Same as above, (pre-settled sender settle mode)
         body = " MCAST PRESETTLED LARGE " + LARGE_PAYLOAD
         test = MulticastPresettled(self.config, 13, body, SendPresettled())
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_60_unsettled_3ack(self):
         # Sender sends unsettled, waits for Outcome from Receiver then settles
@@ -298,7 +298,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED "
         test = MulticastUnsettled3Ack(self.config, 10, body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
         self.assertEqual(test.n_outcomes[Delivery.ACCEPTED], test.n_sent)
 
     def test_61_unsettled_3ack_large_msg(self):
@@ -306,7 +306,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED LARGE " + LARGE_PAYLOAD
         test = MulticastUnsettled3Ack(self.config, 11, body=body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
         self.assertEqual(test.n_outcomes[Delivery.ACCEPTED], test.n_sent)
 
     def _unsettled_3ack_outcomes(self,
@@ -320,7 +320,7 @@ class MulticastLinearTest(TestCase):
                                       body,
                                       outcomes=outcomes)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
         self.assertEqual(test.n_outcomes[expected], test.n_sent)
 
     def test_63_unsettled_3ack_outcomes(self):
@@ -373,20 +373,20 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED 1ACK "
         test = MulticastUnsettled1Ack(self.config, 10, body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_71_unsettled_1ack_large_msg(self):
         # Same as above but with multiframe streaming
         body = " MCAST UNSETTLED 1ACK LARGE " + LARGE_PAYLOAD
         test = MulticastUnsettled1Ack(self.config, 10, body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_80_unsettled_3ack_message_annotations(self):
         body = " MCAST UNSETTLED 3ACK LARGE MESSAGE ANNOTATIONS " + LARGE_PAYLOAD
         test = MulticastUnsettled3AckMA(self.config, 10, body)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_90_credit_no_subscribers(self):
         """
@@ -396,12 +396,12 @@ class MulticastLinearTest(TestCase):
                                       target='multicast/no/subscriber1')
 
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
         test = MulticastCreditBlocked(address=self.INT_A.listener,
                                       target='multicast/no/subscriber2')
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_91_anonymous_sender(self):
         """

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -226,7 +226,7 @@ class MulticastLinearTest(TestCase):
                                          detach=True,
                                          body=body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_01_presettled_large_msg_rx_detach(self):
         self._presettled_large_msg_rx_detach(self.config, 10, ['R-EA1-1', 'R-EB1-2'])
@@ -240,7 +240,7 @@ class MulticastLinearTest(TestCase):
                                          detach=False,
                                          body=body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_presettled_large_msg_rx_close(self):
         self._presettled_large_msg_rx_close(self.config, 10, ['R-EA1-2', 'R-EB1-1'])
@@ -251,7 +251,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED LARGE RX DETACH " + LARGE_PAYLOAD
         test = MulticastUnsettledRxFail(self.config, count, drop_clients, detach=True, body=body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_unsettled_large_msg_rx_detach(self):
         self._unsettled_large_msg_rx_detach(self.config, 10, ['R-EA1-1', 'R-EB1-2'])
@@ -262,7 +262,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED LARGE RX CLOSE " + LARGE_PAYLOAD
         test = MulticastUnsettledRxFail(self.config, count, drop_clients, detach=False, body=body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_11_unsettled_large_msg_rx_close(self):
         self._unsettled_large_msg_rx_close(self.config, 10, ['R-EA1-2', 'R-EB1-1', ])
@@ -283,14 +283,14 @@ class MulticastLinearTest(TestCase):
         body = " MCAST MAYBE PRESETTLED LARGE " + LARGE_PAYLOAD
         test = MulticastPresettled(self.config, 11, body, SendMixed())
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_52_presettled_large_msg(self):
         # Same as above, (pre-settled sender settle mode)
         body = " MCAST PRESETTLED LARGE " + LARGE_PAYLOAD
         test = MulticastPresettled(self.config, 13, body, SendPresettled())
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_60_unsettled_3ack(self):
         # Sender sends unsettled, waits for Outcome from Receiver then settles
@@ -298,7 +298,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED "
         test = MulticastUnsettled3Ack(self.config, 10, body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
         self.assertEqual(test.n_outcomes[Delivery.ACCEPTED], test.n_sent)
 
     def test_61_unsettled_3ack_large_msg(self):
@@ -306,7 +306,7 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED LARGE " + LARGE_PAYLOAD
         test = MulticastUnsettled3Ack(self.config, 11, body=body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
         self.assertEqual(test.n_outcomes[Delivery.ACCEPTED], test.n_sent)
 
     def _unsettled_3ack_outcomes(self,
@@ -320,7 +320,7 @@ class MulticastLinearTest(TestCase):
                                       body,
                                       outcomes=outcomes)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
         self.assertEqual(test.n_outcomes[expected], test.n_sent)
 
     def test_63_unsettled_3ack_outcomes(self):
@@ -373,20 +373,20 @@ class MulticastLinearTest(TestCase):
         body = " MCAST UNSETTLED 1ACK "
         test = MulticastUnsettled1Ack(self.config, 10, body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_71_unsettled_1ack_large_msg(self):
         # Same as above but with multiframe streaming
         body = " MCAST UNSETTLED 1ACK LARGE " + LARGE_PAYLOAD
         test = MulticastUnsettled1Ack(self.config, 10, body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_80_unsettled_3ack_message_annotations(self):
         body = " MCAST UNSETTLED 3ACK LARGE MESSAGE ANNOTATIONS " + LARGE_PAYLOAD
         test = MulticastUnsettled3AckMA(self.config, 10, body)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_90_credit_no_subscribers(self):
         """
@@ -396,12 +396,12 @@ class MulticastLinearTest(TestCase):
                                       target='multicast/no/subscriber1')
 
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
         test = MulticastCreditBlocked(address=self.INT_A.listener,
                                       target='multicast/no/subscriber2')
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_91_anonymous_sender(self):
         """

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -371,14 +371,14 @@ class OneRouterTest(TestCase):
         OneRouterTest.closest_count += 1
         test = PreSettled(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_multicast_unsettled(self) :
         n_receivers = 5
         addr = self.address + '/multicast/1'
         test = MulticastUnsettled(addr, n_messages=10, n_receivers=5)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # DISPATCH-1277. This test will fail with a policy but without the fix in policy_local.py
     # In other words, if the max-frame-size was 2147483647 and not 16384, this
@@ -388,42 +388,42 @@ class OneRouterTest(TestCase):
         OneRouterTest.closest_count += 1
         test = DispositionReturnsToClosedConnection(addr, n_messages=100)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_sender_settles_first(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = SenderSettlesFirst(addr, n_messages=100)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_propagated_disposition(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = PropagatedDisposition(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_unsettled_undeliverable(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = UsettledUndeliverable(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_three_ack(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = ThreeAck(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_message_annotations(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = MessageAnnotations(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Tests stripping of ingress and egress annotations.
     # There is a property in qdrouter.json called stripAnnotations with possible values of ["in", "out", "both", "no"]
@@ -436,7 +436,7 @@ class OneRouterTest(TestCase):
         OneRouterTest.closest_count += 1
         test = StripMessageAnnotationsCustom(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # stripAnnotations property is set to "no"
 
@@ -444,7 +444,7 @@ class OneRouterTest(TestCase):
         addr = self.no_strip_addr + "/strip_message_annotations_no/1"
         test = StripMessageAnnotationsNo(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # stripAnnotations property is set to "no"
 
@@ -452,7 +452,7 @@ class OneRouterTest(TestCase):
         addr = self.no_strip_addr + "/strip_message_annotations_no_add_trace/1"
         test = StripMessageAnnotationsNoAddTrace(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Dont send any pre-existing ingress or trace annotations. Make sure that there
     # are no outgoing message annotations stripAnnotations property is set to "both".
@@ -462,7 +462,7 @@ class OneRouterTest(TestCase):
         addr = self.both_strip_addr + "/strip_message_annotations_both/1"
         test = StripMessageAnnotationsBoth(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Dont send any pre-existing ingress or trace annotations. Make sure that there
     # are no outgoing message annotations
@@ -472,7 +472,7 @@ class OneRouterTest(TestCase):
         addr = self.out_strip_addr + "/strip_message_annotations_out/1"
         test = StripMessageAnnotationsOut(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     # Send in pre-existing trace and ingress and annotations and make sure
     # that they are not in the outgoing annotations.
@@ -482,37 +482,37 @@ class OneRouterTest(TestCase):
         addr = self.in_strip_addr + "/strip_message_annotations_in/1"
         test = StripMessageAnnotationsIn(addr, n_messages=10)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_16_management(self):
         test = ManagementTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_management_get_operations(self):
         test = ManagementGetOperationsTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_18_management_not_implemented(self):
         test = ManagementNotImplemented(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_19_semantics_multicast(self):
         test = SemanticsMulticast(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_20_semantics_closest(self):
         test = SemanticsClosest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_21_semantics_balanced(self):
         test = SemanticsBalanced(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_22_to_override(self):
         test = MessageAnnotaionsPreExistingOverride(self.address)
@@ -535,38 +535,38 @@ class OneRouterTest(TestCase):
         """
         test = ExcessDeliveriesReleasedTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_25_multicast_unsettled(self):
         test = MulticastUnsettledTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_multiframe_presettled(self):
         test = MultiframePresettledTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_27_released_vs_modified(self):
         test = ReleasedVsModifiedTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_28_appearance_of_balance(self):
         test = AppearanceOfBalanceTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_29_batched_settlement(self):
         test = BatchedSettlementTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
         self.assertTrue(test.accepted_count_match)
 
     def test_30_presettled_overflow(self):
         test = PresettledOverflowTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_31_create_unavailable_sender(self):
         test = UnavailableSender(self.address)
@@ -581,7 +581,7 @@ class OneRouterTest(TestCase):
     def test_33_large_streaming_test(self):
         test = LargeMessageStreamTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_34_reject_coordinator(self):
         test = RejectCoordinatorTest(self.address)
@@ -644,17 +644,17 @@ class OneRouterTest(TestCase):
     def test_40_anonymous_sender_no_receiver(self):
         test = AnonymousSenderNoRecvLargeMessagedTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_41_large_streaming_close_conn_test(self):
         test = LargeMessageStreamCloseConnTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_42_unsettled_large_message_test(self):
         test = UnsettledLargeMessageTest(self.address, 250)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_43_dropped_presettled_receiver_stops(self):
         local_node = Node.connect(self.address, timeout=TIMEOUT)
@@ -664,7 +664,7 @@ class OneRouterTest(TestCase):
         ingress_delivery_count = res.results[0][deliveries_ingress]
         test = DroppedPresettledTest(self.address, 200, ingress_delivery_count, presettled_dropped_count)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_44_delete_connection_fail(self):
         """
@@ -708,12 +708,12 @@ class OneRouterTest(TestCase):
         """
         test = Q2HoldoffDropTest(self.router)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_48_connection_uptime_last_dlv(self):
         test = ConnectionUptimeLastDlvTest(self.address, "test_48")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_49_unexpected_release_test(self):
         """
@@ -724,7 +724,7 @@ class OneRouterTest(TestCase):
         """
         test = UnexpectedReleaseTest(self.address)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_50_extension_capabilities(self):
         """
@@ -740,7 +740,7 @@ class OneRouterTest(TestCase):
         for cc in client_caps:
             test = ExtensionCapabilitiesTest(self.address, cc)
             test.run()
-            self.assertEqual(None, test.error)
+            self.assertIsNone(test.error, msg=test.error)
 
             # check the caps sent by router.
             self.assertTrue(test.remote_offered is not None)

--- a/tests/system_tests_one_router.py
+++ b/tests/system_tests_one_router.py
@@ -371,14 +371,14 @@ class OneRouterTest(TestCase):
         OneRouterTest.closest_count += 1
         test = PreSettled(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_multicast_unsettled(self) :
         n_receivers = 5
         addr = self.address + '/multicast/1'
         test = MulticastUnsettled(addr, n_messages=10, n_receivers=5)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # DISPATCH-1277. This test will fail with a policy but without the fix in policy_local.py
     # In other words, if the max-frame-size was 2147483647 and not 16384, this
@@ -388,42 +388,42 @@ class OneRouterTest(TestCase):
         OneRouterTest.closest_count += 1
         test = DispositionReturnsToClosedConnection(addr, n_messages=100)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_sender_settles_first(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = SenderSettlesFirst(addr, n_messages=100)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_propagated_disposition(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = PropagatedDisposition(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_unsettled_undeliverable(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = UsettledUndeliverable(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_three_ack(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = ThreeAck(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_message_annotations(self) :
         addr = self.address + '/closest/' + str(OneRouterTest.closest_count)
         OneRouterTest.closest_count += 1
         test = MessageAnnotations(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Tests stripping of ingress and egress annotations.
     # There is a property in qdrouter.json called stripAnnotations with possible values of ["in", "out", "both", "no"]
@@ -436,7 +436,7 @@ class OneRouterTest(TestCase):
         OneRouterTest.closest_count += 1
         test = StripMessageAnnotationsCustom(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # stripAnnotations property is set to "no"
 
@@ -444,7 +444,7 @@ class OneRouterTest(TestCase):
         addr = self.no_strip_addr + "/strip_message_annotations_no/1"
         test = StripMessageAnnotationsNo(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # stripAnnotations property is set to "no"
 
@@ -452,7 +452,7 @@ class OneRouterTest(TestCase):
         addr = self.no_strip_addr + "/strip_message_annotations_no_add_trace/1"
         test = StripMessageAnnotationsNoAddTrace(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Dont send any pre-existing ingress or trace annotations. Make sure that there
     # are no outgoing message annotations stripAnnotations property is set to "both".
@@ -462,7 +462,7 @@ class OneRouterTest(TestCase):
         addr = self.both_strip_addr + "/strip_message_annotations_both/1"
         test = StripMessageAnnotationsBoth(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Dont send any pre-existing ingress or trace annotations. Make sure that there
     # are no outgoing message annotations
@@ -472,7 +472,7 @@ class OneRouterTest(TestCase):
         addr = self.out_strip_addr + "/strip_message_annotations_out/1"
         test = StripMessageAnnotationsOut(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     # Send in pre-existing trace and ingress and annotations and make sure
     # that they are not in the outgoing annotations.
@@ -482,37 +482,37 @@ class OneRouterTest(TestCase):
         addr = self.in_strip_addr + "/strip_message_annotations_in/1"
         test = StripMessageAnnotationsIn(addr, n_messages=10)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_16_management(self):
         test = ManagementTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_management_get_operations(self):
         test = ManagementGetOperationsTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_18_management_not_implemented(self):
         test = ManagementNotImplemented(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_19_semantics_multicast(self):
         test = SemanticsMulticast(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_20_semantics_closest(self):
         test = SemanticsClosest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_21_semantics_balanced(self):
         test = SemanticsBalanced(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_22_to_override(self):
         test = MessageAnnotaionsPreExistingOverride(self.address)
@@ -535,38 +535,38 @@ class OneRouterTest(TestCase):
         """
         test = ExcessDeliveriesReleasedTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_25_multicast_unsettled(self):
         test = MulticastUnsettledTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_multiframe_presettled(self):
         test = MultiframePresettledTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_27_released_vs_modified(self):
         test = ReleasedVsModifiedTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_28_appearance_of_balance(self):
         test = AppearanceOfBalanceTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_29_batched_settlement(self):
         test = BatchedSettlementTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
         self.assertTrue(test.accepted_count_match)
 
     def test_30_presettled_overflow(self):
         test = PresettledOverflowTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_31_create_unavailable_sender(self):
         test = UnavailableSender(self.address)
@@ -581,7 +581,7 @@ class OneRouterTest(TestCase):
     def test_33_large_streaming_test(self):
         test = LargeMessageStreamTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_34_reject_coordinator(self):
         test = RejectCoordinatorTest(self.address)
@@ -644,17 +644,17 @@ class OneRouterTest(TestCase):
     def test_40_anonymous_sender_no_receiver(self):
         test = AnonymousSenderNoRecvLargeMessagedTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_41_large_streaming_close_conn_test(self):
         test = LargeMessageStreamCloseConnTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_42_unsettled_large_message_test(self):
         test = UnsettledLargeMessageTest(self.address, 250)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_43_dropped_presettled_receiver_stops(self):
         local_node = Node.connect(self.address, timeout=TIMEOUT)
@@ -664,7 +664,7 @@ class OneRouterTest(TestCase):
         ingress_delivery_count = res.results[0][deliveries_ingress]
         test = DroppedPresettledTest(self.address, 200, ingress_delivery_count, presettled_dropped_count)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_44_delete_connection_fail(self):
         """
@@ -708,12 +708,12 @@ class OneRouterTest(TestCase):
         """
         test = Q2HoldoffDropTest(self.router)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_48_connection_uptime_last_dlv(self):
         test = ConnectionUptimeLastDlvTest(self.address, "test_48")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_49_unexpected_release_test(self):
         """
@@ -724,7 +724,7 @@ class OneRouterTest(TestCase):
         """
         test = UnexpectedReleaseTest(self.address)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_50_extension_capabilities(self):
         """
@@ -740,7 +740,7 @@ class OneRouterTest(TestCase):
         for cc in client_caps:
             test = ExtensionCapabilitiesTest(self.address, cc)
             test.run()
-            self.assertIsNone(test.error, msg=test.error)
+            self.assertIsNone(test.error)
 
             # check the caps sent by router.
             self.assertTrue(test.remote_offered is not None)

--- a/tests/system_tests_priority.py
+++ b/tests/system_tests_priority.py
@@ -215,7 +215,7 @@ class PriorityTests (TestCase):
                         self.magic_address_priority
                         )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 # ================================================================

--- a/tests/system_tests_priority.py
+++ b/tests/system_tests_priority.py
@@ -215,7 +215,7 @@ class PriorityTests (TestCase):
                         self.magic_address_priority
                         )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 # ================================================================

--- a/tests/system_tests_routing_protocol.py
+++ b/tests/system_tests_routing_protocol.py
@@ -65,12 +65,12 @@ class RouterTest(TestCase):
     def test_01_reject_higher_version_hello(self):
         test = RejectHigherVersionHelloTest(self.routers[0].addresses[3])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_reject_higher_version_mar(self):
         test = RejectHigherVersionMARTest(self.routers[0].addresses[3], self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class RejectHigherVersionHelloTest(MessagingHandler):

--- a/tests/system_tests_routing_protocol.py
+++ b/tests/system_tests_routing_protocol.py
@@ -65,12 +65,12 @@ class RouterTest(TestCase):
     def test_01_reject_higher_version_hello(self):
         test = RejectHigherVersionHelloTest(self.routers[0].addresses[3])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_reject_higher_version_mar(self):
         test = RejectHigherVersionMARTest(self.routers[0].addresses[3], self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class RejectHigherVersionHelloTest(MessagingHandler):

--- a/tests/system_tests_stuck_deliveries.py
+++ b/tests/system_tests_stuck_deliveries.py
@@ -82,7 +82,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.01', 10, [2], False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_delayed_settlement_different_edges_check_sender(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -90,7 +90,7 @@ class RouterTest(TestCase):
                                      self.routers[2].addresses[0],
                                      'dest.02', 10, [2, 3, 8], False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_delayed_settlement_different_edges_check_receiver(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -98,7 +98,7 @@ class RouterTest(TestCase):
                                      self.routers[5].addresses[0],
                                      'dest.03', 10, [2, 4, 9], False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_delayed_settlement_different_edges_check_interior(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -106,7 +106,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.04', 10, [0, 2, 3, 8], False)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_05_no_settlement_same_interior(self):
         test = DelayedSettlementTest(self.routers[0].addresses[0],
@@ -114,7 +114,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.05', 10, [0, 2, 4, 9], True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_no_settlement_different_edges_check_sender(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -122,7 +122,7 @@ class RouterTest(TestCase):
                                      self.routers[2].addresses[0],
                                      'dest.06', 10, [9], True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_no_settlement_different_edges_check_receiver(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -130,7 +130,7 @@ class RouterTest(TestCase):
                                      self.routers[5].addresses[0],
                                      'dest.07', 10, [0, 9], True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_no_settlement_different_edges_check_interior(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -138,17 +138,17 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.08', 10, [1, 2, 3, 4, 5, 6, 7, 8], True)
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_receiver_link_credit_test(self):
         test = RxLinkCreditTest(self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_sender_link_credit_test(self):
         test = TxLinkCreditTest(self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 class DelayedSettlementTest(MessagingHandler):

--- a/tests/system_tests_stuck_deliveries.py
+++ b/tests/system_tests_stuck_deliveries.py
@@ -82,7 +82,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.01', 10, [2], False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_delayed_settlement_different_edges_check_sender(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -90,7 +90,7 @@ class RouterTest(TestCase):
                                      self.routers[2].addresses[0],
                                      'dest.02', 10, [2, 3, 8], False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_delayed_settlement_different_edges_check_receiver(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -98,7 +98,7 @@ class RouterTest(TestCase):
                                      self.routers[5].addresses[0],
                                      'dest.03', 10, [2, 4, 9], False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_delayed_settlement_different_edges_check_interior(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -106,7 +106,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.04', 10, [0, 2, 3, 8], False)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_05_no_settlement_same_interior(self):
         test = DelayedSettlementTest(self.routers[0].addresses[0],
@@ -114,7 +114,7 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.05', 10, [0, 2, 4, 9], True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_no_settlement_different_edges_check_sender(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -122,7 +122,7 @@ class RouterTest(TestCase):
                                      self.routers[2].addresses[0],
                                      'dest.06', 10, [9], True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_no_settlement_different_edges_check_receiver(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -130,7 +130,7 @@ class RouterTest(TestCase):
                                      self.routers[5].addresses[0],
                                      'dest.07', 10, [0, 9], True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_no_settlement_different_edges_check_interior(self):
         test = DelayedSettlementTest(self.routers[2].addresses[0],
@@ -138,17 +138,17 @@ class RouterTest(TestCase):
                                      self.routers[0].addresses[0],
                                      'dest.08', 10, [1, 2, 3, 4, 5, 6, 7, 8], True)
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_receiver_link_credit_test(self):
         test = RxLinkCreditTest(self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_sender_link_credit_test(self):
         test = TxLinkCreditTest(self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 class DelayedSettlementTest(MessagingHandler):

--- a/tests/system_tests_topology.py
+++ b/tests/system_tests_topology.py
@@ -281,7 +281,7 @@ class TopologyTests (TestCase):
                                 "closest/01"
                                 )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 # ================================================================

--- a/tests/system_tests_topology.py
+++ b/tests/system_tests_topology.py
@@ -274,14 +274,14 @@ class TopologyTests (TestCase):
 
     def test_01_topology_failover(self):
         name = 'test_01'
-        if self.skip[name] :
+        if self.skip[name]:
             self.skipTest("Test skipped during development.")
         test = TopologyFailover(name,
                                 self.client_addrs,
                                 "closest/01"
                                 )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 # ================================================================
@@ -534,7 +534,7 @@ class TopologyFailover (MessagingHandler):
                     self.state_transition("expected trace %d observed successfully %s" % (self.trace_count, expected), 'kill_connector')
                     self.kill_a_connector(self.kill_list[self.trace_count])
                     self.trace_count += 1
-                else :
+                else:
                     self.state_transition("expected trace %s but got %s" % (expected, trace), 'bailing')
                     self.bail("expected trace %s but got %s" % (expected, trace))
 
@@ -741,7 +741,7 @@ class RouterFluxTest(TestCase):
 
         # bit of a hack but ensure that the flush did not take an unreasonably
         # long time with respect to the ra_stale value (3x is a guess btw)
-        self.assertTrue(time.time() - start <= (3.0 * max_age))
+        self.assertLessEqual(time.time() - start, 3.0 * max_age)
 
 
 if __name__ == '__main__':

--- a/tests/system_tests_topology_addition.py
+++ b/tests/system_tests_topology_addition.py
@@ -237,7 +237,7 @@ class TopologyAdditionTests (TestCase):
                          released_ok
                          )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_new_route_high_cost(self):
         # During the test, test code will add a new router D,
@@ -265,7 +265,7 @@ class TopologyAdditionTests (TestCase):
                          released_ok
                          )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
 
 # ================================================================

--- a/tests/system_tests_topology_addition.py
+++ b/tests/system_tests_topology_addition.py
@@ -237,7 +237,7 @@ class TopologyAdditionTests (TestCase):
                          released_ok
                          )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_new_route_high_cost(self):
         # During the test, test code will add a new router D,
@@ -265,7 +265,7 @@ class TopologyAdditionTests (TestCase):
                          released_ok
                          )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
 
 # ================================================================

--- a/tests/system_tests_topology_disposition.py.in
+++ b/tests/system_tests_topology_disposition.py.in
@@ -364,7 +364,7 @@ class TopologyDispositionTests (TestCase):
                                        self.client_addrs['D']
                                        )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02_topology_disposition(self):
         name = 'test_02'
@@ -375,7 +375,7 @@ class TopologyDispositionTests (TestCase):
                                    "closest/02"
                                    )
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_connection_id_propagation(self):
         name = 'test_03'
@@ -408,8 +408,8 @@ class TopologyDispositionTests (TestCase):
                         qci += 1
                     if error is None and oopen[qci].isdigit():
                         error = "log %s, line '%s' published conn-id is too big" % (log_name, oopen)
-                self.assertIsNone(error, msg=error)
-            self.assertIsNone(error, msg=error)
+                self.assertIsNone(error)
+            self.assertIsNone(error)
 
     def test_04_scraper_tool(self):
         name = 'test_04'

--- a/tests/system_tests_topology_disposition.py.in
+++ b/tests/system_tests_topology_disposition.py.in
@@ -364,7 +364,7 @@ class TopologyDispositionTests (TestCase):
                                        self.client_addrs['D']
                                        )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02_topology_disposition(self):
         name = 'test_02'
@@ -375,7 +375,7 @@ class TopologyDispositionTests (TestCase):
                                    "closest/02"
                                    )
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_connection_id_propagation(self):
         name = 'test_03'
@@ -408,8 +408,8 @@ class TopologyDispositionTests (TestCase):
                         qci += 1
                     if error is None and oopen[qci].isdigit():
                         error = "log %s, line '%s' published conn-id is too big" % (log_name, oopen)
-                self.assertEqual(None, error)
-            self.assertEqual(None, error)
+                self.assertIsNone(error, msg=error)
+            self.assertIsNone(error, msg=error)
 
     def test_04_scraper_tool(self):
         name = 'test_04'

--- a/tests/system_tests_two_routers.py
+++ b/tests/system_tests_two_routers.py
@@ -124,7 +124,7 @@ class TwoRouterTest(TestCase):
     def test_01_pre_settled(self):
         test = DeliveriesInTransit(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
         local_node = Node.connect(self.routers[0].addresses[0], timeout=TIMEOUT)
         outs = local_node.query(type='org.apache.qpid.dispatch.router')
@@ -137,22 +137,22 @@ class TwoRouterTest(TestCase):
     def test_02a_multicast_unsettled(self):
         test = MulticastUnsettled(self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_02c_sender_settles_first(self):
         test = SenderSettlesFirst(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_message_annotations(self):
         test = MessageAnnotationsTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03a_test_strip_message_annotations_no(self):
         test = MessageAnnotationsStripTest(self.routers[0].addresses[1], self.routers[1].addresses[1])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03a_test_strip_message_annotations_no_add_trace(self):
         test = MessageAnnotationsStripAddTraceTest(self.routers[0].addresses[1], self.routers[1].addresses[1])
@@ -160,48 +160,48 @@ class TwoRouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03a_test_strip_message_annotations_both_add_ingress_trace(self):
         test = MessageAnnotationsStripBothAddIngressTrace(self.routers[0].addresses[2], self.routers[1].addresses[2])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03a_test_strip_message_annotations_out(self):
         test = MessageAnnotationsStripMessageAnnotationsOut(self.routers[0].addresses[3], self.routers[1].addresses[3])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03a_test_strip_message_annotations_in(self):
         test = MessageAnnotationStripMessageAnnotationsIn(self.routers[0].addresses[4], self.routers[1].addresses[4])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_04_management(self):
         test = ManagementTest(self.routers[0].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_06_semantics_closest_is_local(self):
         test = SemanticsClosestIsLocal(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_07_semantics_closest_is_remote(self):
         test = SemanticsClosestIsRemote(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_08_semantics_balanced(self):
         test = SemanticsBalanced(self.routers[0].addresses[0], self.routers[0].addresses[1],
                                  self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_09_to_override(self):
         test = MessageAnnotaionsPreExistingOverride(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_10_propagated_disposition(self):
         test = PropagatedDisposition(self, self.routers[0].addresses[0], self.routers[1].addresses[0])
@@ -224,12 +224,12 @@ class TwoRouterTest(TestCase):
         """
         test = ExcessDeliveriesReleasedTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_15_attach_on_inter_router(self):
         test = AttachOnInterRouterTest(self.routers[0].addresses[5])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_17_address_wildcard(self):
         # verify proper distribution is selected by wildcard
@@ -290,12 +290,12 @@ class TwoRouterTest(TestCase):
     def test_17_large_streaming_test(self):
         test = LargeMessageStreamTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_18_single_char_dest_test(self):
         test = SingleCharacterDestinationTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_19_delete_inter_router_connection(self):
         """
@@ -1879,7 +1879,7 @@ class PropagationTest(TestCase):
     def test_propagation_of_locally_undefined_address(self):
         test = MulticastTestClient(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
         self.assertEqual(test.received, 2)
 
 
@@ -2133,7 +2133,7 @@ class TwoRouterExtensionStateTest(TestCase):
                                     self.RouterB.addresses[0],
                                     "closest/fleabag")
         test.run()
-        self.assertEqual(None, test.error)
+        self.assertIsNone(test.error, msg=test.error)
 
     def test_03_multicast(self):
         """

--- a/tests/system_tests_two_routers.py
+++ b/tests/system_tests_two_routers.py
@@ -124,7 +124,7 @@ class TwoRouterTest(TestCase):
     def test_01_pre_settled(self):
         test = DeliveriesInTransit(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
         local_node = Node.connect(self.routers[0].addresses[0], timeout=TIMEOUT)
         outs = local_node.query(type='org.apache.qpid.dispatch.router')
@@ -137,22 +137,22 @@ class TwoRouterTest(TestCase):
     def test_02a_multicast_unsettled(self):
         test = MulticastUnsettled(self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_02c_sender_settles_first(self):
         test = SenderSettlesFirst(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_message_annotations(self):
         test = MessageAnnotationsTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03a_test_strip_message_annotations_no(self):
         test = MessageAnnotationsStripTest(self.routers[0].addresses[1], self.routers[1].addresses[1])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03a_test_strip_message_annotations_no_add_trace(self):
         test = MessageAnnotationsStripAddTraceTest(self.routers[0].addresses[1], self.routers[1].addresses[1])
@@ -160,48 +160,48 @@ class TwoRouterTest(TestCase):
         # Dump the logger output only if there is a test error, otherwise dont bother
         if test.error:
             test.logger.dump()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03a_test_strip_message_annotations_both_add_ingress_trace(self):
         test = MessageAnnotationsStripBothAddIngressTrace(self.routers[0].addresses[2], self.routers[1].addresses[2])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03a_test_strip_message_annotations_out(self):
         test = MessageAnnotationsStripMessageAnnotationsOut(self.routers[0].addresses[3], self.routers[1].addresses[3])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03a_test_strip_message_annotations_in(self):
         test = MessageAnnotationStripMessageAnnotationsIn(self.routers[0].addresses[4], self.routers[1].addresses[4])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_04_management(self):
         test = ManagementTest(self.routers[0].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_06_semantics_closest_is_local(self):
         test = SemanticsClosestIsLocal(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_07_semantics_closest_is_remote(self):
         test = SemanticsClosestIsRemote(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_08_semantics_balanced(self):
         test = SemanticsBalanced(self.routers[0].addresses[0], self.routers[0].addresses[1],
                                  self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_09_to_override(self):
         test = MessageAnnotaionsPreExistingOverride(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_10_propagated_disposition(self):
         test = PropagatedDisposition(self, self.routers[0].addresses[0], self.routers[1].addresses[0])
@@ -224,12 +224,12 @@ class TwoRouterTest(TestCase):
         """
         test = ExcessDeliveriesReleasedTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_15_attach_on_inter_router(self):
         test = AttachOnInterRouterTest(self.routers[0].addresses[5])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_17_address_wildcard(self):
         # verify proper distribution is selected by wildcard
@@ -290,12 +290,12 @@ class TwoRouterTest(TestCase):
     def test_17_large_streaming_test(self):
         test = LargeMessageStreamTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_18_single_char_dest_test(self):
         test = SingleCharacterDestinationTest(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_19_delete_inter_router_connection(self):
         """
@@ -1879,7 +1879,7 @@ class PropagationTest(TestCase):
     def test_propagation_of_locally_undefined_address(self):
         test = MulticastTestClient(self.routers[0].addresses[0], self.routers[1].addresses[0])
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
         self.assertEqual(test.received, 2)
 
 
@@ -2133,7 +2133,7 @@ class TwoRouterExtensionStateTest(TestCase):
                                     self.RouterB.addresses[0],
                                     "closest/fleabag")
         test.run()
-        self.assertIsNone(test.error, msg=test.error)
+        self.assertIsNone(test.error)
 
     def test_03_multicast(self):
         """


### PR DESCRIPTION
`TestCase#assertEqual` truncates the diff when arguments differ. `assertIsNone` prints the argument in full when it is not `None`.