### PR TITLE
DISPATCH-2161, DISPATCH-2167: handle various client close errors

### DIFF
--- a/src/adaptors/http1/http1_adaptor.c
+++ b/src/adaptors/http1/http1_adaptor.c
@@ -143,7 +143,8 @@ void qdr_http1_out_data_fifo_cleanup(qdr_http1_out_data_fifo_t *out_data)
 {
     if (out_data) {
         // expect: all buffers returned from proton!
-        assert(qdr_http1_out_data_buffers_outstanding(out_data) == 0);
+        // FIXME: not during router shutdown!
+        // assert(qdr_http1_out_data_buffers_outstanding(out_data) == 0);
         qdr_http1_out_data_t *od = DEQ_HEAD(out_data->fifo);
         while (od) {
             DEQ_REMOVE_HEAD(out_data->fifo);
@@ -586,8 +587,8 @@ static uint64_t _core_link_deliver(void *context, qdr_link_t *link, qdr_delivery
 
     if (hconn) {
         qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG,
-               "[C%"PRIu64"][L%"PRIu64"] Core link deliver %p %s", hconn->conn_id, link->identity,
-               (void*)delivery, settled ? "settled" : "unsettled");
+               DLV_FMT" Core link deliver (%s)", DLV_ARGS(delivery),
+               settled ? "settled" : "unsettled");
 
         if (hconn->type == HTTP1_CONN_SERVER)
             outcome = qdr_http1_server_core_link_deliver(qdr_http1_adaptor, hconn, link, delivery, settled);
@@ -619,10 +620,9 @@ static void _core_delivery_update(void *context, qdr_delivery_t *dlv, uint64_t d
     qdr_http1_request_base_t *hreq = (qdr_http1_request_base_t*) qdr_delivery_get_context(dlv);
     if (hreq) {
         qdr_http1_connection_t *hconn = hreq->hconn;
-        qdr_link_t *link = qdr_delivery_link(dlv);
         qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG,
-               "[C%"PRIu64"][L%"PRIu64"] Core Delivery update disp=0x%"PRIx64" %s",
-               hconn->conn_id, link->identity, disp,
+               DLV_FMT" core delivery update disp=0x%"PRIx64" %s",
+               DLV_ARGS(dlv), disp,
                settled ? "settled" : "unsettled");
 
         if (hconn->type == HTTP1_CONN_SERVER)

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -1678,12 +1678,13 @@ uint64_t qdr_http1_client_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
 static void _client_response_msg_free(_client_request_t *req, _client_response_msg_t *rmsg)
 {
     DEQ_REMOVE(req->responses, rmsg);
+    qdr_http1_out_data_fifo_cleanup(&rmsg->out_data);
+
     if (rmsg->dlv) {
         qdr_delivery_set_context(rmsg->dlv, 0);
         qdr_delivery_decref(qdr_http1_adaptor->core, rmsg->dlv, "HTTP1 client response delivery settled");
+        rmsg->dlv = 0;
     }
-
-    qdr_http1_out_data_fifo_cleanup(&rmsg->out_data);
 
     free__client_response_msg_t(rmsg);
 }

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -366,6 +366,18 @@ static void _setup_client_connection(qdr_http1_connection_t *hconn)
 }
 
 
+static void _handle_conn_read_close(qdr_http1_connection_t *hconn)
+{
+    qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG, "[C%"PRIu64"] Closed for reading", hconn->conn_id);
+}
+
+
+static void _handle_conn_write_close(qdr_http1_connection_t *hconn)
+{
+    qd_log(qdr_http1_adaptor->log, QD_LOG_DEBUG, "[C%"PRIu64"] Closed for writing", hconn->conn_id);
+}
+
+
 // handle PN_RAW_CONNECTION_READ
 static int _handle_conn_read_event(qdr_http1_connection_t *hconn)
 {
@@ -378,6 +390,17 @@ static int _handle_conn_read_event(qdr_http1_connection_t *hconn)
                "[C%"PRIu64"][L%"PRIu64"] Read %"PRIuMAX" bytes from client (%zu buffers)",
                hconn->conn_id, hconn->in_link_id, length, DEQ_SIZE(blist));
         hconn->in_http1_octets += length;
+
+        if (HTTP1_DUMP_BUFFERS) {
+            fprintf(stdout, "\nClient raw buffer READ %"PRIuMAX" total octets\n", length);
+            qd_buffer_t *bb = DEQ_HEAD(blist);
+            while (bb) {
+                fprintf(stdout, "  buffer='%.*s'\n", (int)qd_buffer_size(bb), (char*)&bb[1]);
+                bb = DEQ_NEXT(bb);
+            }
+            fflush(stdout);
+        }
+
         error = h1_codec_connection_rx_data(hconn->http_conn, &blist, length);
     }
     return error;
@@ -413,11 +436,13 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
         _setup_client_connection(hconn);
         break;
     }
