### PR TITLE
DISPATCH-1595: Remove all python test on_modified event handlers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,6 +239,7 @@ jobs:
   docs:
     name: 'Docs (${{ matrix.os }})'
     runs-on: ${{ matrix.os }}
+    if: ${{ false }}  # disabled until Proton 0.34.0 Ubuntu package is published
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -182,7 +182,7 @@ jobs:
       DispatchBuildDir: ${{github.workspace}}/qpid-dispatch/build
       InstallPrefix: ${{github.workspace}}/install
       # TODO(DISPATCH-2078) re-enable system_tests_authz_service_plugin when the GHA failure is understood and fixed
-      DispatchCTestExtraArgs: "-E 'system_tests_authz_service_plugin'"
+      DispatchCTestExtraArgs: "-E 'system_tests_authz_service_plugin|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'"
       LD_LIBRARY_PATH: ${{github.workspace}}/install/lib
     steps:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
     - name: "qdrouterd:TSAN"
     - arch: arm64
     - arch: s390x
+    - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
   include:
   - name: "apache-rat:check"
     os: linux
@@ -114,7 +115,7 @@ jobs:
       - PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo
       - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
       - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
-  - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
+  - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal) on arm64"
     arch: arm64
     os: linux
     dist: focal

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ jobs:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - PATH="/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
+    - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
   - name: "qdrouterd:Coverage"
     os: linux
     env:
@@ -63,6 +64,7 @@ jobs:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - PATH="/usr/bin:$PATH" PROTON_VERSION=0.34.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
+    - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
     os: linux
     dist: focal
@@ -85,6 +87,7 @@ jobs:
     - CXX=clang++-11
     - PATH="/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
+    - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on focal)"
     arch: s390x
     os: linux
@@ -110,6 +113,7 @@ jobs:
     env:
       - PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo
       - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
+      - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
     arch: arm64
     os: linux
@@ -137,6 +141,7 @@ jobs:
       - CXX=clang++-11
       - PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo
       - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
+      - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
   - name: "qdrouterd:Default Build"
     os: linux
     env:
@@ -160,6 +165,7 @@ jobs:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - PATH="/usr/bin:$PATH" PROTON_VERSION=0.34.0
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=tsan'
+    - DISPATCH_CTEST_EXTRA='-E system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on macOS)"
     os: osx
     osx_image: xcode11

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -416,23 +416,20 @@ static void _do_reconnect(void *context)
     }
     sys_mutex_unlock(qdr_http1_adaptor->lock);
 
-    if (hconn->qdr_conn) {
+    // handle any qdr_connection_t processing requests that occurred since
+    // this raw connection dropped.
+    while (hconn->qdr_conn && qdr_connection_process(hconn->qdr_conn))
+        ;
 
-        // handle any qdr_connection_t processing requests that occurred since
-        // this raw connection dropped.
-        while (qdr_connection_process(hconn->qdr_conn))
-            ;
-
-        if (!hconn->qdr_conn) {
-            // the qdr_connection_t has been closed
-            qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG,
-                   "[C%"PRIu64"] HTTP/1.x server connection closed", hconn->conn_id);
-            qdr_http1_connection_free(hconn);
-            return;
-        }
-
-        _process_request((_server_request_t*) DEQ_HEAD(hconn->requests));
+    if (!hconn->qdr_conn) {
+        // the qdr_connection_t has been closed
+        qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG,
+               "[C%"PRIu64"] HTTP/1.x server connection closed", hconn->conn_id);
+        qdr_http1_connection_free(hconn);
+        return;
     }
+
+    _process_request((_server_request_t*) DEQ_HEAD(hconn->requests));
 
     // Do not attempt to re-connect if the current request is still in
     // progress. This happens when the server has closed the connection before
@@ -597,7 +594,7 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
         // prevent core activation
         sys_mutex_lock(qdr_http1_adaptor->lock);
         hconn->raw_conn = 0;
