### PR TITLE
NO-JIRA: Run ctest with --output-on-failure, esp. on CentOS 7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -418,7 +418,7 @@ jobs:
         working-directory: ${{env.DispatchBuildDir}}
         run: |
           ulimit -c unlimited
-          ctest -C ${BuildType} -V -T Test --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.DispatchCTestExtraArgs}}
+          ctest -C ${BuildType} -V -T Test --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.DispatchCTestExtraArgs}}
 
       - name: Upload test results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This seems to be necessary for the CentOS 7 version of ctest to put errors directly into the log output. The newer versions of ctest don't seem to be affected by this added option.

See the result at https://github.com/apache/qpid-dispatch/runs/2827373458