### PR TITLE
DISPATCH-2097: Identify TCP connections with property qd.adaptor=tcp

### DIFF
--- a/include/qpid/dispatch/amqp.h
+++ b/include/qpid/dispatch/amqp.h
@@ -168,6 +168,8 @@ extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_NETHOST_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_PORT_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_SCHEME_KEY;
 extern const char * const QD_CONNECTION_PROPERTY_FAILOVER_HOSTNAME_KEY;
+extern const char * const QD_CONNECTION_PROPERTY_ADAPTOR_KEY;
+extern const char * const QD_CONNECTION_PROPERTY_TCP_ADAPTOR_VALUE;
 /// @}
 
 /** @name Terminus Addresses */

--- a/src/amqp.c
+++ b/src/amqp.c
@@ -65,6 +65,8 @@ const char * const QD_CONNECTION_PROPERTY_FAILOVER_NETHOST_KEY  = "network-host"
 const char * const QD_CONNECTION_PROPERTY_FAILOVER_PORT_KEY     = "port";
 const char * const QD_CONNECTION_PROPERTY_FAILOVER_SCHEME_KEY   = "scheme";
 const char * const QD_CONNECTION_PROPERTY_FAILOVER_HOSTNAME_KEY = "hostname";
+const char * const QD_CONNECTION_PROPERTY_ADAPTOR_KEY           = "qd.adaptor";
+const char * const QD_CONNECTION_PROPERTY_TCP_ADAPTOR_VALUE     = "tcp";
 
 const char * const QD_TERMINUS_EDGE_ADDRESS_TRACKING = "_$qd.edge_addr_tracking";
 const char * const QD_TERMINUS_ADDRESS_LOOKUP        = "_$qd.addr_lookup";


### PR DESCRIPTION
    Example: Connections on TCP Listener router
    
    > qdmanage query --type=connection 
    [
      {
        "name": "connection/127.0.0.1:38932",
        "identity": "1",
        "host": "127.0.0.1:38932",
        "role": "inter-router",
        "protocol": "amqp",
        "dir": "in",
        "container": "D-1878-B",
        "sasl": "ANONYMOUS",
        "isAuthenticated": true,
        "user": "anonymous",
        "isEncrypted": false,
        "properties": {
          "product": "qpid-dispatch-router",
          "version": "1.17.0-SNAPSHOT",
          "qd.conn-id": 2
        },
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 109,
        "lastDlvSeconds": 0,
        "enableProtocolTrace": false
      },
      {
        "name": "connection/127.0.0.1:41204",
        "identity": "2",
        "host": "127.0.0.1:41204",
        "role": "normal",
        "protocol": "tcp",
        "dir": "in",
        "container": "TcpAdaptor",
        "sasl": "",
        "isAuthenticated": false,
        "user": "",
        "isEncrypted": false,
        "properties": {
          "qd.adaptor": "tcp"
        },
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 88,
        "lastDlvSeconds": 88,
        "enableProtocolTrace": false
      },
      {
        "name": "connection/127.0.0.1:58858",
        "identity": "3",
        "host": "127.0.0.1:58858",
        "role": "normal",
        "protocol": "amqp",
        "dir": "in",
        "container": "2f8320df-4fcc-4481-8fb0-a5cf86a5f0db",
        "isAuthenticated": false,
        "user": "anonymous",
        "isEncrypted": false,
        "properties": {},
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 0,
        "lastDlvSeconds": 0,
        "enableProtocolTrace": false
      }
    ]
    
    Example: Connections on TCP Connector router
    
    > qdmanage query -b 127.0.0.1:21001 --type=connection 
    [
      {
        "name": "connection/egress-dispatch",
        "identity": "1",
        "host": "egress-dispatch",
        "role": "normal",
        "protocol": "tcp",
        "dir": "out",
        "container": "TcpAdaptor",
        "sasl": "",
        "isAuthenticated": false,
        "user": "",
        "isEncrypted": false,
        "properties": {
          "qd.adaptor": "tcp"
        },
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 80,
        "lastDlvSeconds": 59,
        "enableProtocolTrace": false
      },
      {
        "name": "connection/127.0.0.1:21000",
        "identity": "2",
        "host": "127.0.0.1:21000",
        "role": "inter-router",
        "protocol": "amqp",
        "dir": "out",
        "container": "D-1878",
        "sasl": "ANONYMOUS",
        "isAuthenticated": true,
        "isEncrypted": false,
        "properties": {
          "product": "qpid-dispatch-router",
          "version": "1.17.0-SNAPSHOT",
          "qd.conn-id": 1
        },
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 80,
        "lastDlvSeconds": 0,
        "enableProtocolTrace": false
      },
      {
        "name": "connection/127.0.0.1:9090",
        "identity": "3",
        "host": "127.0.0.1:9090",
        "role": "normal",
        "protocol": "tcp",
        "dir": "out",
        "container": "TcpAdaptor",
        "sasl": "",
        "isAuthenticated": false,
        "user": "",
        "isEncrypted": false,
        "properties": {
          "qd.adaptor": "tcp"
        },
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 59,
        "lastDlvSeconds": 59,
        "enableProtocolTrace": false
      },
      {
        "name": "connection/127.0.0.1:47998",
        "identity": "5",
        "host": "127.0.0.1:47998",
        "role": "normal",
        "protocol": "amqp",
        "dir": "in",
        "container": "b80c2c45-224b-459c-b34e-3474ac265b84",
        "isAuthenticated": false,
        "user": "anonymous",
        "isEncrypted": false,
        "properties": {},
        "sslSsf": 0,
        "type": "org.apache.qpid.dispatch.connection",
        "ssl": false,
        "opened": true,
        "active": true,
        "adminStatus": "enabled",
        "operStatus": "up",
        "uptimeSeconds": 0,
        "lastDlvSeconds": 0,
        "enableProtocolTrace": false
      }
    ]

