### PR TITLE
DISPATCH-2120 Create GitHub Actions jobs used for gating incoming pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -244,6 +244,202 @@ jobs:
           path: |
             **/core
 
+  compile_and_test:
+    name: "Compile and Test (${{matrix.container}}, ${{matrix.runtimeCheck}}, shard ${{matrix.shard}} of ${{matrix.shards}})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        container: ['library/fedora:34']
+        buildType: [RelWithDebInfo]
+        runtimeCheck: [asan, tsan]
+        shard: [ 1, 2 ]
+        shards: [ 2 ]
+        include:
+          - os: ubuntu-20.04
+            container: 'library/centos:7'
+            runtimeCheck: OFF
+            shard: 1
+            shards: 2
+          - os: ubuntu-20.04
+            container: 'library/centos:7'
+            runtimeCheck: OFF
+            shard: 2
+            shards: 2
+
+    container:
+      image: '${{ matrix.container }}'
+      volumes:
+        - ${{github.workspace}}:${{github.workspace}}
+
+    env:
+      BuildType: ${{matrix.buildType}}
+      ProtonBuildDir: ${{github.workspace}}/qpid-proton/build
+      DispatchBuildDir: ${{github.workspace}}/qpid-dispatch/build
+      InstallPrefix: ${{github.workspace}}/install
+      # TODO(DISPATCH-2078) re-enable system_tests_authz_service_plugin when the GHA failure is understood and fixed
+      DispatchCTestExtraArgs: "-E 'system_tests_authz_service_plugin|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc'"
+
+      # TODO(DISPATCH-2144) use -DPython_EXECUTABLE=/usr/bin/python3-debug when issue is fixed,
+      #  as that allows for -DSANITIZE_3RD_PARTY=ON on Fedora
+      # TODO(https://github.com/google/sanitizers/issues/1385) some targeted asan suppressions don't work on Fedora
+      ProtonCMakeExtraArgs: >
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DBUILD_BINDINGS=python
+        -DPython_EXECUTABLE=/usr/bin/python3
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_TESTING=OFF
+        -DENABLE_FUZZ_TESTING=OFF
+        -DRUNTIME_CHECK=${{matrix.runtimeCheck}}
+      DispatchCMakeExtraArgs: >
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DPython_EXECUTABLE=/usr/bin/python3
+        -DQD_ENABLE_ASSERTIONS=ON
+        -DCONSOLE_INSTALL=OFF
+        -DRUNTIME_CHECK=${{matrix.runtimeCheck}}
+
+      CCACHE_BASEDIR: ${{github.workspace}}
+      CCACHE_DIR: ${{github.workspace}}/.ccache
+      CCACHE_COMPRESS: 'true'
+      CCACHE_MAXSIZE: '400MB'
+
+    steps:
+
+      - name: Show environment (Linux)
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: env -0 | sort -z | tr '\0' '\n'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'apache/qpid-proton'
+          ref: 'main'
+          path: 'qpid-proton'
+
+      - uses: actions/checkout@v2
+        with:
+          path: 'qpid-dispatch'
+
+      - name: Install EPEL (on CentOS 7)
+        if: ${{ matrix.container == 'library/centos:7' }}
+        run: |
+          yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+      - name: Install Linux build dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          yum install -y gcc gcc-c++ cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain swig python3-devel make libwebsockets-devel ccache libasan libubsan libtsan
+
+      - name: Install Python build dependencies
+        run: python3 -m pip install setuptools wheel tox
+
+      # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - uses: actions/cache@v2.1.5
+        env:
+          cache-name: cache-ccache
+        with:
+          path: .ccache
+          key: ${{ matrix.container }}-${{ matrix.runtimeCheck }}-${{ env.cache-name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.container }}-${{ matrix.runtimeCheck }}-${{ env.cache-name }}
+
+      - name: Create Build and Install directories
+        run: mkdir -p "${ProtonBuildDir}" "${DispatchBuildDir}" "{InstallPrefix}"
+
+      - name: Zero ccache stats
+        run: ccache -z
+
+      - name: qpid-proton cmake configure
+        working-directory: ${{env.ProtonBuildDir}}
+        run: >
+          cmake "${{github.workspace}}/qpid-proton" \
+            "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" \
+            "-DCMAKE_BUILD_TYPE=${BuildType}" \
+            ${ProtonCMakeExtraArgs}
+
+      - name: qpid-proton cmake build/install
+        run: cmake --build "${ProtonBuildDir}" --config ${BuildType} --target install
+
+      - name: Display ccache stats
+        run: ccache -s
+
+      - name: qpid-dispatch cmake configure
+        working-directory: ${{env.DispatchBuildDir}}
+        run: >
+          cmake "${{github.workspace}}/qpid-dispatch" \
+            "-DCMAKE_INSTALL_PREFIX=${InstallPrefix}" \
+            "-DCMAKE_BUILD_TYPE=${BuildType}" \
+            "-DPYTHON_TEST_COMMAND='-m;pytest;-vs;--junit-prefix=pytest.\${py_test_module};--junit-xml=junitxmls/\${py_test_module}.xml;--pyargs;\${py_test_module}'" \
+            ${DispatchCMakeExtraArgs}
+
+      - name: qpid-dispatch cmake build/install
+        run: cmake --build "${DispatchBuildDir}" --config ${BuildType} --target install
+
+      - name: Display ccache stats
+        run: ccache -s
+
+      - name: Show environment (Linux)
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: env -0 | sort -z | tr '\0' '\n'
+
+      - name: Install Python runtime/test dependencies
+        run: python3 -m pip install tox quart selectors protobuf pytest
+
+      - name: Install Python runtime/test dependencies (Fedora)
+        if: ${{ matrix.container == 'library/fedora:34' }}
+        run: python3 -m pip install grpcio
+
+      - name: Install Linux runtime/test dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          yum install -y curl
+
+      - name: Install Linux runtime/test dependencies (for sanitizers)
+        if: ${{ matrix.runtimeCheck != 'OFF' }}
+        run: |
+          dnf install -y binutils
+
+      - name: install qpid-proton python wheel
+        run: python3 -m pip install ${ProtonBuildDir}/python/pkgs/python_qpid_proton*.whl
+
+      - name: CTest
+        working-directory: ${{env.DispatchBuildDir}}
+        run: |
+          ulimit -c unlimited
+          ctest -C ${BuildType} -V -T Test --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.DispatchCTestExtraArgs}}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: ${{ ! cancelled() }}
+        with:
+          name: Test_Results_${{matrix.container}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.shard}}
+          path: ${{env.DispatchBuildDir}}/Testing/**/*.xml
+
+      - name: Upload log files (if any tests failed)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: testLogs_${{matrix.container}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.shard}}
+          path: |
+            qpid-dispatch/build/tests
+
+      - name: Upload core files (if any)
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cores_${{matrix.container}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.shard}}
+          path: |
+            **/core
+
   docs:
     name: 'Docs (${{ matrix.os }})'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -251,7 +251,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        container: ['library/fedora']
