### PR TITLE
DISPATCH-2136: Fix tsan race: convert message aborted flag to atomic

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -45,6 +45,10 @@
 #define LOCK   sys_mutex_lock
 #define UNLOCK sys_mutex_unlock
 
+// Implement bool flags with atomic variables
+#define SET_FLAG(flag)  sys_atomic_set(flag, 1)
+#define  IS_FLAG(flag) (sys_atomic_get(flag) == 1)
+
 const char *STR_AMQP_NULL = "null";
 const char *STR_AMQP_TRUE = "T";
 const char *STR_AMQP_FALSE = "F";
@@ -1393,13 +1397,15 @@ qd_message_t *discard_receive(pn_delivery_t *delivery,
             break;
         } else if (rc == PN_EOS || rc < 0) {
             // End of message or error: finalize message_receive handling
-            msg->content->aborted = pn_delivery_aborted(delivery);
+            if (pn_delivery_aborted(delivery)) {
+                SET_FLAG(&msg->content->aborted);
+            }
             pn_record_t *record = pn_delivery_attachments(delivery);
             pn_record_set(record, PN_DELIVERY_CTX, 0);
             if (msg->content->oversize) {
                 // Aborting the content disposes of downstream copies.
                 // This has no effect on the received message.
-                msg->content->aborted = true;
+                SET_FLAG(&msg->content->aborted);
             }
             qd_message_set_receive_complete((qd_message_t*) msg);
             break;
@@ -1521,8 +1527,9 @@ qd_message_t *qd_message_receive(pn_delivery_t *delivery)
                 content->receive_complete = true;
                 content->q2_unblocker.handler = 0;
                 qd_nullify_safe_ptr(&content->q2_unblocker.context);
-                content->aborted = pn_delivery_aborted(delivery);
-
+                if (pn_delivery_aborted(delivery)) {
+                    SET_FLAG(&msg->content->aborted);
+                }
                 // unlink message and delivery
                 pn_record_set(record, PN_DELIVERY_CTX, 0);
             }
