### PR TITLE
DISPATCH-2056: Do not reference qdr connection after it is closed

### DIFF
--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -489,14 +489,15 @@ static void handle_disconnected(qdr_tcp_connection_t* conn)
                conn->conn_id, conn->outgoing_id);
         qdr_link_detach(conn->outgoing, QD_LOST, 0);
     }
-    if (conn->qdr_conn) {
-        qdr_connection_closed(conn->qdr_conn);
-        qdr_connection_set_context(conn->qdr_conn, 0);
-    }
     if (conn->initial_delivery) {
         qdr_delivery_remote_state_updated(tcp_adaptor->core, conn->initial_delivery, PN_RELEASED, true, 0, false);
         qdr_delivery_decref(tcp_adaptor->core, conn->initial_delivery, "tcp-adaptor.handle_disconnected - initial_delivery");
         conn->initial_delivery = 0;
+    }
+    if (conn->qdr_conn) {
+        qdr_connection_set_context(conn->qdr_conn, 0);
+        qdr_connection_closed(conn->qdr_conn);
+        conn->qdr_conn = 0;
     }
 
     //need to free on core thread to avoid deleting while in use by management agent


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/DISPATCH-2056 for consequences of referring to the connection after scheduling connection close.