+        container: ['fedora']
         containerTag: ['34']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
@@ -259,20 +259,20 @@ jobs:
         shards: [ 2 ]
         include:
           - os: ubuntu-20.04
-            container: 'library/centos'
+            container: 'centos'
             containerTag: 7
             runtimeCheck: OFF
             shard: 1
             shards: 2
           - os: ubuntu-20.04
-            container: 'library/centos'
+            container: 'centos'
             containerTag: 7
             runtimeCheck: OFF
             shard: 2
             shards: 2
 
     container:
-      image: '${{ matrix.container }}:${{ matrix.containerTag }}'
+      image: 'library/${{ matrix.container }}:${{ matrix.containerTag }}'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -326,7 +326,7 @@ jobs:
           path: 'qpid-dispatch'
 
       - name: Install EPEL (on CentOS 7)
-        if: ${{ matrix.container == 'library/centos' }}
+        if: ${{ matrix.container == 'centos' }}
         run: |
           yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
@@ -398,7 +398,7 @@ jobs:
         run: python3 -m pip install tox quart selectors protobuf pytest
 
       - name: Install Python runtime/test dependencies (Fedora)
-        if: ${{ matrix.container == 'library/fedora' }}
+        if: ${{ matrix.container == 'fedora' }}
         run: python3 -m pip install grpcio
 
       - name: Install Linux runtime/test dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -251,25 +251,28 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        container: ['library/fedora:34']
+        container: ['library/fedora']
+        containerTag: ['34']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         shard: [ 1, 2 ]
         shards: [ 2 ]
         include:
           - os: ubuntu-20.04
-            container: 'library/centos:7'
+            container: 'library/centos'
+            containerTag: 7
             runtimeCheck: OFF
             shard: 1
             shards: 2
           - os: ubuntu-20.04
-            container: 'library/centos:7'
+            container: 'library/centos'
+            containerTag: 7
             runtimeCheck: OFF
             shard: 2
             shards: 2
 
     container:
-      image: '${{ matrix.container }}'
+      image: '${{ matrix.container }}:${{ matrix.containerTag }}'
       volumes:
         - ${{github.workspace}}:${{github.workspace}}
 
@@ -323,7 +326,7 @@ jobs:
           path: 'qpid-dispatch'
 
       - name: Install EPEL (on CentOS 7)
-        if: ${{ matrix.container == 'library/centos:7' }}
+        if: ${{ matrix.container == 'library/centos' }}
         run: |
           yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
@@ -395,7 +398,7 @@ jobs:
         run: python3 -m pip install tox quart selectors protobuf pytest
 
       - name: Install Python runtime/test dependencies (Fedora)
