### PR TITLE
NO-JIRA Reenable GHA Docs job after Ubuntu PPA update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,7 +239,6 @@ jobs:
   docs:
     name: 'Docs (${{ matrix.os }})'
     runs-on: ${{ matrix.os }}
-    if: ${{ false }}  # disabled until Proton 0.34.0 Ubuntu package is published
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
@@ -266,10 +265,6 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt install -y libqpid-proton-proactor1-dev python3-qpid-proton libpython3-dev libwebsockets-dev libnghttp2-dev
-
-      - name: "Workaround for: make[3]: *** No rule to make target '/usr/lib/x86_64-linux-gnu/libqpid-proton-core.so', needed by 'src/libqpid-dispatch.so'.  Stop."
-        if: ${{ runner.os == 'Linux' }}
-        run: sudo ln -s /usr/lib/x86_64-linux-gnu/libqpid-proton-core.so.10 /usr/lib/x86_64-linux-gnu/libqpid-proton-core.so
 
       - name: Install Linux docs dependencies
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PROTON-2341 appears to be resolved.