### PR TITLE
DISPATCH-1595: Remove all python test on_modified event handlers

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -1107,15 +1107,10 @@ class AsyncTestSender(MessagingHandler):
         event.delivery.settle()
 
     def on_released(self, event):
-        # for some reason Proton 'helpfully' calls on_released even though the
-        # delivery state is actually MODIFIED
         if event.delivery.remote_state == Delivery.MODIFIED:
-            return self.on_modified(event)
-        self.released += 1
-        event.delivery.settle()
-
-    def on_modified(self, event):
-        self.modified += 1
+            self.modified += 1
+        else:
+            self.released += 1
         event.delivery.settle()
 
     def on_rejected(self, event):

--- a/tests/system_tests_link_routes.py
+++ b/tests/system_tests_link_routes.py
@@ -2543,10 +2543,6 @@ class DispositionSniffer(MessagingHandler):
         self.delivery = event.delivery
         self.close()
 
-    def on_modified(self, event):
-        self.delivery = event.delivery
-        self.close()
-
     def on_rejected(self, event):
         self.delivery = event.delivery
         self.close()

--- a/tests/system_tests_multicast.py
+++ b/tests/system_tests_multicast.py
@@ -600,18 +600,14 @@ class MulticastBase(MessagingHandler):
         self.n_outcomes[Delivery.ACCEPTED] = 1 + self.n_outcomes.get(Delivery.ACCEPTED, 0)
 
     def on_released(self, event):
-        # for some reason Proton 'helpfully' calls on_released even though the
-        # delivery state is actually MODIFIED
         if event.delivery.remote_state == Delivery.MODIFIED:
-            return self.on_modified(event)
-        self.n_released += 1
-        name = event.link.name
-        self.n_outcomes[Delivery.RELEASED] = 1 + self.n_outcomes.get(Delivery.RELEASED, 0)
-
-    def on_modified(self, event):
-        self.n_modified += 1
-        name = event.link.name
-        self.n_outcomes[Delivery.MODIFIED] = 1 + self.n_outcomes.get(Delivery.MODIFIED, 0)
+            self.n_modified += 1
+            name = event.link.name
+            self.n_outcomes[Delivery.MODIFIED] = 1 + self.n_outcomes.get(Delivery.MODIFIED, 0)
+        else:
+            self.n_released += 1
+            name = event.link.name
+            self.n_outcomes[Delivery.RELEASED] = 1 + self.n_outcomes.get(Delivery.RELEASED, 0)
 
     def on_rejected(self, event):
         self.n_rejected += 1
@@ -806,11 +802,6 @@ class MulticastUnsettled3Ack(MulticastBase):
 
     def on_released(self, event):
         super(MulticastUnsettled3Ack, self).on_released(event)
-        event.delivery.settle()
-        self.check_if_done()
-
-    def on_modified(self, event):
-        super(MulticastUnsettled3Ack, self).on_modified(event)
         event.delivery.settle()
         self.check_if_done()
 


### PR DESCRIPTION
There is no on_modified event in proton python MessagingHandler.
Proton conflates Delivery.MODIFIED and Delivery.RELEASED state handling
and delivers both states in the on_released handler.

This patch makes the dispatch handler model precisely reflect the
proton handler model.