-        if: ${{ matrix.container == 'library/fedora:34' }}
+        if: ${{ matrix.container == 'library/fedora' }}
         run: python3 -m pip install grpcio
 
       - name: Install Linux runtime/test dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,12 @@ if(QD_ENABLE_ASSERTIONS)
     if(NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
         # NOTE: use `add_compile_options` rather than `add_definitions` since
         # `add_definitions` does not support generator expressions.
-        add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+        if(${CMAKE_VERSION} VERSION_LESS "3.11.4")
+            add_compile_options(-UNDEBUG)
+        else()
+            add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+        endif()
+
 
         # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
         foreach (flags_var_to_scrub

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -137,7 +137,8 @@ elseif(RUNTIME_CHECK STREQUAL "asan" OR RUNTIME_CHECK STREQUAL "hwasan")
   set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -fsanitize=${ASAN_VARIANTS} -DQD_MEMORY_DEBUG=1")
   # `detect_leaks=1` is set by default where it is available; better not to set it conditionally ourselves
   # https://github.com/openSUSE/systemd/blob/1270e56526cd5a3f485ae2aba975345c38860d37/docs/TESTING_WITH_SANITIZERS.md
-  set(RUNTIME_ASAN_ENV_OPTIONS "strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_invalid_pointer_pairs=2 suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
+  # TODO(DISPATCH-2148) re-enable odr violation detection when Proton linking issue in test-sender is fixed
+  set(RUNTIME_ASAN_ENV_OPTIONS "detect_odr_violation=0 strict_string_checks=1 detect_stack_use_after_return=1 check_initialization_order=1 strict_init_order=1 detect_invalid_pointer_pairs=2 suppressions=${CMAKE_SOURCE_DIR}/tests/asan.supp")
   set(RUNTIME_LSAN_ENV_OPTIONS "suppressions=${CMAKE_BINARY_DIR}/tests/lsan.supp")
   set(RUNTIME_UBSAN_ENV_OPTIONS "print_stacktrace=1 print_summary=1")
 

--- a/cmake/RuntimeChecks.cmake
+++ b/cmake/RuntimeChecks.cmake
@@ -150,7 +150,7 @@ elseif(RUNTIME_CHECK STREQUAL "tsan")
   endif(TSAN_LIBRARY-NOTFOUND)
   message(STATUS "Runtime race checker: gcc/clang thread sanitizer")
   set(SANITIZE_FLAGS "-g -fno-omit-frame-pointer -fsanitize=thread")
-  set(RUNTIME_TSAN_ENV_OPTIONS "second_deadlock_stack=1 suppressions=${CMAKE_SOURCE_DIR}/tests/tsan.supp")
+  set(RUNTIME_TSAN_ENV_OPTIONS "history_size=4 second_deadlock_stack=1 suppressions=${CMAKE_SOURCE_DIR}/tests/tsan.supp")
 
 elseif(RUNTIME_CHECK)
   message(FATAL_ERROR "'RUNTIME_CHECK=${RUNTIME_CHECK}' is invalid, valid values: ${runtime_checks}")

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -79,7 +79,7 @@ race:qdr_delivery_move_delivery_state_CT
 race:qdr_delivery_mcast_outbound_disposition_CT
 
 # DISPATCH-2152
-race:^new_qdr_connection_info_t$
+race:^qd_alloc$
 
 #
 # External libraries

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -99,3 +99,8 @@ race:^pni_logger_log$
 # DISPATCH-2151
 race:^_lws_logv.part.0$
 
+# DISPATCH-2155
+race:^qd_connection_manager_delete_listener$
+
+# DISPATCH-2156
+race:^pconnection_final_free$

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -78,6 +78,9 @@ race:qdr_delivery_move_delivery_state_CT
 # DISPATCH-2143
 race:qdr_delivery_mcast_outbound_disposition_CT
 
+# DISPATCH-2152
+race:^new_qdr_connection_info_t$
+
 #
 # External libraries
 #
@@ -86,4 +89,13 @@ race:qdr_delivery_mcast_outbound_disposition_CT
 # TBD: discuss with proton devs, JIRA if necessary
 deadlock:pni_timer_set
 
+# DISPATCH-2150, PROTON-2133
+race:^check_earmark_override$
+
+# DISPATCH-2153
+race:^pn_logger_reset_mask$
+race:^pni_logger_log$
+
+# DISPATCH-2151
+race:^_lws_logv.part.0$
 

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -79,6 +79,8 @@ race:qdr_delivery_move_delivery_state_CT
 # DISPATCH-2143
 race:qdr_delivery_mcast_outbound_disposition_CT
 
+# DISPATCH-2157
+race:^qd_message_send$
 
 #
 # External libraries

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -15,6 +15,7 @@ deadlock:push_event
 race:qd_vlog_impl
 
 # DISPATCH-2122
+race:^qd_alloc$
 race:qd_alloc_init
 
 # DISPATCH-2123
@@ -78,8 +79,6 @@ race:qdr_delivery_move_delivery_state_CT
 # DISPATCH-2143
 race:qdr_delivery_mcast_outbound_disposition_CT
 
-# DISPATCH-2152
-race:^qd_alloc$
 
 #
 # External libraries


### PR DESCRIPTION
I decided to use Fedora in Docker instead of Ubuntu, to make the steps more similar to the CentOS; also, not splitting the builds into compile job and test job simplifies things, at the cost of having to compile everything twice (for every one of the two shards).