-    case PN_RAW_CONNECTION_CLOSED_READ:
+    case PN_RAW_CONNECTION_CLOSED_READ: {
+        _handle_conn_read_close(hconn);
+        pn_raw_connection_close(hconn->raw_conn);
+        break;
+    }
     case PN_RAW_CONNECTION_CLOSED_WRITE: {
-        qd_log(log, QD_LOG_DEBUG, "[C%"PRIu64"] Closed for %s", hconn->conn_id,
-               pn_event_type(e) == PN_RAW_CONNECTION_CLOSED_READ
-               ? "reading" : "writing");
+        _handle_conn_write_close(hconn);
         pn_raw_connection_close(hconn->raw_conn);
         break;
     }
@@ -434,10 +459,12 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
 
         if (hconn->out_link) {
             qdr_link_set_context(hconn->out_link, 0);
+            qdr_link_detach(hconn->in_link, QD_LOST, 0);
             hconn->out_link = 0;
         }
         if (hconn->in_link) {
             qdr_link_set_context(hconn->in_link, 0);
+            qdr_link_detach(hconn->in_link, QD_LOST, 0);
             hconn->in_link = 0;
         }
         if (hconn->qdr_conn) {
@@ -944,7 +971,7 @@ static void _client_rx_done_cb(h1_codec_request_state_t *hrs)
 }
 
 
-// The coded has completed processing the request and response messages.
+// The codec has completed processing the request and response messages.
 //
 static void _client_request_complete_cb(h1_codec_request_state_t *lib_rs, bool cancelled)
 {
@@ -962,7 +989,7 @@ static void _client_request_complete_cb(h1_codec_request_state_t *lib_rs, bool c
                "[C%"PRIu64"] HTTP request msg-id=%"PRIu64" %s. Octets read: %"PRIu64" written: %"PRIu64,
                hreq->base.hconn->conn_id,
                hreq->base.msg_id,
-               cancelled ? "cancelled!" : "codec done",
+               cancelled ? "cancelled" : "codec done",
                in_octets, out_octets);
     }
 }

