### PR TITLE
DISPATCH-2154: Disallow setting message abort flag to False

### DIFF
--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -594,9 +594,8 @@ bool qd_message_aborted(const qd_message_t *msg);
 /**
  * Set the aborted flag on the message.
  * @param msg A pointer to the message
- * @param aborted
  */
-void qd_message_set_aborted(const qd_message_t *msg, bool aborted);
+void qd_message_set_aborted(const qd_message_t *msg);
 
 /**
  * Return message priority

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -714,7 +714,7 @@ static bool _process_request(_server_request_t *hreq)
         while (rmsg) {
             if (rmsg->dlv) {
                 qd_message_set_receive_complete(qdr_delivery_message(rmsg->dlv));
-                qdr_delivery_set_aborted(rmsg->dlv, true);
+                qdr_delivery_set_aborted(rmsg->dlv);
             }
             _server_response_msg_free(hreq, rmsg);
             rmsg = DEQ_HEAD(hreq->responses);

--- a/src/message.c
+++ b/src/message.c
@@ -2892,12 +2892,12 @@ bool qd_message_aborted(const qd_message_t *msg)
     return ((qd_message_pvt_t *)msg)->content->aborted;
 }
 
-void qd_message_set_aborted(const qd_message_t *msg, bool aborted)
+void qd_message_set_aborted(const qd_message_t *msg)
 {
     if (!msg)
         return;
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
-    msg_pvt->content->aborted = aborted;
+    msg_pvt->content->aborted = true;
 }
 
 

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -893,7 +893,7 @@ void qdr_link_cleanup_deliveries_CT(qdr_core_t *core, qdr_connection_t *conn, qd
         }
 
         if (!qdr_delivery_receive_complete(dlv)) {
-            qdr_delivery_set_aborted(dlv, true);
+            qdr_delivery_set_aborted(dlv);
             qdr_delivery_continue_peers_CT(core, dlv, false);
         }
 
@@ -942,7 +942,7 @@ void qdr_link_cleanup_deliveries_CT(qdr_core_t *core, qdr_connection_t *conn, qd
         DEQ_REMOVE_HEAD(settled);
 
         if (!qdr_delivery_receive_complete(dlv)) {
-            qdr_delivery_set_aborted(dlv, true);
+            qdr_delivery_set_aborted(dlv);
             qdr_delivery_continue_peers_CT(core, dlv, false);
         }
 
@@ -977,7 +977,7 @@ static void qdr_link_abort_undelivered_CT(qdr_core_t *core, qdr_link_t *link)
     qdr_delivery_t *dlv = DEQ_HEAD(link->undelivered);
     while (dlv) {
         if (!qdr_delivery_receive_complete(dlv))
-            qdr_delivery_set_aborted(dlv, true);
+            qdr_delivery_set_aborted(dlv);
         dlv = DEQ_NEXT(dlv);
     }
     sys_mutex_unlock(conn->work_lock);

--- a/src/router_core/delivery.c
+++ b/src/router_core/delivery.c
@@ -117,10 +117,10 @@ void qdr_delivery_incref(qdr_delivery_t *delivery, const char *label)
 }
 
 
-void qdr_delivery_set_aborted(const qdr_delivery_t *delivery, bool aborted)
+void qdr_delivery_set_aborted(const qdr_delivery_t *delivery)
 {
     assert(delivery);
-    qd_message_set_aborted(delivery->msg, aborted);
+    qd_message_set_aborted(delivery->msg);
 }
 
 bool qdr_delivery_is_aborted(const qdr_delivery_t *delivery)

--- a/src/router_core/delivery.h
+++ b/src/router_core/delivery.h
@@ -101,7 +101,7 @@ void qdr_delivery_set_tag_sent(const qdr_delivery_t *delivery, bool tag_sent);
 uint64_t qdr_delivery_disposition(const qdr_delivery_t *delivery);
 void qdr_delivery_set_disposition(qdr_delivery_t *delivery, uint64_t disposition);
 
-void qdr_delivery_set_aborted(const qdr_delivery_t *delivery, bool aborted);
+void qdr_delivery_set_aborted(const qdr_delivery_t *delivery);
 bool qdr_delivery_is_aborted(const qdr_delivery_t *delivery);
 
 qd_message_t *qdr_delivery_message(const qdr_delivery_t *delivery);


### PR DESCRIPTION
Messages are created in the non-aborted state.

The control interface is modified to allow only setting the aborted
state to True.