@@ -1766,11 +1773,11 @@ void qd_message_send(qd_message_t *in_msg,
 
     if (msg->sent_depth < QD_DEPTH_MESSAGE_ANNOTATIONS) {
 
-        if (content->aborted) {
+        if (IS_FLAG(&content->aborted)) {
             // Message is aborted before any part of it has been sent.
             // Declare the message to be sent,
             msg->send_complete = true;
-            // the link has an outgoing deliver. abort it.
+            // If the outgoing delivery is not already aborted then abort it.
             if (!pn_delivery_aborted(pn_link_current(pnl))) {
                 pn_delivery_abort(pn_link_current(pnl));
             }
@@ -1873,7 +1880,7 @@ void qd_message_send(qd_message_t *in_msg,
     pn_session_t              *pns        = pn_link_session(pnl);
     const size_t               q3_upper   = BUFFER_SIZE * QD_QLIMIT_Q3_UPPER;
 
-    while (!content->aborted
+    while (!IS_FLAG(&content->aborted)
            && buf
            && pn_session_outgoing_bytes(pns) < q3_upper) {
 
@@ -1895,7 +1902,7 @@ void qd_message_send(qd_message_t *in_msg,
             // send error - likely the link has failed and we will eventually
             // get a link detach event for this link
             //
-            content->aborted = true;
+            SET_FLAG(&content->aborted);
             msg->send_complete = true;
             if (!pn_delivery_aborted(pn_link_current(pnl))) {
                 pn_delivery_abort(pn_link_current(pnl));
@@ -1972,7 +1979,7 @@ void qd_message_send(qd_message_t *in_msg,
     if (q2_unblock.handler)
         q2_unblock.handler(q2_unblock.context);
 
-    if (content->aborted) {
+    if (IS_FLAG(&content->aborted)) {
         if (pn_link_current(pnl)) {
             msg->send_complete = true;
             if (!pn_delivery_aborted(pn_link_current(pnl))) {
@@ -2893,7 +2900,7 @@ bool qd_message_aborted(const qd_message_t *msg)
 {
     assert(msg);
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
-    return sys_atomic_get(&msg_pvt->content->aborted) > 0;
+    return IS_FLAG(&msg_pvt->content->aborted);
 }
 
 void qd_message_set_aborted(const qd_message_t *msg)
@@ -2901,7 +2908,7 @@ void qd_message_set_aborted(const qd_message_t *msg)
     if (!msg)
         return;
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
-    sys_atomic_set(&msg_pvt->content->aborted, 1);
+    SET_FLAG(&msg_pvt->content->aborted);
 }
 
 

--- a/src/message.c
+++ b/src/message.c
@@ -46,8 +46,8 @@
 #define UNLOCK sys_mutex_unlock
 
 // Implement bool flags with atomic variables
-#define SET_FLAG(flag)  sys_atomic_set(flag, 1)
-#define  IS_FLAG(flag) (sys_atomic_get(flag) == 1)
+#define    SET_FLAG(flag)  sys_atomic_set(flag, 1)
+#define IS_FLAG_SET(flag) (sys_atomic_get(flag) == 1)
 
 const char *STR_AMQP_NULL = "null";
 const char *STR_AMQP_TRUE = "T";
@@ -1773,7 +1773,7 @@ void qd_message_send(qd_message_t *in_msg,
 
     if (msg->sent_depth < QD_DEPTH_MESSAGE_ANNOTATIONS) {
 
-        if (IS_FLAG(&content->aborted)) {
+        if (IS_FLAG_SET(&content->aborted)) {
             // Message is aborted before any part of it has been sent.
             // Declare the message to be sent,
             msg->send_complete = true;
@@ -1880,7 +1880,7 @@ void qd_message_send(qd_message_t *in_msg,
     pn_session_t              *pns        = pn_link_session(pnl);
     const size_t               q3_upper   = BUFFER_SIZE * QD_QLIMIT_Q3_UPPER;
 
-    while (!IS_FLAG(&content->aborted)
+    while (!IS_FLAG_SET(&content->aborted)
            && buf
            && pn_session_outgoing_bytes(pns) < q3_upper) {
 
@@ -1979,7 +1979,7 @@ void qd_message_send(qd_message_t *in_msg,
     if (q2_unblock.handler)
         q2_unblock.handler(q2_unblock.context);
 
-    if (IS_FLAG(&content->aborted)) {
+    if (IS_FLAG_SET(&content->aborted)) {
         if (pn_link_current(pnl)) {
             msg->send_complete = true;
             if (!pn_delivery_aborted(pn_link_current(pnl))) {
@@ -2900,7 +2900,7 @@ bool qd_message_aborted(const qd_message_t *msg)
 {
     assert(msg);
     qd_message_pvt_t * msg_pvt = (qd_message_pvt_t *)msg;
-    return IS_FLAG(&msg_pvt->content->aborted);
+    return IS_FLAG_SET(&msg_pvt->content->aborted);
 }
 
 void qd_message_set_aborted(const qd_message_t *msg)

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -140,13 +140,13 @@ typedef struct {
     bool                 discard;                        // Should this message be discarded?
     bool                 receive_complete;               // true if the message has been completely received, false otherwise
     bool                 q2_input_holdoff;               // hold off calling pn_link_recv
-    bool                 aborted;                        // receive completed with abort flag set
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
     bool                 priority_parsed;
     bool                 priority_present;
     bool                 oversize;                       // policy oversize handling in effect
     bool                 no_body;                        // Used for http2 messages. If no_body is true, the HTTP request had no body
     uint8_t              priority;                       // The priority of this message
+    sys_atomic_t         aborted;
 } qd_message_content_t;
 
 struct qd_message_pvt_t {

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -58,9 +58,6 @@ race:tsan_reset_delivery_ids
 # DISPATCH-2135
 race:qd_message_Q2_holdoff_disable
 
-# DISPATCH-2136
-race:qd_message_set_aborted
-
 # DISPATCH-2137
 race:remote_sasl_process_init
 race:remote_sasl_prepare


### PR DESCRIPTION
The message aborted flag is read and written by I/O and core threads.
Conversion to a sys_atomic variable ensures consistent state.