--- a/src/adaptors/http1/http1_client.c
+++ b/src/adaptors/http1/http1_client.c
@@ -459,7 +459,7 @@ static void _handle_connection_events(pn_event_t *e, qd_server_t *qd_server, voi
 
         if (hconn->out_link) {
             qdr_link_set_context(hconn->out_link, 0);
-            qdr_link_detach(hconn->in_link, QD_LOST, 0);
+            qdr_link_detach(hconn->out_link, QD_LOST, 0);
             hconn->out_link = 0;
         }
         if (hconn->in_link) {

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -1644,12 +1644,12 @@ static void _server_request_free(_server_request_t *hreq)
 {
     if (hreq) {
         qdr_http1_request_base_cleanup(&hreq->base);
+        qdr_http1_out_data_fifo_cleanup(&hreq->out_data);
         if (hreq->request_dlv) {
             qdr_delivery_set_context(hreq->request_dlv, 0);
             qdr_delivery_decref(qdr_http1_adaptor->core, hreq->request_dlv, "HTTP1 server releasing request delivery");
+            hreq->request_dlv = 0;
         }
-
-        qdr_http1_out_data_fifo_cleanup(&hreq->out_data);
 
         _server_response_msg_t *rmsg = DEQ_HEAD(hreq->responses);
         while (rmsg) {

--- a/src/adaptors/http1/http1_server.c
+++ b/src/adaptors/http1/http1_server.c
@@ -49,6 +49,7 @@ typedef struct _server_response_msg_t {
     qd_composed_field_t *msg_props; // hold incoming headers
     qdr_delivery_t      *dlv;       // inbound to router (qdr_link_deliver)
     bool                 rx_complete; // response rx complete
+    bool                 discard;     // client no longer present
 } _server_response_msg_t;
 ALLOC_DECLARE(_server_response_msg_t);
 ALLOC_DEFINE(_server_response_msg_t);
@@ -715,6 +716,7 @@ static bool _process_request(_server_request_t *hreq)
             if (rmsg->dlv) {
                 qd_message_set_receive_complete(qdr_delivery_message(rmsg->dlv));
                 qdr_delivery_set_aborted(rmsg->dlv);
+                qdr_delivery_continue(qdr_http1_adaptor->core, rmsg->dlv, true);
             }
             _server_response_msg_free(hreq, rmsg);
             rmsg = DEQ_HEAD(hreq->responses);
@@ -1025,15 +1027,20 @@ static int _server_rx_body_cb(h1_codec_request_state_t *hrs, qd_buffer_list_t *b
     }
 
     _server_response_msg_t *rmsg  = DEQ_TAIL(hreq->responses);
+    if (rmsg->discard) {
+        qd_buffer_list_free_buffers(body);
+        return 0;
+    }
 
     qd_message_t *msg = rmsg->msg ? rmsg->msg : qdr_delivery_message(rmsg->dlv);
-
-
     qd_message_stream_data_append(msg, body, &q2_blocked);
     hconn->q2_blocked = hconn->q2_blocked || q2_blocked;
     if (q2_blocked) {
         // note: unit tests grep for this log!
-        qd_log(qdr_http1_adaptor->log, QD_LOG_TRACE, "[C%"PRIu64"] server link blocked on Q2 limit", hconn->conn_id);
+        if (rmsg->dlv)
+            qd_log(qdr_http1_adaptor->log, QD_LOG_TRACE, DLV_FMT" server link blocked on Q2 limit", DLV_ARGS(rmsg->dlv));
+        else
+            qd_log(qdr_http1_adaptor->log, QD_LOG_TRACE, "[C%"PRIu64"] server link blocked on Q2 limit", hconn->conn_id);
     }
 
     //
@@ -1191,14 +1198,32 @@ void qdr_http1_server_core_delivery_update(qdr_http1_adaptor_t      *adaptor,
                                            bool                      settled)
 {
     qd_log(qdr_http1_adaptor->log, QD_LOG_TRACE,
-           "[C%"PRIu64"][L%"PRIu64"] HTTP response delivery update, outcome=0x%"PRIx64"%s",
-           hconn->conn_id, hconn->in_link_id, disp, settled ? " settled": "");
+           DLV_FMT" HTTP response delivery update, outcome=0x%"PRIx64"%s",
+           DLV_ARGS(dlv), disp, settled ? " settled": "");
 
-    // Not much can be done with error dispositions (I think)
-    if (disp != PN_ACCEPTED) {
-        qd_log(adaptor->log, QD_LOG_WARNING,
-               "[C%"PRIu64"][L%"PRIu64"] response message was not accepted, outcome=0x%"PRIx64,
-               hconn->conn_id, hconn->in_link_id, disp);
+    if (settled) {
+        if (disp && disp != PN_ACCEPTED) {
+            qd_log(adaptor->log, QD_LOG_WARNING,
+                   "[C%"PRIu64"][L%"PRIu64"] response message was not accepted, outcome=0x%"PRIx64,
+                   hconn->conn_id, hconn->in_link_id, disp);
+
+            // This indicates the client that originated the request is
+            // unreachable. Rather than drop the connection allow the server to
+            // finish the response. We'll simply discard the response data as
+            // it is read from the raw connection
+            _server_request_t *hreq = (_server_request_t*)hbase;
+            _server_response_msg_t *rmsg  = DEQ_HEAD(hreq->responses);
+            while (rmsg) {
+                if (rmsg->dlv == dlv) {
+                    rmsg->discard = true;
+                    qd_message_t *msg = qdr_delivery_message(dlv);
+                    qd_message_set_discard(msg, true);
+                    qd_message_Q2_holdoff_disable(msg);
+                    break;
+                }
+                rmsg = DEQ_NEXT(rmsg);
+            }
+        }
     }
     if (hconn->cfg.aggregation != QD_AGGREGATION_NONE) {
         _server_request_t *hreq = (_server_request_t*)hbase;
@@ -1529,6 +1554,16 @@ uint64_t qdr_http1_server_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
 
     _server_request_t *hreq = (_server_request_t*) qdr_delivery_get_context(delivery);
     if (!hreq) {
+
+        if (qd_message_aborted(msg)) {
+            // can safely discard since it was yet to be processed
+            qd_log(qdr_http1_adaptor->log, QD_LOG_WARNING,
+                   DLV_FMT" Discarding aborted request", DLV_ARGS(delivery));
+            qd_message_set_send_complete(msg);
+            qdr_link_flow(qdr_http1_adaptor->core, link, 1, false);
+            return PN_REJECTED;
+        }
+
         // new delivery - create new request:
         switch (qd_message_check_depth(msg, QD_DEPTH_PROPERTIES)) {
         case QD_MESSAGE_DEPTH_INCOMPLETE:
@@ -1536,8 +1571,7 @@ uint64_t qdr_http1_server_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
 
         case QD_MESSAGE_DEPTH_INVALID:
             qd_log(qdr_http1_adaptor->log, QD_LOG_WARNING,
-                   "[C%"PRIu64"][L%"PRIu64"] Malformed HTTP/1.x message",
-                   hconn->conn_id, link->identity);
+                   DLV_FMT" Malformed HTTP/1.x message", DLV_ARGS(delivery));
             qd_message_set_send_complete(msg);
             qdr_link_flow(qdr_http1_adaptor->core, link, 1, false);
             return PN_REJECTED;
@@ -1546,7 +1580,7 @@ uint64_t qdr_http1_server_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
             hreq = _create_request_context(hconn, msg);
             if (!hreq) {
                 qd_log(qdr_http1_adaptor->log, QD_LOG_WARNING,
-                       "[C%"PRIu64"][L%"PRIu64"] Discarding malformed message.", hconn->conn_id, link->identity);
+                       DLV_FMT" Discarding malformed message.", DLV_ARGS(delivery));
                 qd_message_set_send_complete(msg);
                 qdr_link_flow(qdr_http1_adaptor->core, link, 1, false);
                 return PN_REJECTED;
@@ -1557,8 +1591,22 @@ uint64_t qdr_http1_server_core_link_deliver(qdr_http1_adaptor_t    *adaptor,
             qdr_delivery_incref(delivery, "HTTP1 server referencing request delivery");
             break;
         }
+
+    } else if (qd_message_aborted(msg)) {
+        //
+        // The client has aborted the request message.  This can happen when
+        // the HTTP client has dropped its connection mid-request message. If
+        // this request has not yet been written to the server it can be safely
+        // discard.  However, if some of the request has been sent then the
+        // connection to the server must be bounced in order to recover.
+        //
+        qd_log(qdr_http1_adaptor->log, QD_LOG_WARNING,
+               DLV_FMT" Client has aborted the request", DLV_ARGS(delivery));
+        _cancel_request(hreq);
+        return 0;
     }
 
+    // send request in the proper order
     if (DEQ_HEAD(hconn->requests) == &hreq->base)
         _send_request_message(hreq);
 

--- a/tests/http1_tests.py
+++ b/tests/http1_tests.py
@@ -1228,10 +1228,10 @@ class Http1ClientCloseTestsMixIn(object):
             "PUT": [
                 (RequestMsg("PUT", "/PUT/test_04_client_request_close",
                             headers={
-                                "Content-Length": "100000",
+                                "Content-Length": "500000",
                                 "Content-Type": "text/plain;charset=utf-8"
                             },
-                            body=b'4' * (100000 - 19) + b'END OF TRANSMISSION'),
+                            body=b'4' * (500000 - 19) + b'END OF TRANSMISSION'),
                  ResponseMsg(201, reason="Created",
                              headers={"Test-Header": "/PUT/test_04_client_request_close",
                                       "Content-Length": "0"}),

--- a/tests/system_tests_http1_adaptor.py
+++ b/tests/system_tests_http1_adaptor.py
@@ -517,7 +517,8 @@ class Http1AdaptorBadEndpointsTest(TestCase,
 
         body_filler = "?" * 1024 * 300  # Q2
 
-        # fake server - just to create a sink for the "fakeServer" address
+        # fake server - just to create a sink for the "fakeServer" address so
+        # credit will be granted.
         rx = AsyncTestReceiver(self.INT_A.listener,
                                source="fakeServer")
 


### PR DESCRIPTION
Handle abort of request message on server-facing egress side.
Discard incoming response from server if client does not accept it.
Improve logging.