-        if (reconnect)
+        if (reconnect && hconn->server.reconnect_timer)
             qd_timer_schedule(hconn->server.reconnect_timer, hconn->server.reconnect_pause);
         sys_mutex_unlock(qdr_http1_adaptor->lock);
 

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -231,7 +231,7 @@ static int handle_incoming_raw_read(qdr_tcp_connection_t *conn, qd_buffer_list_t
     int free_count = 0;
     const bool was_open = conn->bytes_unacked < TCP_MAX_CAPACITY;
 
-    while ((count + conn->bytes_unacked < TCP_MAX_CAPACITY)
+    while ((conn->raw_closed_write || count + conn->bytes_unacked < TCP_MAX_CAPACITY)
            && (n = pn_raw_connection_take_read_buffers(conn->pn_raw_conn, raw_buffers, READ_BUFFERS)) ) {
 
         for (size_t i = 0; i < n && raw_buffers[i].bytes; ++i) {

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -452,7 +452,6 @@ static void free_qdr_tcp_connection(qdr_tcp_connection_t* tc)
     if (tc->activate_timer) {
         qd_timer_free(tc->activate_timer);
     }
-    flush_outgoing_buffs(tc);
     sys_mutex_free(tc->activation_lock);
     //proactor will free the socket
     free_qdr_tcp_connection_t(tc);
@@ -495,6 +494,8 @@ static void handle_disconnected(qdr_tcp_connection_t* conn)
         qdr_delivery_decref(tcp_adaptor->core, conn->initial_delivery, "tcp-adaptor.handle_disconnected - initial_delivery");
         conn->initial_delivery = 0;
     }
+    flush_outgoing_buffs(conn);
+
 
     //need to free on core thread to avoid deleting while in use by management agent
     qdr_action_t *action = qdr_action(qdr_del_tcp_connection_CT, "delete_tcp_connection");

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -89,8 +89,6 @@ DEQ_DECLARE(qd_alloc_type_t, qd_alloc_type_list_t);
 //
 #if QD_MEMORY_STATS
 static const char *leaking_types[] = {
-    // DISPATCH-1679:
-    "qd_timer_t", "qd_connector_t",
     "qd_hash_handle_t",       // DISPATCH-1696
 
     // system_tests_edge_router (centos7)

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -97,6 +97,7 @@ static const char *leaking_types[] = {
     "qd_message_t",
     "qd_message_content_t",
     "qdr_delivery_t",
+    "qd_delivery_state_t", // DISPATCH-2082: See comments in JIRA
     "qd_link_ref_t",
 
     // system_tests_priority (centos7)

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -783,14 +783,16 @@ static int get_failover_info_length(qd_failover_item_list_t   conn_info_list)
  */
 qd_error_t qd_entity_refresh_connector(qd_entity_t* entity, void *impl)
 {
-    qd_connector_t *ct = (qd_connector_t*) impl;
+    qd_connector_t *connector = (qd_connector_t*) impl;
 
-    int conn_index = ct->conn_index;
+    int conn_index = connector->conn_index;
 
     int i = 1;
     int num_items = 0;
 
-    qd_failover_item_list_t   conn_info_list = ct->conn_info_list;
+    sys_mutex_lock(connector->lock);
+
+    qd_failover_item_list_t   conn_info_list = connector->conn_info_list;
 
     int conn_info_len = DEQ_SIZE(conn_info_list);
 
@@ -846,7 +848,7 @@ qd_error_t qd_entity_refresh_connector(qd_entity_t* entity, void *impl)
     }
 
     const char *state_info = 0;
-    switch (ct->state) {
+    switch (connector->state) {
     case CXTR_STATE_CONNECTING:
       state_info = "CONNECTING";
       break;
@@ -859,16 +861,24 @@ qd_error_t qd_entity_refresh_connector(qd_entity_t* entity, void *impl)
     case CXTR_STATE_INIT:
       state_info = "INITIALIZING";
       break;
+    case CXTR_STATE_DELETED:
+      // deleted by management, waiting for connection to close
+      state_info = "CLOSING";
+      break;
     default:
       state_info = "UNKNOWN";
       break;
     }
 
     if (qd_entity_set_string(entity, "failoverUrls", failover_info) == 0
-            && qd_entity_set_string(entity, "connectionStatus", state_info) == 0
-            && qd_entity_set_string(entity, "connectionMsg", ct->conn_msg) == 0)
-        return QD_ERROR_NONE;
+        && qd_entity_set_string(entity, "connectionStatus", state_info) == 0
+        && qd_entity_set_string(entity, "connectionMsg", connector->conn_msg) == 0) {
 
+        sys_mutex_unlock(connector->lock);
+        return QD_ERROR_NONE;
+    }
+
+    sys_mutex_unlock(connector->lock);
     return qd_error_code();
 }
 
@@ -955,11 +965,21 @@ void qd_connection_manager_free(qd_connection_manager_t *cm)
         li = DEQ_HEAD(cm->listeners);
     }
 
-    qd_connector_t *c = DEQ_HEAD(cm->connectors);
-    while (c) {
+    qd_connector_t *connector = DEQ_HEAD(cm->connectors);
+    while (connector) {
         DEQ_REMOVE_HEAD(cm->connectors);
-        qd_connector_decref(c);
-        c = DEQ_HEAD(cm->connectors);
+        sys_mutex_lock(connector->lock);
+        // setting DELETED below ensures the timer callback
+        // will not initiate a re-connect once we drop
+        // the lock
+        connector->state = CXTR_STATE_DELETED;
+        sys_mutex_unlock(connector->lock);
+        // cannot cancel timer while holding lock since the
+        // callback takes the lock
+        qd_timer_cancel(connector->timer);
+        qd_connector_decref(connector);
+
+        connector = DEQ_HEAD(cm->connectors);
     }
 
     qd_config_ssl_profile_t *sslp = DEQ_HEAD(cm->config_ssl_profiles);
@@ -1049,18 +1069,27 @@ static void deferred_close(void *context, bool discard) {
 }
 
 
+// threading: called by management thread while I/O thread may be
+// referencing the qd_connector_t via the qd_connection_t
+//
 void qd_connection_manager_delete_connector(qd_dispatch_t *qd, void *impl)
 {
     qd_connector_t *ct = (qd_connector_t*) impl;
     if (ct) {
+        // cannot free the timer while holding ct->lock since the
+        // timer callback may be running during the call to qd_timer_free
+        qd_timer_t *timer = 0;
         sys_mutex_lock(ct->lock);
-        if (ct->ctx) {
-            ct->ctx->connector = 0;
-            if(ct->ctx->pn_conn)
-                qd_connection_invoke_deferred(ct->ctx, deferred_close, ct->ctx->pn_conn);
-
+        timer = ct->timer;
+        ct->timer = 0;
+        ct->state = CXTR_STATE_DELETED;
+        qd_connection_t *conn = ct->qd_conn;
+        if (conn && conn->pn_conn) {
+            qd_connection_invoke_deferred(conn, deferred_close, conn->pn_conn);
         }
         sys_mutex_unlock(ct->lock);
+
+        qd_timer_free(timer);
         DEQ_REMOVE(qd->connection_manager->connectors, ct);
         qd_connector_decref(ct);
     }

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -363,6 +363,10 @@ static void qd_dispatch_set_router_area(qd_dispatch_t *qd, char *_area) {
 void qd_dispatch_free(qd_dispatch_t *qd)
 {
     if (!qd) return;
+
+    /* Stop HTTP threads immediately */
+    qd_http_server_free(qd_server_http(qd->server));
+
     free(qd->sasl_config_path);
     free(qd->sasl_config_name);
     qd_connection_manager_free(qd->connection_manager);

--- a/src/message.c
+++ b/src/message.c
@@ -1041,6 +1041,11 @@ void qd_message_free(qd_message_t *in_msg)
         //
         LOCK(content->lock);
 
+        // DISPATCH-2099: ensure all outstanding stream_data items associated
+        // with this message have been returned since the underlying buffers
+        // may be released
+        assert(DEQ_IS_EMPTY(msg->stream_data_list));
+
         const bool was_blocked = !qd_message_Q2_holdoff_should_unblock(in_msg);
         qd_buffer_t *buf = msg->cursor.buffer;
         while (buf) {

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -219,7 +219,7 @@ int qdr_link_process_deliveries(qdr_core_t *core, qdr_link_t *link, int credit)
                         } else {
                             DEQ_INSERT_TAIL(link->unsettled, dlv);
                             dlv->where = QDR_DELIVERY_IN_UNSETTLED;
-                            qd_log(core->log, QD_LOG_DEBUG, DLV_FMT"Delivery transfer:  qdr_link_process_deliveries: undelivered-list -> unsettled-list", DLV_ARGS(dlv));
+                            qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery transfer:  qdr_link_process_deliveries: undelivered-list -> unsettled-list", DLV_ARGS(dlv));
                         }
                     } else {
                         //
@@ -315,7 +315,7 @@ void qdr_link_complete_sent_message(qdr_core_t *core, qdr_link_t *link)
         if (!dlv->settled && !qdr_delivery_oversize(dlv) && !qdr_delivery_is_aborted(dlv)) {
             DEQ_INSERT_TAIL(link->unsettled, dlv);
             dlv->where = QDR_DELIVERY_IN_UNSETTLED;
-            qd_log(core->log, QD_LOG_DEBUG, DLV_FMT"Delivery transfer:  qdr_link_complete_sent_message: undelivered-list -> unsettled-list", DLV_ARGS(dlv));
+            qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery transfer:  qdr_link_complete_sent_message: undelivered-list -> unsettled-list", DLV_ARGS(dlv));
         } else {
             dlv->where = QDR_DELIVERY_NOWHERE;
             qdr_delivery_decref(core, dlv, "qdr_link_complete_sent_message - removed from undelivered");
@@ -545,6 +545,7 @@ static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery
         // messages will not *actually* be released in this case because these
         // are presettled messages.
         //
+        qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery forward:  qdr_link_forward_CT (qdr_addr_path_count_CT(addr) == 0): released dlv", DLV_ARGS(dlv));
         qdr_delivery_release_CT(core, dlv);
 
         //
@@ -665,8 +666,10 @@ static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery
         //
         // If the delivery is not settled, release it.
         //
-        if (!dlv->settled)
+        if (!dlv->settled) {
+        	qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery forward:  qdr_link_forward_CT(fanout == 0): released dlv", DLV_ARGS(dlv));
             qdr_delivery_release_CT(core, dlv);
+        }
         else {
             link->dropped_presettled_deliveries++;
             if (dlv_link->link_type == QD_LINK_ENDPOINT)
@@ -704,7 +707,7 @@ static void qdr_link_forward_CT(qdr_core_t *core, qdr_link_t *link, qdr_delivery
                 //
                 DEQ_INSERT_TAIL(link->settled, dlv);
                 dlv->where = QDR_DELIVERY_IN_SETTLED;
-                qd_log(core->log, QD_LOG_DEBUG, DLV_FMT"Delivery transfer:  qdr_link_forward_CT: action-list -> settled-list", DLV_ARGS(dlv));
+                qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery transfer:  qdr_link_forward_CT: action-list -> settled-list", DLV_ARGS(dlv));
             }
         } else {
             //
@@ -781,7 +784,7 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         if (!dlv->settled) {
             DEQ_INSERT_TAIL(link->unsettled, dlv);
             dlv->where = QDR_DELIVERY_IN_UNSETTLED;
-            qd_log(core->log, QD_LOG_DEBUG, DLV_FMT"Delivery transfer:  qdr_link_deliver_CT: action-list -> unsettled-list", DLV_ARGS(dlv));
+            qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery transfer:  qdr_link_deliver_CT: action-list -> unsettled-list", DLV_ARGS(dlv));
         } else {
             //
             // If the delivery is settled, decrement the ref_count on the delivery.
@@ -848,6 +851,7 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         // Deal with any delivery restrictions for this address.
         //
         if (addr && addr->router_control_only && link->link_type != QD_LINK_CONTROL) {
+        	qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Link forward:  qdr_link_deliver_CT: released dlv", DLV_ARGS(dlv));
             qdr_delivery_release_CT(core, dlv);
             qdr_link_issue_credit_CT(core, link, 1, false);
             qdr_delivery_decref_CT(core, dlv, "qdr_link_deliver_CT - removed from action on restricted access");
@@ -868,7 +872,7 @@ static void qdr_link_deliver_CT(qdr_core_t *core, qdr_action_t *action, bool dis
         //
         DEQ_INSERT_TAIL(link->undelivered, dlv);
         dlv->where = QDR_DELIVERY_IN_UNDELIVERED;
-        qd_log(core->log, QD_LOG_DEBUG, DLV_FMT"Delivery transfer:  qdr_link_deliver_CT: action-list -> undelivered-list", DLV_ARGS(dlv));
+        qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery transfer:  qdr_link_deliver_CT: action-list -> undelivered-list", DLV_ARGS(dlv));
     }
 }
 

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1398,7 +1398,9 @@ static void AMQP_opened_handler(qd_router_t *router, qd_connection_t *conn, bool
                 " auth=%s user=%s container_id=%s",
                 connection_id, inbound ? "in" : "out", host, vhost ? vhost : "", encrypted ? proto : "no",
                         authenticated ? mech : "no", (char*) user, container);
+        sys_mutex_lock(conn->connector->lock);
         strcpy(conn->connector->conn_msg, conn_msg);
+        sys_mutex_unlock(conn->connector->lock);
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -1366,12 +1366,13 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
     return qd_server;
 }
 
+qd_http_server_t *qd_server_http(qd_server_t *qd_server) {
+    return qd_server->http;
+}
 
 void qd_server_free(qd_server_t *qd_server)
 {
     if (!qd_server) return;
-
-    qd_http_server_free(qd_server->http);
 
     qd_connection_t *ctx = DEQ_HEAD(qd_server->conn_list);
     while (ctx) {

--- a/src/server.c
+++ b/src/server.c
@@ -888,53 +888,53 @@ bool qd_connector_has_failover_info(qd_connector_t* ct)
 }
 
 
-static void qd_connection_free(qd_connection_t *ctx)
+static void qd_connection_free(qd_connection_t *qd_conn)
 {
-    qd_server_t *qd_server = ctx->server;
+    qd_server_t    *qd_server = qd_conn->server;
+    qd_connector_t *connector = qd_conn->connector;
 
-    // If this is a dispatch connector, schedule the re-connect timer
-    if (ctx->connector) {
-        long delay = ctx->connector->delay;
-        sys_mutex_lock(ctx->connector->lock);
-        ctx->connector->ctx = 0;
-        // Increment the connection index by so that we can try connecting to the failover url (if any).
-        bool has_failover = qd_connector_has_failover_info(ctx->connector);
+    // If this is a dispatch connector uncouple it from the
+    // connection and restart the re-connect timer if necessary
 
-        if (has_failover) {
-            // Go thru the failover list round robin.
-            // IMPORTANT: Note here that we set the re-try timer to 1 second.
-            // We want to quickly keep cycling thru the failover urls every second.
-            delay = 1000;
+    if (connector) {
+        sys_mutex_lock(connector->lock);
+        connector->qd_conn = 0;  // this connection to be freed
+        if (connector->state != CXTR_STATE_DELETED) {
+            // Increment the connection index by so that we can try connecting to the failover url (if any).
+            bool has_failover = qd_connector_has_failover_info(connector);
+            long delay = connector->delay;
+
+            if (has_failover) {
+                // Go thru the failover list round robin.
+                // IMPORTANT: Note here that we set the re-try timer to 1 second.
+                // We want to quickly keep cycling thru the failover urls every second.
+                delay = 1000;
+            }
+            connector->state = CXTR_STATE_CONNECTING;
+            qd_timer_schedule(connector->timer, delay);
         }
-
-        ctx->connector->state = CXTR_STATE_CONNECTING;
-        sys_mutex_unlock(ctx->connector->lock);
-
-        //
-        // Increment the ref-count to account for the timer's reference to the connector.
-        //
-        sys_atomic_inc(&ctx->connector->ref_count);
-        qd_timer_schedule(ctx->connector->timer, delay);
+        sys_mutex_unlock(connector->lock);
+        qd_connector_decref(connector);  // drop connection's reference
     }
 
     sys_mutex_lock(qd_server->lock);
-    DEQ_REMOVE(qd_server->conn_list, ctx);
+    DEQ_REMOVE(qd_server->conn_list, qd_conn);
 
     // If counted for policy enforcement, notify it has closed
-    if (ctx->policy_counted) {
-        qd_policy_socket_close(qd_server->qd->policy, ctx);
+    if (qd_conn->policy_counted) {
+        qd_policy_socket_close(qd_server->qd->policy, qd_conn);
     }
     sys_mutex_unlock(qd_server->lock);
 
-    invoke_deferred_calls(ctx, true);  // Discard any pending deferred calls
-    sys_mutex_free(ctx->deferred_call_lock);
-    qd_policy_settings_free(ctx->policy_settings);
-    if (ctx->free_user_id) free((char*)ctx->user_id);
-    if (ctx->timer) qd_timer_free(ctx->timer);
-    free(ctx->name);
-    free(ctx->role);
+    invoke_deferred_calls(qd_conn, true);  // Discard any pending deferred calls
+    sys_mutex_free(qd_conn->deferred_call_lock);
+    qd_policy_settings_free(qd_conn->policy_settings);
+    if (qd_conn->free_user_id) free((char*)qd_conn->user_id);
+    if (qd_conn->timer) qd_timer_free(qd_conn->timer);
+    free(qd_conn->name);
+    free(qd_conn->role);
     sys_mutex_lock(qd_server->conn_activation_lock);
-    free_qd_connection_t(ctx);
+    free_qd_connection_t(qd_conn);
     sys_mutex_unlock(qd_server->conn_activation_lock);
 
     /* Note: pn_conn is freed by the proactor */
@@ -1053,6 +1053,7 @@ static bool handle(qd_server_t *qd_server, pn_event_t *e, pn_connection_t *pn_co
             if (ctx && ctx->connector) { /* Outgoing connection */
                 qd_increment_conn_index(ctx);
                 const qd_server_config_t *config = &ctx->connector->config;
+                // note: will transition back to STATE_CONNECTING when ctx is freed (pn_connection_free)
                 ctx->connector->state = CXTR_STATE_FAILED;
                 char conn_msg[300];
                 if (condition  && pn_condition_is_set(condition)) {
@@ -1155,55 +1156,54 @@ static qd_failover_item_t *qd_connector_get_conn_info(qd_connector_t *ct) {
 
 
 /* Timer callback to try/retry connection open */
-static void try_open_lh(qd_connector_t *ct)
+static void try_open_lh(qd_connector_t *connector)
 {
-    if (ct->state != CXTR_STATE_CONNECTING && ct->state != CXTR_STATE_INIT) {
-        /* No longer referenced by pn_connection or timer */
-        qd_connector_decref(ct);
+    // Allocate a new connection. No other thread will touch this
+    // connection until pn_proactor_connect is called below
+    qd_connection_t *qd_conn = qd_server_connection(connector->server, &connector->config);
+    if (!qd_conn) {                 /* Try again later */
+        qd_log(connector->server->log_source, QD_LOG_CRITICAL, "Allocation failure connecting to %s",
+               connector->config.host_port);
+        connector->delay = 10000;
+        connector->state = CXTR_STATE_CONNECTING;
+        qd_timer_schedule(connector->timer, connector->delay);
         return;
     }
 
-    qd_connection_t *ctx = qd_server_connection(ct->server, &ct->config);
-    if (!ctx) {                 /* Try again later */
-        qd_log(ct->server->log_source, QD_LOG_CRITICAL, "Allocation failure connecting to %s",
-               ct->config.host_port);
-        ct->delay = 10000;
-        sys_atomic_inc(&ct->ref_count);
-        qd_timer_schedule(ct->timer, ct->delay);
-        return;
-    }
+    qd_conn->connector = connector;
+    sys_atomic_inc(&connector->ref_count);
 
-    ctx->connector    = ct;
-    const qd_server_config_t *config = &ct->config;
+    connector->qd_conn = qd_conn;
+    connector->state   = CXTR_STATE_OPEN;
+    connector->delay   = 5000;
 
     //
     // Set the hostname on the pn_connection. This hostname will be used by proton as the
     // hostname in the open frame.
     //
 
-    qd_failover_item_t *item = qd_connector_get_conn_info(ct);
+    qd_failover_item_t *item = qd_connector_get_conn_info(connector);
 
     char *current_host = item->host;
     char *host_port = item->host_port;
 
-    pn_connection_set_hostname(ctx->pn_conn, current_host);
+    pn_connection_set_hostname(qd_conn->pn_conn, current_host);
 
     // Set the sasl user name and password on the proton connection object. This has to be
     // done before pn_proactor_connect which will bind a transport to the connection
+    const qd_server_config_t *config = &connector->config;
     if(config->sasl_username)
-        pn_connection_set_user(ctx->pn_conn, config->sasl_username);
+        pn_connection_set_user(qd_conn->pn_conn, config->sasl_username);
     if (config->sasl_password)
-        pn_connection_set_password(ctx->pn_conn, config->sasl_password);
+        pn_connection_set_password(qd_conn->pn_conn, config->sasl_password);
 
-    ctx->connector->state = CXTR_STATE_OPEN;
-    ct->ctx   = ctx;
-    ct->delay = 5000;
-
-    qd_log(ct->server->log_source, QD_LOG_TRACE,
-           "[C%"PRIu64"] Connecting to %s", ctx->connection_id, host_port);
+    qd_log(connector->server->log_source, QD_LOG_TRACE,
+           "[C%"PRIu64"] Connecting to %s", qd_conn->connection_id, host_port);
     /* Note: the transport is configured in the PN_CONNECTION_BOUND event */
-    pn_proactor_connect(ct->server->proactor, ctx->pn_conn, host_port);
+    pn_proactor_connect(connector->server->proactor, qd_conn->pn_conn, host_port);
+    // at this point the qd_conn may now be scheduled on another thread
 }
+
 
 static bool setup_ssl_sasl_and_open(qd_connection_t *ctx)
 {
@@ -1316,13 +1316,22 @@ static bool setup_ssl_sasl_and_open(qd_connection_t *ctx)
     return true;
 }
 
-static void try_open_cb(void *context) {
+
+// (re)connection timer callback used by connector
+//
+static void try_open_cb(void *context)
+{
     qd_connector_t *ct = (qd_connector_t*) context;
-    if (!qd_connector_decref(ct)) {
-        sys_mutex_lock(ct->lock);   /* TODO aconway 2017-05-09: this lock looks too big */
+
+    sys_mutex_lock(ct->lock);   /* TODO aconway 2017-05-09: this lock looks too big */
+
+    if (ct->state == CXTR_STATE_CONNECTING || ct->state == CXTR_STATE_INIT) {
+        // else deleted or failed - on failed wait until after connection is freed
+        // and state is set to CXTR_STATE_CONNECTING (timer is rescheduled then)
         try_open_lh(ct);
-        sys_mutex_unlock(ct->lock);
     }
+
+    sys_mutex_unlock(ct->lock);
 }
 
 
@@ -1395,6 +1404,10 @@ void qd_server_free(qd_server_t *qd_server)
         free(ctx->role);
         if (ctx->policy_settings)
             free_qd_policy_settings_t(ctx->policy_settings);
+        if (ctx->connector) {
+            ctx->connector->qd_conn = 0;
+            qd_connector_decref(ctx->connector);
+        }
         free_qd_connection_t(ctx);
         ctx = DEQ_HEAD(qd_server->conn_list);
     }
@@ -1645,25 +1658,33 @@ void qd_listener_decref(qd_listener_t* li)
 
 qd_connector_t *qd_server_connector(qd_server_t *server)
 {
-    qd_connector_t *ct = new_qd_connector_t();
-    if (!ct) return 0;
-    ZERO(ct);
-    sys_atomic_init(&ct->ref_count, 1);
-    ct->server  = server;
-    qd_failover_item_list_t conn_info_list;
-    DEQ_INIT(conn_info_list);
-    ct->conn_info_list = conn_info_list;
-    ct->conn_index = 1;
-    ct->state   = CXTR_STATE_INIT;
-    ct->lock = sys_mutex();
-    ct->conn_msg = (char*) malloc(300);
-    memset(ct->conn_msg, 0, 300);
-    ct->timer = qd_timer(ct->server->qd, try_open_cb, ct);
-    if (!ct->lock || !ct->timer) {
-        qd_connector_decref(ct);
-        return 0;
-    }
-    return ct;
+    qd_connector_t *connector = new_qd_connector_t();
+    if (!connector) return 0;
+    ZERO(connector);
+    sys_atomic_init(&connector->ref_count, 1);
+    DEQ_INIT(connector->conn_info_list);
+
+    connector->lock = sys_mutex();
+    if (!connector->lock)
+        goto error;
+    connector->timer = qd_timer(server->qd, try_open_cb, connector);
+    if (!connector->timer)
+        goto error;
+    connector->conn_msg = (char*) malloc(300);
+    if (!connector->conn_msg)
+        goto error;
+    memset(connector->conn_msg, 0, 300);
+
+    connector->server     = server;
+    connector->conn_index = 1;
+    connector->state      = CXTR_STATE_INIT;
+
+    return connector;
+
+error:
+    connector->state = CXTR_STATE_DELETED;
+    qd_connector_decref(connector);
+    return 0;
 }
 
 
@@ -1676,45 +1697,45 @@ const char *qd_connector_policy_vhost(qd_connector_t* ct)
 bool qd_connector_connect(qd_connector_t *ct)
 {
     sys_mutex_lock(ct->lock);
-    ct->ctx     = 0;
+    // expect: do not attempt to connect an already connected qd_connection
+    assert(ct->qd_conn == 0);
+    ct->qd_conn = 0;
     ct->delay   = 0;
-    /* Referenced by timer */
-    sys_atomic_inc(&ct->ref_count);
+    ct->state   = CXTR_STATE_CONNECTING;
     qd_timer_schedule(ct->timer, ct->delay);
     sys_mutex_unlock(ct->lock);
     return true;
 }
 
 
-bool qd_connector_decref(qd_connector_t* ct)
+void qd_connector_decref(qd_connector_t* connector)
 {
-    if (ct && sys_atomic_dec(&ct->ref_count) == 1) {
-        sys_mutex_lock(ct->lock);
-        if (ct->ctx) {
-            ct->ctx->connector = 0;
-        }
-        sys_mutex_unlock(ct->lock);
-        qd_server_config_free(&ct->config);
-        qd_timer_free(ct->timer);
+    if (!connector) return;
+    if (sys_atomic_dec(&connector->ref_count) == 1) {
 
-        qd_failover_item_t *item = DEQ_HEAD(ct->conn_info_list);
+        // expect both mgmt and qd_connection no longer reference this
+        assert(connector->state == CXTR_STATE_DELETED);
+        assert(connector->qd_conn == 0);
+
+        qd_server_config_free(&connector->config);
+        qd_timer_free(connector->timer);
+        if (connector->lock) sys_mutex_free(connector->lock);
+
+        qd_failover_item_t *item = DEQ_HEAD(connector->conn_info_list);
         while (item) {
-            DEQ_REMOVE_HEAD(ct->conn_info_list);
+            DEQ_REMOVE_HEAD(connector->conn_info_list);
             free(item->scheme);
             free(item->host);
             free(item->port);
             free(item->hostname);
             free(item->host_port);
             free(item);
-            item = DEQ_HEAD(ct->conn_info_list);
+            item = DEQ_HEAD(connector->conn_info_list);
         }
-        sys_mutex_free(ct->lock);
-        if (ct->policy_vhost) free(ct->policy_vhost);
-        free(ct->conn_msg);
-        free_qd_connector_t(ct);
-        return true;
+        if (connector->policy_vhost) free(connector->policy_vhost);
+        free(connector->conn_msg);
+        free_qd_connector_t(connector);
     }
-    return false;
 }
 
 __attribute__((noinline)) // permit replacement by dummy implementation in unit_tests

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -54,7 +54,7 @@ const qd_server_config_t *qd_connector_config(const qd_connector_t *c);
 qd_listener_t *qd_server_listener(qd_server_t *server);
 qd_connector_t *qd_server_connector(qd_server_t *server);
 
-bool qd_connector_decref(qd_connector_t* ct);
+void qd_connector_decref(qd_connector_t* ct);
 void qd_listener_decref(qd_listener_t* ct);
 void qd_server_config_free(qd_server_config_t *cf);
 
@@ -62,7 +62,8 @@ typedef enum {
     CXTR_STATE_INIT = 0,
     CXTR_STATE_CONNECTING,
     CXTR_STATE_OPEN,
-    CXTR_STATE_FAILED
+    CXTR_STATE_FAILED,
+    CXTR_STATE_DELETED  // by management
 } cxtr_state_t;
 
 
@@ -123,23 +124,23 @@ DEQ_DECLARE(qd_listener_t, qd_listener_list_t);
  * Connector objects represent the desire to create and maintain an outgoing transport connection.
  */
 struct qd_connector_t {
-    /* May be referenced by connection_manager, timer and pn_connection_t */
+    /* Referenced by connection_manager and pn_connection_t */
     sys_atomic_t              ref_count;
     qd_server_t              *server;
     qd_server_config_t        config;
     qd_timer_t               *timer;
     long                      delay;
 
-    /* Connector state and ctx can be modified in proactor or management threads. */
+    /* Connector state and ctx can be modified by I/O or management threads. */
     sys_mutex_t              *lock;
     cxtr_state_t              state;
     char                     *conn_msg;
-    qd_connection_t          *ctx;
+    qd_connection_t          *qd_conn;
 
     /* This conn_list contains all the connection information needed to make a connection. It also includes failover connection information */
     qd_failover_item_list_t   conn_info_list;
     int                       conn_index; // Which connection in the connection list to connect to next.
-    
+
     /* Optional policy vhost name */
     char                     *policy_vhost;
 

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -92,6 +92,8 @@ DEQ_DECLARE(qd_pn_free_link_session_t, qd_pn_free_link_session_list_t);
 
 pn_proactor_t* qd_server_proactor(qd_server_t *s);
 
+qd_http_server_t *qd_server_http(qd_server_t *server);
+
 typedef void (*qd_server_event_handler_t) (pn_event_t *e, qd_server_t *qd_server, void *context);
 
 typedef struct qd_handler_context_t {

--- a/src/timer.c
+++ b/src/timer.c
@@ -25,15 +25,59 @@
 
 #include "qpid/dispatch/alloc.h"
 #include "qpid/dispatch/ctools.h"
-#include "qpid/dispatch/threading.h"
+#include "qpid/dispatch/atomic.h"
 
 #include <assert.h>
 #include <stdio.h>
 #include <time.h>
 
+
+// timer state machine
+//
+// IDLE: initial state or state immediately after the callback finishes
+// running.
+//
+// SCHEDULED: timer has been scheduled to run.  It is on the scheduled_timer
+// list.  Valid next states are IDLE (if timer canceled), RUNNING, or DELETED.
+//
+// RUNNING: the timer callback is executing.  Valid next states are IDLE,
+// SCHEDULED, BLOCKED or DELETED.  The address of the thread executing the
+// callback is available in callback_thread
+//
+// BLOCKED: the callback is executing and another thread is blocked waiting for
+// the callback to complete.  This state is used when cancelling or freeing a
+// running timer.
+//
+// DELETED: final state.  There are no valid next states.
+//
+typedef enum {
+    QD_TIMER_STATE_IDLE,
+    QD_TIMER_STATE_SCHEDULED,
+    QD_TIMER_STATE_RUNNING,
+    QD_TIMER_STATE_BLOCKED,
+    QD_TIMER_STATE_DELETED
+} qd_timer_state_t;
+
+
+struct qd_timer_t {
+    DEQ_LINKS(qd_timer_t);
+    qd_server_t      *server;
+    qd_timer_cb_t     handler;
+    void             *context;
+    sys_cond_t       *condition;
+    sys_atomic_t      ref_count; // referenced by user and when on scheduled list
+    qd_timestamp_t    delta_time;
+    qd_timer_state_t  state;
+};
+
+DEQ_DECLARE(qd_timer_t, qd_timer_list_t);
+
 static sys_mutex_t     *lock = NULL;
-static qd_timer_list_t  idle_timers = {0};
 static qd_timer_list_t  scheduled_timers = {0};
+
+// thread currently running timer callbacks or 0 if callbacks are not running
+static sys_thread_t    *callback_thread = 0;
+
 /* Timers have relative delta_time measured from the previous timer.
  * The delta_time of the first timer on the queue is measured from timer_base.
  */
@@ -49,16 +93,19 @@ sys_mutex_t* qd_timer_lock() { return lock; }
 // Private static functions
 //=========================================================================
 
-static void timer_cancel_LH(qd_timer_t *timer)
+// returns true if timer removed from scheduled list
+static bool timer_cancel_LH(qd_timer_t *timer)
 {
-    if (timer->scheduled) {
+    if (timer->state == QD_TIMER_STATE_SCHEDULED) {
         if (timer->next)
             timer->next->delta_time += timer->delta_time;
         DEQ_REMOVE(scheduled_timers, timer);
-        DEQ_INSERT_TAIL(idle_timers, timer);
-        timer->scheduled = false;
+        timer->state = QD_TIMER_STATE_IDLE;
+        return true;
     }
+    return false;
 }
+
 
 /* Adjust timer's time_base and delays for the current time. */
 static void timer_adjust_now_LH()
@@ -81,6 +128,18 @@ static void timer_adjust_now_LH()
 }
 
 
+static void timer_decref_LH(qd_timer_t *timer)
+{
+    assert(sys_atomic_get(&timer->ref_count) > 0);
+    if (sys_atomic_dec(&timer->ref_count) == 1) {
+        assert(timer->state != QD_TIMER_STATE_SCHEDULED);
+        sys_cond_free(timer->condition);
+        sys_atomic_destroy(&timer->ref_count);
+        free_qd_timer_t(timer);
+    }
+}
+
+
 //=========================================================================
 // Public Functions from timer.h
 //=========================================================================
@@ -92,16 +151,21 @@ qd_timer_t *qd_timer(qd_dispatch_t *qd, qd_timer_cb_t cb, void* context)
     if (!timer)
         return 0;
 
+    sys_cond_t *cond = sys_cond();
+    if (!cond) {
+        free_qd_timer_t(timer);
+        return 0;
+    }
+
     DEQ_ITEM_INIT(timer);
 
     timer->server     = qd ? qd->server : 0;
     timer->handler    = cb;
     timer->context    = context;
     timer->delta_time = 0;
-    timer->scheduled  = false;
-    sys_mutex_lock(lock);
-    DEQ_INSERT_TAIL(idle_timers, timer);
-    sys_mutex_unlock(lock);
+    timer->condition  = cond;
+    timer->state      = QD_TIMER_STATE_IDLE;
+    sys_atomic_init(&timer->ref_count, 1);
 
     return timer;
 }
@@ -110,16 +174,37 @@ qd_timer_t *qd_timer(qd_dispatch_t *qd, qd_timer_cb_t cb, void* context)
 void qd_timer_free(qd_timer_t *timer)
 {
     if (!timer) return;
+
     sys_mutex_lock(lock);
-    timer_cancel_LH(timer);
-    DEQ_REMOVE(idle_timers, timer);
+
+    assert(timer->state != QD_TIMER_STATE_DELETED);  // double free!!!
+
+    if (timer->state == QD_TIMER_STATE_RUNNING) {
+        if (sys_thread_self() != callback_thread) {
+            // Another thread is running the callback (see qd_timer_visit())
+            // Wait until the callback finishes
+            timer->state = QD_TIMER_STATE_BLOCKED;
+            sys_cond_wait(timer->condition, lock);
+        }
+    }
+
+    // we can safely free the timer since the callback is not running
+
+    if (timer_cancel_LH(timer)) {
+        // removed from scheduled_timers, so drop ref_count
+        assert(sys_atomic_get(&timer->ref_count) > 1);  // expect caller holds a ref_count
+        timer_decref_LH(timer);
+    }
+
+    timer->state = QD_TIMER_STATE_DELETED;
+    timer_decref_LH(timer);  // now drop caller ref_count
     sys_mutex_unlock(lock);
-    free_qd_timer_t(timer);
 }
 
 
 __attribute__((noinline)) // permit replacement by dummy implementation in unit_tests
-qd_timestamp_t qd_timer_now() {
+qd_timestamp_t qd_timer_now()
+{
     struct timespec tv;
     clock_gettime(CLOCK_MONOTONIC, &tv);
     return ((qd_timestamp_t)tv.tv_sec) * 1000 + tv.tv_nsec / 1000000;
@@ -129,8 +214,9 @@ qd_timestamp_t qd_timer_now() {
 void qd_timer_schedule(qd_timer_t *timer, qd_duration_t duration)
 {
     sys_mutex_lock(lock);
-    timer_cancel_LH(timer);  // Timer is now on the idle list
-    DEQ_REMOVE(idle_timers, timer);
+
+    assert(timer->state != QD_TIMER_STATE_DELETED);
+    const bool was_scheduled = timer_cancel_LH(timer);
 
     //
     // Find the insert point in the schedule.
@@ -157,7 +243,12 @@ void qd_timer_schedule(qd_timer_t *timer, qd_duration_t duration)
         else
             DEQ_INSERT_HEAD(scheduled_timers, timer);
     }
-    timer->scheduled = true;
+
+    timer->state = QD_TIMER_STATE_SCHEDULED;
+    if (!was_scheduled) {
+        // scheduled_timers list reference:
+        sys_atomic_inc(&timer->ref_count);
+    }
 
     qd_timer_t *first = DEQ_HEAD(scheduled_timers);
     qd_server_timeout(first->server, first->delta_time);
@@ -168,7 +259,19 @@ void qd_timer_schedule(qd_timer_t *timer, qd_duration_t duration)
 void qd_timer_cancel(qd_timer_t *timer)
 {
     sys_mutex_lock(lock);
-    timer_cancel_LH(timer);
+
+    if (timer->state == QD_TIMER_STATE_RUNNING) {
+        assert(sys_thread_self() != callback_thread);  // cancel within callback not allowed
+        timer->state = QD_TIMER_STATE_BLOCKED;
+        sys_cond_wait(timer->condition, lock);
+    }
+
+    // timer may have been resheduled before wait returns
+    const bool need_decref = timer_cancel_LH(timer);
+    timer->state = QD_TIMER_STATE_IDLE;
+    if (need_decref)  // was on scheduled list
+        timer_decref_LH(timer);
+
     sys_mutex_unlock(lock);
 }
 
@@ -181,7 +284,6 @@ void qd_timer_cancel(qd_timer_t *timer)
 void qd_timer_initialize(sys_mutex_t *server_lock)
 {
     lock = server_lock;
-    DEQ_INIT(idle_timers);
     DEQ_INIT(scheduled_timers);
     time_base = 0;
 }
@@ -197,18 +299,39 @@ void qd_timer_finalize(void)
 void qd_timer_visit()
 {
     sys_mutex_lock(lock);
+    callback_thread = sys_thread_self();
     timer_adjust_now_LH();
     qd_timer_t *timer = DEQ_HEAD(scheduled_timers);
     while (timer && timer->delta_time == 0) {
-        timer_cancel_LH(timer); /* Removes timer from scheduled_timers */
+        // Remove timer from scheduled_timers but keep ref_count
+        assert(timer->state == QD_TIMER_STATE_SCHEDULED);
+        // note: still holding scheduled_timers refcount
+        timer_cancel_LH(timer);
+        timer->state = QD_TIMER_STATE_RUNNING;
         sys_mutex_unlock(lock);
-        timer->handler(timer->context); /* Call the handler outside the lock, may re-schedule */
+
+        /* The callback may reschedule or delete the timer while the lock is
+         * dropped.  Attempting to delete the timer now will cause the caller to
+         * block until the callback is done.
+         */
+        timer->handler(timer->context);
+
         sys_mutex_lock(lock);
+        if (timer->state == QD_TIMER_STATE_BLOCKED) {
+            sys_cond_signal(timer->condition);
+            // expect blocked caller sets timer->state
+        } else if (timer->state == QD_TIMER_STATE_RUNNING) {
+            timer->state = QD_TIMER_STATE_IDLE;
+        }
+
+        // now drop scheduled_timers reference:
+        timer_decref_LH(timer);
         timer = DEQ_HEAD(scheduled_timers);
     }
     qd_timer_t *first = DEQ_HEAD(scheduled_timers);
     if (first) {
         qd_server_timeout(first->server, first->delta_time);
     }
+    callback_thread = 0;
     sys_mutex_unlock(lock);
 }

--- a/src/timer_private.h
+++ b/src/timer_private.h
@@ -19,20 +19,8 @@
  * under the License.
  */
 
-#include "qpid/dispatch/ctools.h"
-#include "qpid/dispatch/threading.h"
 #include "qpid/dispatch/timer.h"
-
-struct qd_timer_t {
-    DEQ_LINKS(qd_timer_t);
-    qd_server_t      *server;
-    qd_timer_cb_t     handler;
-    void             *context;
-    qd_timestamp_t    delta_time;
-    bool              scheduled; /* true means on scheduled list, false on idle list */
-};
-
-DEQ_DECLARE(qd_timer_t, qd_timer_list_t);
+#include "qpid/dispatch/threading.h"
 
 void qd_timer_initialize(sys_mutex_t *server_lock);
 void qd_timer_finalize(void);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,9 @@ target_link_libraries(test-receiver ${Proton_LIBRARIES})
 add_executable(clogger clogger.c)
 target_link_libraries(clogger ${Proton_LIBRARIES})
 
+add_executable(threaded_timer_test threaded_timer_test.c)
+target_link_libraries(threaded_timer_test qpid-dispatch)
+
 # Bubblewrap is an unprivileged sandboxing tool for Linux. Setting --unshare-net allows
 # running tests in parallel (the ctest -j option) without port clashes
 set(USE_BWRAP OFF CACHE BOOL "Wrap test executions with bwrap (https://github.com/containers/bubblewrap)")
@@ -82,6 +85,9 @@ add_test(unit_tests_size_3     ${TEST_WRAP} unit_tests_size 3)
 add_test(unit_tests_size_2     ${TEST_WRAP} unit_tests_size 2)
 add_test(unit_tests_size_1     ${TEST_WRAP} unit_tests_size 1)
 add_test(unit_tests            ${TEST_WRAP} unit_tests ${CMAKE_CURRENT_SOURCE_DIR}/threads4.conf)
+
+# stand alone tests
+add_test(threaded_timer_test   ${TEST_WRAP} threaded_timer_test ${CMAKE_CURRENT_SOURCE_DIR}/dummy.conf)
 
 # Unit test python modules
 foreach(py_test_module

--- a/tests/dummy.conf
+++ b/tests/dummy.conf
@@ -1,0 +1,28 @@
+##
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License
+##
+
+
+router {
+   id : QDR
+}
+
+log {
+    module: DEFAULT
+    enable: none
+}

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -7,7 +7,6 @@ leak:^IoAdapter_init$
 
 # to be triaged; pretty much all tests
 leak:^load_server_config$
-leak:^qd_dispatch_configure_connector$
 
 # to be triaged; system_tests_autolinks
 leak:^qdr_error_description$

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -1107,15 +1107,10 @@ class AsyncTestSender(MessagingHandler):
         event.delivery.settle()
 
     def on_released(self, event):
-        # for some reason Proton 'helpfully' calls on_released even though the
-        # delivery state is actually MODIFIED
         if event.delivery.remote_state == Delivery.MODIFIED:
-            return self.on_modified(event)
-        self.released += 1
-        event.delivery.settle()
-
-    def on_modified(self, event):
-        self.modified += 1
+            self.modified += 1
+        else:
+            self.released += 1
         event.delivery.settle()
 
     def on_rejected(self, event):

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -2543,10 +2543,6 @@ class DispositionSniffer(MessagingHandler):
         self.delivery = event.delivery
         self.close()
 
-    def on_modified(self, event):
-        self.delivery = event.delivery
-        self.close()
-
     def on_rejected(self, event):
         self.delivery = event.delivery
         self.close()

--- a/tests/system_tests_multi_phase.py
+++ b/tests/system_tests_multi_phase.py
@@ -47,7 +47,7 @@ class RouterTest(TestCase):
 
         def router(name, mode, connection, extra=None):
             config = [
-                ('router', {'mode': mode, 'id': name}),
+                ('router', {'mode': mode, 'id': name, "helloMaxAgeSeconds": '10'}),
                 ('listener', {'port': cls.tester.get_port(), 'stripAnnotations': 'no'}),
                 ('address', {'prefix': 'queue', 'waypoint': 'yes'}),
                 ('address', {'prefix': 'multi', 'ingressPhase': '0', 'egressPhase': '9'}),

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -600,18 +600,14 @@ class MulticastBase(MessagingHandler):
         self.n_outcomes[Delivery.ACCEPTED] = 1 + self.n_outcomes.get(Delivery.ACCEPTED, 0)
 
     def on_released(self, event):
-        # for some reason Proton 'helpfully' calls on_released even though the
-        # delivery state is actually MODIFIED
         if event.delivery.remote_state == Delivery.MODIFIED:
-            return self.on_modified(event)
-        self.n_released += 1
-        name = event.link.name
-        self.n_outcomes[Delivery.RELEASED] = 1 + self.n_outcomes.get(Delivery.RELEASED, 0)
-
-    def on_modified(self, event):
-        self.n_modified += 1
-        name = event.link.name
-        self.n_outcomes[Delivery.MODIFIED] = 1 + self.n_outcomes.get(Delivery.MODIFIED, 0)
+            self.n_modified += 1
+            name = event.link.name
+            self.n_outcomes[Delivery.MODIFIED] = 1 + self.n_outcomes.get(Delivery.MODIFIED, 0)
+        else:
+            self.n_released += 1
+            name = event.link.name
+            self.n_outcomes[Delivery.RELEASED] = 1 + self.n_outcomes.get(Delivery.RELEASED, 0)
 
     def on_rejected(self, event):
         self.n_rejected += 1
@@ -806,11 +802,6 @@ class MulticastUnsettled3Ack(MulticastBase):
 
     def on_released(self, event):
         super(MulticastUnsettled3Ack, self).on_released(event)
-        event.delivery.settle()
-        self.check_if_done()
-
-    def on_modified(self, event):
-        super(MulticastUnsettled3Ack, self).on_modified(event)
         event.delivery.settle()
         self.check_if_done()
 

--- a/tests/system_tests_qdmanage.py
+++ b/tests/system_tests_qdmanage.py
@@ -77,6 +77,7 @@ class QdmanageTest(TestCase):
         cls.router_2 = cls.tester.qdrouterd('test_router_2', config_2, wait=True)
         cls.router_1 = cls.tester.qdrouterd('test_router_1', config_1, wait=True)
         cls.router_1.wait_router_connected('R2')
+        cls.router_2.wait_router_connected('R1')
 
     def address(self):
         return self.router_1.addresses[0]

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -565,6 +565,7 @@ class QdstatLinkPriorityTest(system_test.TestCase):
         cls.router_2 = cls.tester.qdrouterd('test_router_2', config_2, wait=True)
         cls.router_1 = cls.tester.qdrouterd('test_router_1', config_1, wait=True)
         cls.router_1.wait_router_connected('R2')
+        cls.router_2.wait_router_connected('R1')
 
     def address(self):
         return self.router_1.addresses[0]

--- a/tests/threaded_timer_test.c
+++ b/tests/threaded_timer_test.c
@@ -1,0 +1,473 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <limits.h>
+#include <sys/select.h>
+#include <qpid/dispatch/timer.h>
+#include "dispatch_private.h"
+#include <qpid/dispatch/alloc.h>
+#include "timer_private.h"
+#include "test_case.h"
+#include <qpid/dispatch/atomic.h>
+#include <qpid/dispatch/threading.h>
+
+
+// test the interaction of threads and timers
+//
+// This test cannot be part of the unit_test executable since unit_test
+// overrides some of the timer-private functions and this test needs to
+// exercise the "real" versions of those functions.
+
+
+// overide qd_server_timeout - this test uses ticker_thread instead of proactor
+// so this is not needed
+void qd_server_timeout(qd_server_t *server, qd_duration_t duration)
+{
+}
+
+
+// Timer thread - polls the timers every 10 msecs
+//
+static sys_mutex_t *ticker_lock = 0;
+static bool done = false;
+static void *ticker_thread(void *arg)
+{
+    struct timeval period;
+
+    sys_mutex_lock(ticker_lock);
+    while (!done) {
+        // 10 msec sleep
+        sys_mutex_unlock(ticker_lock);
+        period.tv_sec = 0;
+        period.tv_usec = 10 * 1000;
+        select(0, 0, 0, 0, &period);
+        qd_timer_visit();
+        sys_mutex_lock(ticker_lock);
+    }
+    sys_mutex_unlock(ticker_lock);
+    return 0;
+}
+
+
+// global event for synchronizing with timer callback
+//
+static struct event_t {
+    sys_mutex_t *m;
+    sys_cond_t  *c;
+} event;
+
+static void test_setup()
+{
+    event.m = sys_mutex();
+    event.c = sys_cond();
+}
+
+static void test_cleanup()
+{
+    sys_mutex_free(event.m);
+    event.m = 0;
+    sys_cond_free(event.c);
+    event.c = 0;
+}
+
+
+//
+// simple set and expire test
+//
+
+static void test_simple_cb(void *context)
+{
+    int *iptr = (int *)context;
+
+    sys_mutex_lock(event.m);  // block until test_simple waits
+    *iptr = 2;
+    sys_cond_signal(event.c);
+    sys_mutex_unlock(event.m);
+}
+
+static int test_simple(const char *name)
+{
+    int i = 1;
+    int result = 0;
+
+    test_setup();
+
+    qd_timer_t *t = qd_timer(0, test_simple_cb, (void *)&i);
+    sys_mutex_lock(event.m);
+
+    qd_timestamp_t start = qd_timer_now();
+    qd_timer_schedule(t, 100);
+    sys_cond_wait(event.c, event.m);   // wait for cb to finish
+    qd_timestamp_t stop = qd_timer_now();
+    if (i != 2) {
+        fprintf(stderr, "%s failed: expected timer to run\n", name);
+        result = 1;
+    }
+
+    if ((stop - start) < 100) {
+        fprintf(stderr, "%s failed: expected timer ran too soon\n", name);
+        result = 1;
+    }
+    sys_mutex_unlock(event.m);
+    qd_timer_free(t);
+
+    test_cleanup();
+    fprintf(stderr, "Test test_simple: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test rescheduling from within the callback
+//
+
+static qd_timer_t *reschedule_timer;
+
+static void test_reschedule_internal_cb(void *context)
+{
+    int *iptr = (int *)context;
+
+    switch (*iptr) {
+    case 1:  // first time in
+        (*iptr) += 1;
+        qd_timer_schedule(reschedule_timer, 100);
+        break;
+    case 2:
+        (*iptr) += 1;
+        sys_mutex_lock(event.m);
+        sys_cond_signal(event.c);
+        sys_mutex_unlock(event.m);
+        break;
+    }
+}
+
+static int test_reschedule_internal(const char *name)
+{
+    int i = 1;
+    int result = 0;
+
+    test_setup();
+    reschedule_timer = qd_timer(0, test_reschedule_internal_cb, (void *)&i);
+    sys_mutex_lock(event.m);
+    qd_timestamp_t start = qd_timer_now();
+    qd_timer_schedule(reschedule_timer, 100);
+    sys_cond_wait(event.c, event.m);   // wait for cb to finish
+    qd_timestamp_t stop = qd_timer_now();
+
+    if (i != 3) {
+        fprintf(stderr, "%s failed: expected timer to reschedule\n", name);
+        result = 1;
+    }
+
+    if ((stop - start) < 200) {
+        fprintf(stderr, "%s failed: timer expired too soon\n", name);
+        result = 1;
+    }
+    sys_mutex_unlock(event.m);
+    qd_timer_free(reschedule_timer);
+
+    test_cleanup();
+    fprintf(stderr, "Test reschedule_internal: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test freeing timer from within the callback
+//
+
+static qd_timer_t *free_timer;
+
+static void test_free_internal_cb(void *context)
+{
+    sys_mutex_lock(event.m);
+    qd_timer_free(free_timer);
+    free_timer = 0;
+
+    sys_cond_signal(event.c);
+    sys_mutex_unlock(event.m);
+}
+
+static int test_free_internal(const char *name)
+{
+    int result = 0;
+
+    test_setup();
+    free_timer = qd_timer(0, test_free_internal_cb, 0);
+    sys_mutex_lock(event.m);
+    qd_timestamp_t start = qd_timer_now();
+    qd_timer_schedule(free_timer, 100);
+    sys_cond_wait(event.c, event.m);   // wait for cb to finish
+    qd_timestamp_t stop = qd_timer_now();
+    if ((stop - start) < 100) {
+        fprintf(stderr, "%s failed: timer expired too soon\n", name);
+        result = 1;
+    }
+    sys_mutex_unlock(event.m);
+    if (free_timer != 0) {
+        fprintf(stderr, "%s failed: timer free failed\n", name);
+        result = 1;
+    }
+
+    test_cleanup();
+    fprintf(stderr, "Test free_internal: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test freeing timer before it can run
+//
+
+static void test_prefree_cb(void *context)
+{
+    abort();  // should never run
+}
+
+static int test_prefree(const char *name)
+{
+    int result = 0;
+
+    test_setup();
+    qd_timer_t *t = qd_timer(0, test_prefree_cb, 0);
+    qd_timestamp_t start = qd_timer_now();
+    qd_timer_schedule(t, 1000 * 60);   // looong time
+    qd_timer_free(t);
+    qd_timestamp_t stop = qd_timer_now();
+    if ((stop - start) > 1000 * 60) {
+        fprintf(stderr, "%s failed: free blocked\n", name);
+        result = 1;
+    }
+
+    test_cleanup();
+    fprintf(stderr, "Test prefree: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test canceling timer before it can run
+//
+
+static void test_early_cancel_cb(void *context)
+{
+    abort();  // should never run
+}
+
+static int test_early_cancel(const char *name)
+{
+    int result = 0;
+
+    test_setup();
+    qd_timer_t *t = qd_timer(0, test_early_cancel_cb, 0);
+    qd_timestamp_t start = qd_timer_now();
+    qd_timer_schedule(t, 1000 * 60);   // looong time
+    qd_timer_cancel(t);
+    qd_timestamp_t stop = qd_timer_now();
+    if ((stop - start) > 1000 * 60) {
+        fprintf(stderr, "%s failed: free blocked\n", name);
+        result = 1;
+    }
+    qd_timer_free(t);
+
+    test_cleanup();
+    fprintf(stderr, "Test early cancel: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test cancel then re-arm timer
+//
+
+static void test_rerun_cb(void *context)
+{
+    int *iptr = (int *)context;
+    if (*iptr != 2) {
+        abort();  // should never run
+    }
+    (*iptr) = 3;
+    sys_mutex_lock(event.m);
+    sys_cond_signal(event.c);
+    sys_mutex_unlock(event.m);
+}
+
+static int test_rerun(const char *name)
+{
+    int result = 0;
+    int i = 1;
+
+    test_setup();
+    qd_timer_t *t = qd_timer(0, test_rerun_cb, &i);
+    qd_timestamp_t start = qd_timer_now();
+    qd_timer_schedule(t, 1000 * 60);   // looong time
+    qd_timer_cancel(t);
+    qd_timestamp_t stop = qd_timer_now();
+    if ((stop - start) > 1000 * 60) {
+        fprintf(stderr, "%s failed: free blocked\n", name);
+        result = 1;
+    }
+
+    sys_mutex_lock(event.m);
+
+    i = 2;
+    start = qd_timer_now();
+    qd_timer_schedule(t, 100);
+    sys_cond_wait(event.c, event.m);   // wait for cb to finish
+    stop = qd_timer_now();
+    if ((stop - start) < 100) {
+        fprintf(stderr, "%s failed: expected timer ran too soon\n", name);
+        result = 1;
+    }
+    if (i != 3) {
+        fprintf(stderr, "%s failed: expected callback to finish\n", name);
+        result = 1;
+    }
+    sys_mutex_unlock(event.m);
+    qd_timer_free(t);
+
+    test_cleanup();
+    fprintf(stderr, "Test rerun: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test that canceling a running timer will block until callback completes
+//
+
+static void long_running_cb(void *context)
+{
+    struct timeval period = {.tv_sec = 0,
+                             .tv_usec = 2000 * 1000}; // 2 sec
+
+    // wake caller
+    sys_mutex_lock(event.m);
+    sys_cond_signal(event.c);
+    sys_mutex_unlock(event.m);
+
+    // sleep for 2 second, cancel should block for this
+    select(0, 0, 0, 0, &period);
+    sys_atomic_inc((sys_atomic_t *)context);
+}
+
+static int test_sync_cancel(const char *name)
+{
+    int result = 0;
+    sys_atomic_t flag;
+    sys_atomic_init(&flag, 1);
+
+    test_setup();
+    qd_timer_t *t = qd_timer(0, long_running_cb, (void *)&flag);
+
+    sys_mutex_lock(event.m);
+    qd_timer_schedule(t, 10);
+    sys_cond_wait(event.c, event.m);   // wait for cb to start
+    qd_timer_cancel(t);   // expected to block until cb finishes
+    if (sys_atomic_get(&flag) != 2) {
+        fprintf(stderr, "%s failed: callback still running\n", name);
+        result = 1;
+    }
+    sys_mutex_unlock(event.m);
+    qd_timer_free(t);
+
+    test_cleanup();
+    fprintf(stderr, "Test sync cancel: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+//
+// Test that freeing a running timer will block until callback completes
+//
+
+static int test_sync_free(const char *name)
+{
+    int result = 0;
+    sys_atomic_t flag;
+    sys_atomic_init(&flag, 1);
+
+    test_setup();
+    qd_timer_t *t = qd_timer(0, long_running_cb, (void *)&flag);
+
+    sys_mutex_lock(event.m);
+    qd_timer_schedule(t, 10);
+    sys_cond_wait(event.c, event.m);   // wait for cb to start
+    qd_timer_free(t);   // expected to block until cb finishes
+    if (sys_atomic_get(&flag) != 2) {
+        fprintf(stderr, "%s failed: callback still running\n", name);
+        result = 1;
+    }
+    sys_mutex_unlock(event.m);
+
+    test_cleanup();
+    fprintf(stderr, "Test sync free: %s\n", result ? "FAILED" : "ok");
+    return result;
+}
+
+
+int main(int argc, char *argv[])
+{
+    int result = 0;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <config-file>\n", argv[0]);
+        exit(1);
+    }
+
+    // Call qd_dispatch() first initialize allocator used by other tests.
+    qd_dispatch_t *qd = qd_dispatch(0, false);
+
+    qd_dispatch_validate_config(argv[1]);
+    if (qd_error_code()) {
+        printf("Config failed: %s\n", qd_error_message());
+        return 1;
+    }
+
+    qd_dispatch_load_config(qd, argv[1]);
+    if (qd_error_code()) {
+        printf("Config failed: %s\n", qd_error_message());
+        return 1;
+    }
+
+    ticker_lock = sys_mutex();
+    
+    sys_thread_t *ticker = sys_thread(ticker_thread, 0);
+
+    result = test_simple(argv[0]);
+    result += test_reschedule_internal(argv[0]);
+    result += test_free_internal(argv[0]);
+    result += test_prefree(argv[0]);
+    result += test_early_cancel(argv[0]);
+    result += test_rerun(argv[0]);
+    result += test_sync_cancel(argv[0]);
+    result += test_sync_free(argv[0]);
+
+    sys_mutex_lock(ticker_lock);
+    done = true;
+    sys_mutex_unlock(ticker_lock);
+
+    sys_thread_join(ticker);
+    sys_thread_free(ticker);
+
+    qd_dispatch_free(qd);       // dispatch_free last.
+
+    return result;
+}

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -14,7 +14,8 @@ race:qd_entity_refresh_allocator
 
 mutex:qd_router_timer_handler
 race:qdr_process_tick_CT
-deadlock:qd_timer
+deadlock:qd_timer_schedule
+deadlock:qd_timer_visit
 
 race:qdr_connection_process
 

--- a/tools/scraper/parser.py
+++ b/tools/scraper/parser.py
@@ -762,7 +762,7 @@ class ParsedLogLine(object):
                 self.highlighted("more", res.transfer_more, common.color_of("more")),
                 self.highlighted("resume", res.transfer_resume, common.color_of("aborted")),
                 self.highlighted("aborted", res.transfer_aborted, common.color_of("aborted")),
-                showdat, spl[-SEQUENCE_TRANSFER_SIZE:],
+                showdat, common.html_escape(spl[-SEQUENCE_TRANSFER_SIZE:]),
                 res.transfer_size)
             res.sdorg_str = "%s %s (%s) %s (%s%s%s%s)\\n%s" % (
                 res.name, res.channel_handle, res.delivery_id, res.transfer_size,


### PR DESCRIPTION
There is no on_modified event in proton python MessagingHandler.
Proton conflates Delivery.MODIFIED and Delivery.RELEASED state handling
and delivers both states in the on_released handler.
    
This patch makes the dispatch handler model precisely reflect the
proton handler model.
