### PR TITLE
DISPATCH-2104: Fix display of plain number in qdstat

### DIFF
--- a/tools/qdstat.in
+++ b/tools/qdstat.in
@@ -652,7 +652,7 @@ class BusManager(object):
             row = []
             row.append(al.address)
             row.append(al.direction)
-            row.append(al.phase)
+            row.append(PlainNum(al.phase))
             row.append(al.externalAddress)
             row.append(al.linkRef)
             row.append(al.operStatus)


### PR DESCRIPTION
This closes #1193

(cherry picked from commit a5267f599ab00b2ca4e0c6583f0f7064ec36aa87)