### PR TITLE
DISPATCH-2108: Aggregate statistics for TCP listeners and connectors

### DIFF
--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -1279,6 +1279,26 @@
                     "required": false,
                     "description": "Used to identify where connection is handled.",
                     "create": true
+                },
+                "connectionsOpened": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of connections opened by this listener."
+                },
+                "connectionsClosed": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of connections closed by this listener."
+                },
+                "bytesIn": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of bytes sent from clients to servers on all connections to this listener."
+                },
+                "bytesOut": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of bytes sent from servers to clients on all connections to this listener."
                 }
             }
         },
@@ -1302,13 +1322,32 @@
                     "description": "Port number or symbolic service name.",
                     "type": "string",
                     "create": true
-
                 },
                 "siteId": {
                     "type": "string",
                     "required": false,
                     "description": "Used to identify origin of connections.",
                     "create": true
+                },
+                "connectionsOpened": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of connections opened by this connector."
+                },
+                "connectionsClosed": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of connections closed by this connector."
+                },
+                "bytesIn": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of bytes sent from servers to clients on all connections created by this connector."
+                },
+                "bytesOut": {
+                    "type": "integer",
+                    "graph": true,
+                    "description": "The number of bytes sent from clients to servers on all connections created by this connector."
                 }
             }
         },

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -255,6 +255,7 @@ static int handle_incoming_raw_read(qdr_tcp_connection_t *conn, qd_buffer_list_t
     conn->read_pending = false;
     if (result > 0) {
         // account for any incoming bytes just read
+
         conn->last_in_time = tcp_adaptor->core->uptime_ticks;
         conn->bytes_in      += result;
         LOCK(conn->bridge->stats_lock);
@@ -1091,6 +1092,7 @@ static void free_bridge_config(qd_tcp_bridge_t *config)
     free(config->site_id);
     free(config->host_port);
 
+    sys_atomic_destroy(&config->ref_count);
     sys_mutex_free(config->stats_lock);
     free_qd_tcp_bridge_t(config);
 }


### PR DESCRIPTION
This commit adds counters

  * bytesIn
  * bytesOut
  * connectionsOpened
  * connectionsClosed

to tcpListener and tcpConnector entities. Individual bytesIn and bytesOut
for tcpConnections are tracked in the connection entity. The new aggregated
statistics are running totals for all connections created through the
listener and connector entities.

Internally the tcp_bridge_config structure was renamed to tcp_bridge as
the struct is not just config any more. The qd_tcp_connection no longer
holds the actual structure in 'config'. Instead it holds a pointer to
the repurposed structure in 'bridge'.

qd_tcp_bridge_t is now a pooled object. Its lifetime is controlled by
a ref count. A bridge is created synchronously with a listener or a
connector and those entities hold the first reference. Tcp connections
hold a reference to the bridge and target that bridge for ongoing
statistics accumulation.

With the ref counting a connection may be created, say, through a listener.
Then before the connection is closed the listener may be deleted. The
ref count keeps the bridge object alive so that the connection statistics
are still aggregated. Only when the bridge object loses all of its
references is the bridge finally disposed. Bridge objects dump their final
statistics to the TCP_ADAPTOR log at INFO level.

This commit also creates LOCK and UNLOCK macros to aid developers trying
to read the code.

A self test is added to make sure the entity attributes are present and
hold reasonable values.