### PR TITLE
DISPATCH-2121 Fix Proton link order for use with static libs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,8 +129,8 @@ set(qpid_dispatch_INCLUDES
   )
 
 set(qpid_dispatch_LIBRARIES
-  ${Proton_Core_LIBRARIES}
   ${Proton_Proactor_LIBRARIES}
+  ${Proton_Core_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}
   ${rt_lib}
   ${CMAKE_DL_LIBS}


### PR DESCRIPTION
This is something that can be workarounded, but for the future,
it would be nice to have the order correct in Dispatch.