### PR TITLE
DISPATCH-2097: Add management status for hiding connections on console gui

### DIFF
--- a/include/qpid/dispatch/protocol_adaptor.h
+++ b/include/qpid/dispatch/protocol_adaptor.h
@@ -447,6 +447,16 @@ const char *qdr_connection_get_tenant_space(const qdr_connection_t *conn, int *l
 int qdr_connection_process(qdr_connection_t *conn);
 
 /**
+ * qdr_connection_set_hidden
+ *
+ * Set flag to indicate that this connection must not be shown on console
+ * displays. The first use of this feature is to signal to the console not
+ * to display TCP adaptor egress_dispatcher connections.
+ */
+void qdr_connection_set_hidden_on_gui(qdr_connection_t *conn);
+
+
+/**
  ******************************************************************************
  * Terminus functions
  ******************************************************************************

--- a/python/qpid_dispatch/management/qdrouter.json
+++ b/python/qpid_dispatch/management/qdrouter.json
@@ -2057,7 +2057,11 @@
                     "type": "integer",
                     "graph": true,
                     "description": "The number of seconds since a delivery was sent on this connection. Will display a - (dash) if no deliveries have been sent on the connection."
-                }                
+                },
+                "hideOnGui": {
+                    "type": "boolean",
+                    "description": "This connection is for internal use only and should not be shown on console screens depicting user configuration or traffic flow."
+                }
             }
         },
 

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -960,6 +960,10 @@ static void qdr_tcp_open_server_side_connection(qdr_tcp_connection_t* tc)
     tc->qdr_conn = conn;
     qdr_connection_set_context(conn, tc);
 
+    if (tc->egress_dispatcher) {
+        qdr_connection_set_hidden_on_gui(conn);
+    }
+
     qdr_terminus_t *source = qdr_terminus(0);
     qdr_terminus_set_address(source, tc->config.address);
 

--- a/src/router_core/agent_connection.c
+++ b/src/router_core/agent_connection.c
@@ -49,6 +49,7 @@
 #define QDR_CONNECTION_UPTIME_SECONDS        22
 #define QDR_CONNECTION_LAST_DLV_SECONDS      23
 #define QDR_CONNECTION_ENABLE_PROTOCOL_TRACE 24
+#define QDR_CONNECTION_HIDE_ON_GUI           25
 
 
 const char * const QDR_CONNECTION_DIR_IN  = "in";
@@ -94,6 +95,7 @@ const char *qdr_connection_columns[] =
      "uptimeSeconds",
      "lastDlvSeconds",
      "enableProtocolTrace",
+     "hideOnGui",
      0};
 
 const char *CONNECTION_TYPE = "org.apache.qpid.dispatch.connection";
@@ -308,6 +310,11 @@ static void qdr_connection_insert_column_CT(qdr_core_t *core, qdr_connection_t *
         qd_compose_end_map(body);
     }
     break;
+
+    case QDR_CONNECTION_HIDE_ON_GUI:
+        qd_compose_insert_bool(body, conn->hide_on_gui);
+        break;
+
     }
 }
 

--- a/src/router_core/agent_connection.h
+++ b/src/router_core/agent_connection.h
@@ -35,7 +35,7 @@ void qdra_connection_update_CT(qdr_core_t      *core,
                              qdr_query_t       *query,
                              qd_parsed_field_t *in_body);
 
-#define QDR_CONNECTION_COLUMN_COUNT 25
+#define QDR_CONNECTION_COLUMN_COUNT 26
 extern const char *qdr_connection_columns[QDR_CONNECTION_COLUMN_COUNT + 1];
 
 #endif

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -486,6 +486,12 @@ int qdr_connection_process(qdr_connection_t *conn)
 }
 
 
+void qdr_connection_set_hidden_on_gui(qdr_connection_t *conn)
+{
+    conn->hide_on_gui = true;
+}
+
+
 void qdr_link_set_context(qdr_link_t *link, void *context)
 {
     if (link)

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -699,6 +699,7 @@ struct qdr_connection_t {
     bool                        has_streaming_links;   ///< one or more of this connection's links are for streaming messages
     qdr_link_list_t             streaming_link_pool;   ///< pool of links available for streaming messages
     const qd_policy_spec_t     *policy_spec;
+    bool                        hide_on_gui;
 };
 
 DEQ_DECLARE(qdr_connection_t, qdr_connection_list_t);


### PR DESCRIPTION
The first use of this feature is to signal to the console not
to display TCP adaptor egress_dispatcher connections.