### PR TITLE
Thread debug cr4 - DO NOT MERGE

### DIFF
--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -569,6 +569,35 @@ void qd_connection_invoke_deferred(qd_connection_t *conn, qd_deferred_t call, vo
 
 
 /**
+ * Schedule a call to be invoked on a thread that has ownership of this connection
+ * when it will be safe for the callback to perform operations related to this connection.
+ * A qd_deferred_call_t object has been allocated before hand to avoid taking
+ * the ENTITY_CACHE lock.
+ *
+ * @param conn Connection object
+ * @param call The function to be invoked on the connection's thread
+ * @param context The context to be passed back in the callback
+ * @param dct Pointer to preallocated qd_deferred_call_t object
+ */
+void qd_connection_invoke_deferred_impl(qd_connection_t *conn, qd_deferred_t call, void *context, void *dct);
+
+
+/**
+ * Allocate a qd_deferred_call_t object
+ */
+void *qd_connection_new_qd_deferred_call_t();
+
+
+/**
+ * Deallocate a qd_deferred_call_t object
+ *
+ * @param dct Pointer to preallocated qd_deferred_call_t object
+ */
+void qd_connection_free_qd_deferred_call_t(void *dct);
+
+
+
+/**
  * Listen for incoming connections, return true if listening succeeded.
  */
 bool qd_listener_listen(qd_listener_t *l);

--- a/include/qpid/dispatch/threading.h
+++ b/include/qpid/dispatch/threading.h
@@ -23,9 +23,13 @@
  * Portable threading and locking API.
  */
 
+#if !defined(NDEBUG)
+#define QD_THREAD_DEBUG 1
+#endif
+
 typedef struct sys_mutex_t sys_mutex_t;
 
-sys_mutex_t *sys_mutex(void);
+sys_mutex_t *sys_mutex(const char *name);
 void         sys_mutex_free(sys_mutex_t *mutex);
 void         sys_mutex_lock(sys_mutex_t *mutex);
 void         sys_mutex_unlock(sys_mutex_t *mutex);
@@ -42,7 +46,7 @@ void        sys_cond_signal_all(sys_cond_t *cond);
 
 typedef struct sys_rwlock_t sys_rwlock_t;
 
-sys_rwlock_t *sys_rwlock(void);
+sys_rwlock_t *sys_rwlock(const char *name);
 void          sys_rwlock_free(sys_rwlock_t *lock);
 void          sys_rwlock_wrlock(sys_rwlock_t *lock);
 void          sys_rwlock_rdlock(sys_rwlock_t *lock);

--- a/include/qpid/dispatch/timer.h
+++ b/include/qpid/dispatch/timer.h
@@ -39,6 +39,11 @@ typedef int64_t qd_timestamp_t;
 /** Relative duration in milliseconds */
 typedef int64_t qd_duration_t;
 
+/** Absolute time stamp from monotonic clock source, microseconds since arbitrary (fixed) instant */
+typedef uint64_t qd_timestamp_us_t;
+/** Relative duration in microseconds */
+typedef uint64_t qd_duration_us_t;
+
 /**
  * Timer Callback
  *
@@ -116,6 +121,11 @@ void qd_timer_cancel(qd_timer_t *timer);
  * The current time.
  */
 qd_timestamp_t qd_timer_now() ;
+
+/**
+ * The current time. microseconds
+ */
+qd_timestamp_us_t qd_timer_us_now() ;
 
 /**
  * @}

--- a/lock-analyzer-e397609e.txt
+++ b/lock-analyzer-e397609e.txt
@@ -1,0 +1,341 @@
+This file holds a sample complete run for /system_tests_topology_disposition/TopologyDispositionTests/setUpClass/A router.
+
+/home/chug/git/qpid-dispatch/tools/lock-analyzer.py --outfile /home/chug/git/qpid-dispatch/build/tests/system_test.dir/system_tests_topology_disposition/TopologyDispositionTests/setUpClass/A-1.out --core-tid 0x1a374d0
+pydev debugger: process 249727 is connecting
+
+Connected to pydev debugger (build 201.8538.36)
+
+Exceptional observations made during processing
+===============================================
+
+Long wait timestamp:294674242371 0x7fcbad72fe60 acquire: 0 use: 49470 total: 49470 lock stack: ['PYTHON']
+Long wait timestamp:294674295265 0x1a374d0 --CORE-- acquire: 0 use: 10094 total: 10094 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674301251 0x7fcbad72fe60 acquire: 0 use: 58776 total: 58776 lock stack: ['PYTHON']
+Long wait timestamp:294674437946 0x1a374d0 --CORE-- acquire: 0 use: 138148 total: 138148 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674599862 0x1a374d0 --CORE-- acquire: 0 use: 142095 total: 142095 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674612272 0x1a374d0 --CORE-- acquire: 0 use: 12193 total: 12193 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674779562 0x1a374d0 --CORE-- acquire: 0 use: 150288 total: 150288 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674793120 0x1a374d0 --CORE-- acquire: 0 use: 12915 total: 12915 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674811638 0x1a374d0 --CORE-- acquire: 0 use: 11937 total: 11937 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674814842 0x1a374d0 --CORE-- acquire: 1307 use: 9 total: 1316 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674841982 0x1a374d0 --CORE-- acquire: 0 use: 16484 total: 16484 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674881197 0x1a374d0 --CORE-- acquire: 0 use: 36282 total: 36282 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674895315 0x1a374d0 --CORE-- acquire: 6727 use: 28 total: 6755 lock stack: ['ALLOC_INIT', 'ENTITY_CACHE']
+Long wait timestamp:294674952963 0x1a374d0 --CORE-- acquire: 0 use: 17797 total: 17797 lock stack: ['CORE_ACTION']
+Long wait timestamp:294674993731 0x1a374d0 --CORE-- acquire: 0 use: 33753 total: 33753 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675069122 0x1a374d0 --CORE-- acquire: 0 use: 68750 total: 68750 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675221216 0x1a374d0 --CORE-- acquire: 0 use: 131847 total: 131847 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675238349 0x1a6b210 acquire: 0 use: 11020 total: 11020 lock stack: ['PYTHON']
+Long wait timestamp:294675287330 0x1a374d0 --CORE-- acquire: 0 use: 43700 total: 43700 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675300026 0x1a374d0 --CORE-- acquire: 1152 use: 648 total: 1800 lock stack: ['LOG']
+Long wait timestamp:294675311855 0x1a374d0 --CORE-- acquire: 1312 use: 489 total: 1801 lock stack: ['LOG']
+Long wait timestamp:294675446877 0x1a374d0 --CORE-- acquire: 0 use: 125585 total: 125585 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675460289 0x1a13050 acquire: 0 use: 11476 total: 11476 lock stack: ['PYTHON']
+Long wait timestamp:294675506835 0x1a374d0 --CORE-- acquire: 0 use: 45432 total: 45432 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675535851 0x1a13050 acquire: 0 use: 13126 total: 13126 lock stack: ['PYTHON', 'ROUTER', 'ENTITY_CACHE']
+Long wait timestamp:294675535904 0x1a13050 acquire: 0 use: 13237 total: 13237 lock stack: ['PYTHON', 'ROUTER']
+Long wait timestamp:294675538906 0x1a374d0 --CORE-- acquire: 0 use: 15623 total: 15623 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675539350 0x1a13050 acquire: 1 use: 19599 total: 19600 lock stack: ['PYTHON']
+Long wait timestamp:294675573385 0x1a374d0 --CORE-- acquire: 0 use: 28001 total: 28001 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675782023 0x1a374d0 --CORE-- acquire: 0 use: 188675 total: 188675 lock stack: ['CORE_ACTION']
+Long wait timestamp:294675806116 0x1a6b210 acquire: 1 use: 19537 total: 19538 lock stack: ['PYTHON']
+Long wait timestamp:294676295428 0x1a374d0 --CORE-- acquire: 0 use: 480127 total: 480127 lock stack: ['CORE_ACTION']
+Long wait timestamp:294676318114 0x1a374d0 --CORE-- acquire: 1341 use: 294 total: 1635 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294676331494 0x1a6b210 acquire: 1 use: 37638 total: 37639 lock stack: ['PYTHON']
+Long wait timestamp:294676338653 0x1a374d0 --CORE-- acquire: 1011 use: 25 total: 1036 lock stack: ['LOG']
+Long wait timestamp:294676437467 0x1a374d0 --CORE-- acquire: 0 use: 61078 total: 61078 lock stack: ['CORE_ACTION']
+Long wait timestamp:294676457997 0x1a374d0 --CORE-- acquire: 1258 use: 10 total: 1268 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294676461583 0x1a374d0 --CORE-- acquire: 1924 use: 49 total: 1973 lock stack: ['LOG']
+Long wait timestamp:294676471912 0x1a374d0 --CORE-- acquire: 1607 use: 11 total: 1618 lock stack: ['CORE_ACTION']
+Long wait timestamp:294676496532 0x1a374d0 --CORE-- acquire: 1 use: 10607 total: 10608 lock stack: ['CORE_ACTION']
+Long wait timestamp:294676602948 0x1a374d0 --CORE-- acquire: 0 use: 94140 total: 94140 lock stack: ['CORE_ACTION']
+Long wait timestamp:294676621985 0x1a6b210 acquire: 1 use: 10110 total: 10111 lock stack: ['PYTHON']
+Long wait timestamp:294676662983 0x1a374d0 --CORE-- acquire: 0 use: 13847 total: 13847 lock stack: ['CORE_ACTION']
+Long wait timestamp:294676662737 0x1a6b210 acquire: 1 use: 27792 total: 27793 lock stack: ['PYTHON']
+Long wait timestamp:294676692963 0x1a374d0 --CORE-- acquire: 1460 use: 107 total: 1567 lock stack: ['LOG']
+Long wait timestamp:294676698880 0x1a6b210 acquire: 0 use: 16179 total: 16179 lock stack: ['PYTHON']
+Long wait timestamp:294676718360 0x1a374d0 --CORE-- acquire: 2063 use: 13 total: 2076 lock stack: ['qd_message_t']
+Long wait timestamp:294676719484 0x1a6b210 acquire: 1 use: 14398 total: 14399 lock stack: ['PYTHON']
+Long wait timestamp:294676723612 0x1a374d0 --CORE-- acquire: 3798 use: 23 total: 3821 lock stack: ['qd_buffer_t']
+Long wait timestamp:294676779581 0x1a374d0 --CORE-- acquire: 2203 use: 36 total: 2239 lock stack: ['LOG']
+Long wait timestamp:294676796007 0x1a374d0 --CORE-- acquire: 1153 use: 30 total: 1183 lock stack: ['LOG']
+Long wait timestamp:294676866349 0x1a374d0 --CORE-- acquire: 0 use: 18998 total: 18998 lock stack: ['CORE_ACTION']
+Long wait timestamp:294677333411 0x1a374d0 --CORE-- acquire: 0 use: 466098 total: 466098 lock stack: ['CORE_ACTION']
+Long wait timestamp:294677346070 0x1a13050 acquire: 0 use: 14077 total: 14077 lock stack: ['PYTHON']
+Long wait timestamp:294677454177 0x1a374d0 --CORE-- acquire: 0 use: 73051 total: 73051 lock stack: ['CORE_ACTION']
+Long wait timestamp:294677490576 0x1a374d0 --CORE-- acquire: 0 use: 29789 total: 29789 lock stack: ['CORE_ACTION']
+Long wait timestamp:294677507798 0x1a374d0 --CORE-- acquire: 1005 use: 96 total: 1101 lock stack: ['LOG']
+Long wait timestamp:294677636006 0x1a374d0 --CORE-- acquire: 0 use: 92741 total: 92741 lock stack: ['CORE_ACTION']
+Long wait timestamp:294677800828 0x1a374d0 --CORE-- acquire: 0 use: 154574 total: 154574 lock stack: ['CORE_ACTION']
+Long wait timestamp:294677820842 0x1a6b210 acquire: 0 use: 14991 total: 14991 lock stack: ['PYTHON']
+Long wait timestamp:294677832917 0x1a6b210 acquire: 1 use: 10503 total: 10504 lock stack: ['PYTHON']
+Long wait timestamp:294678348849 0x1a374d0 --CORE-- acquire: 0 use: 492036 total: 492036 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678365639 0x1a374d0 --CORE-- acquire: 1535 use: 50 total: 1585 lock stack: ['qd_buffer_t']
+Long wait timestamp:294678458294 0x1a374d0 --CORE-- acquire: 0 use: 57119 total: 57119 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678643582 0x1a374d0 --CORE-- acquire: 0 use: 179788 total: 179788 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678802933 0x1a374d0 --CORE-- acquire: 0 use: 148825 total: 148825 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678820482 0x7fcbad72fe60 acquire: 1 use: 15323 total: 15324 lock stack: ['PYTHON']
+Long wait timestamp:294678833541 0x7fcbad72fe60 acquire: 1 use: 11552 total: 11553 lock stack: ['PYTHON']
+Long wait timestamp:294678862561 0x1a374d0 --CORE-- acquire: 0 use: 13271 total: 13271 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678891484 0x1a374d0 --CORE-- acquire: 0 use: 11398 total: 11398 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678963462 0x1a374d0 --CORE-- acquire: 0 use: 60255 total: 60255 lock stack: ['CORE_ACTION']
+Long wait timestamp:294678991083 0x1a374d0 --CORE-- acquire: 0 use: 19085 total: 19085 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679024091 0x1a374d0 --CORE-- acquire: 0 use: 29333 total: 29333 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679041583 0x1a374d0 --CORE-- acquire: 0 use: 13008 total: 13008 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679065026 0x1a374d0 --CORE-- acquire: 0 use: 13558 total: 13558 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679097426 0x1a374d0 --CORE-- acquire: 0 use: 16503 total: 16503 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679115043 0x1a374d0 --CORE-- acquire: 0 use: 17314 total: 17314 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679134411 0x1a374d0 --CORE-- acquire: 0 use: 19106 total: 19106 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679162959 0x1a374d0 --CORE-- acquire: 0 use: 17873 total: 17873 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679265776 0x1a374d0 --CORE-- acquire: 0 use: 70842 total: 70842 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679306273 0x1a374d0 --CORE-- acquire: 1 use: 22258 total: 22259 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679354030 0x1a374d0 --CORE-- acquire: 0 use: 42290 total: 42290 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679386913 0x1a374d0 --CORE-- acquire: 2982 use: 395 total: 3377 lock stack: ['LOG']
+Long wait timestamp:294679423518 0x1a374d0 --CORE-- acquire: 0 use: 10405 total: 10405 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679564887 0x1a374d0 --CORE-- acquire: 0 use: 97369 total: 97369 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679649845 0x1a374d0 --CORE-- acquire: 0 use: 78427 total: 78427 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679665689 0x1a374d0 --CORE-- acquire: 2133 use: 57 total: 2190 lock stack: ['SERVER']
+Long wait timestamp:294679768002 0x1a374d0 --CORE-- acquire: 1 use: 85802 total: 85803 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679806026 0x1a374d0 --CORE-- acquire: 0 use: 25463 total: 25463 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679870887 0x1a374d0 --CORE-- acquire: 0 use: 50857 total: 50857 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679910111 0x1a374d0 --CORE-- acquire: 0 use: 17366 total: 17366 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679925630 0x1a374d0 --CORE-- acquire: 0 use: 10569 total: 10569 lock stack: ['CORE_ACTION']
+Long wait timestamp:294679965806 0x1a374d0 --CORE-- acquire: 0 use: 31154 total: 31154 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680067676 0x1a374d0 --CORE-- acquire: 1 use: 71516 total: 71517 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680102146 0x1a374d0 --CORE-- acquire: 0 use: 22354 total: 22354 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680137858 0x1a374d0 --CORE-- acquire: 0 use: 30738 total: 30738 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680167588 0x1a374d0 --CORE-- acquire: 0 use: 23841 total: 23841 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680219128 0x1a374d0 --CORE-- acquire: 0 use: 13175 total: 13175 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680249713 0x1a374d0 --CORE-- acquire: 0 use: 24790 total: 24790 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680284883 0x1a374d0 --CORE-- acquire: 0 use: 24877 total: 24877 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680322395 0x1a374d0 --CORE-- acquire: 0 use: 28814 total: 28814 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680357230 0x1a374d0 --CORE-- acquire: 0 use: 13031 total: 13031 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680459792 0x1a374d0 --CORE-- acquire: 0 use: 49421 total: 49421 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680479302 0x1a374d0 --CORE-- acquire: 0 use: 16406 total: 16406 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680581886 0x1a374d0 --CORE-- acquire: 0 use: 95203 total: 95203 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680667558 0x1a374d0 --CORE-- acquire: 1 use: 18697 total: 18698 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680683915 0x1a374d0 --CORE-- acquire: 0 use: 15966 total: 15966 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680695803 0x1a374d0 --CORE-- acquire: 5962 use: 263 total: 6225 lock stack: ['LOG']
+Long wait timestamp:294680718449 0x1a374d0 --CORE-- acquire: 2445 use: 11 total: 2456 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294680746889 0x1a374d0 --CORE-- acquire: 0 use: 16209 total: 16209 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680789482 0x1a374d0 --CORE-- acquire: 1819 use: 23 total: 1842 lock stack: ['LOG']
+Long wait timestamp:294680813499 0x1a374d0 --CORE-- acquire: 0 use: 17658 total: 17658 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680837840 0x1a374d0 --CORE-- acquire: 0 use: 12942 total: 12942 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680841298 0x1a374d0 --CORE-- acquire: 1620 use: 8 total: 1628 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294680903265 0x1a374d0 --CORE-- acquire: 1026 use: 11 total: 1037 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680921067 0x1a374d0 --CORE-- acquire: 1 use: 11972 total: 11973 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680947775 0x1a374d0 --CORE-- acquire: 0 use: 10684 total: 10684 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680978369 0x1a374d0 --CORE-- acquire: 0 use: 19957 total: 19957 lock stack: ['CORE_ACTION']
+Long wait timestamp:294680987386 0x1a374d0 --CORE-- acquire: 1277 use: 9 total: 1286 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294681078426 0x1a374d0 --CORE-- acquire: 0 use: 38482 total: 38482 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681111610 0x1a374d0 --CORE-- acquire: 0 use: 16856 total: 16856 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681179424 0x1a374d0 --CORE-- acquire: 1 use: 35087 total: 35088 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681222044 0x1a374d0 --CORE-- acquire: 0 use: 27583 total: 27583 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681249377 0x1a374d0 --CORE-- acquire: 0 use: 12412 total: 12412 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681278975 0x1a374d0 --CORE-- acquire: 0 use: 15514 total: 15514 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681293602 0x1a374d0 --CORE-- acquire: 1080 use: 40 total: 1120 lock stack: ['LOG']
+Long wait timestamp:294681371014 0x1a374d0 --CORE-- acquire: 0 use: 22330 total: 22330 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681421682 0x1a374d0 --CORE-- acquire: 0 use: 21600 total: 21600 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681479633 0x1a374d0 --CORE-- acquire: 0 use: 17723 total: 17723 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681484066 0x1a374d0 --CORE-- acquire: 1009 use: 173 total: 1182 lock stack: ['LOG']
+Long wait timestamp:294681527517 0x1a374d0 --CORE-- acquire: 0 use: 12239 total: 12239 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681579510 0x1a374d0 --CORE-- acquire: 0 use: 32643 total: 32643 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681627347 0x1a374d0 --CORE-- acquire: 0 use: 10936 total: 10936 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681659067 0x1a374d0 --CORE-- acquire: 0 use: 16174 total: 16174 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681679521 0x1a374d0 --CORE-- acquire: 0 use: 17893 total: 17893 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681711555 0x1a374d0 --CORE-- acquire: 0 use: 16346 total: 16346 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681780062 0x1a374d0 --CORE-- acquire: 0 use: 35829 total: 35829 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681822954 0x1a374d0 --CORE-- acquire: 0 use: 24335 total: 24335 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681831703 0x1a374d0 --CORE-- acquire: 1693 use: 44 total: 1737 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294681881196 0x1a374d0 --CORE-- acquire: 0 use: 15127 total: 15127 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681923874 0x1a374d0 --CORE-- acquire: 0 use: 23049 total: 23049 lock stack: ['CORE_ACTION']
+Long wait timestamp:294681980246 0x1a374d0 --CORE-- acquire: 0 use: 20707 total: 20707 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682081000 0x1a374d0 --CORE-- acquire: 0 use: 30708 total: 30708 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682112080 0x1a374d0 --CORE-- acquire: 0 use: 14856 total: 14856 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682134232 0x1a374d0 --CORE-- acquire: 0 use: 12468 total: 12468 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682181158 0x1a374d0 --CORE-- acquire: 0 use: 32416 total: 32416 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682281756 0x1a374d0 --CORE-- acquire: 0 use: 37167 total: 37167 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682290527 0x1a374d0 --CORE-- acquire: 1645 use: 9 total: 1654 lock stack: ['qd_buffer_t']
+Long wait timestamp:294682311230 0x1a374d0 --CORE-- acquire: 0 use: 10866 total: 10866 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682373072 0x1a374d0 --CORE-- acquire: 0 use: 48467 total: 48467 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682426816 0x1a374d0 --CORE-- acquire: 0 use: 14812 total: 14812 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682461818 0x1a374d0 --CORE-- acquire: 0 use: 26146 total: 26146 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682483652 0x1a374d0 --CORE-- acquire: 0 use: 17692 total: 17692 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682531972 0x1a374d0 --CORE-- acquire: 0 use: 15905 total: 15905 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682583212 0x1a374d0 --CORE-- acquire: 0 use: 39589 total: 39589 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682664777 0x1a374d0 --CORE-- acquire: 0 use: 22094 total: 22094 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682684447 0x1a374d0 --CORE-- acquire: 0 use: 14124 total: 14124 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682782751 0x1a374d0 --CORE-- acquire: 0 use: 40268 total: 40268 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682828559 0x1a374d0 --CORE-- acquire: 1068 use: 18 total: 1086 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294682882929 0x1a374d0 --CORE-- acquire: 0 use: 25631 total: 25631 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682900601 0x1a374d0 --CORE-- acquire: 1004 use: 33 total: 1037 lock stack: ['LOG']
+Long wait timestamp:294682914134 0x1a374d0 --CORE-- acquire: 0 use: 10644 total: 10644 lock stack: ['CORE_ACTION']
+Long wait timestamp:294682982706 0x1a374d0 --CORE-- acquire: 0 use: 37627 total: 37627 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683019549 0x1a374d0 --CORE-- acquire: 0 use: 21053 total: 21053 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683083644 0x1a374d0 --CORE-- acquire: 0 use: 41743 total: 41743 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683129676 0x1a374d0 --CORE-- acquire: 0 use: 20917 total: 20917 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683183989 0x1a374d0 --CORE-- acquire: 0 use: 22798 total: 22798 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683235055 0x1a374d0 --CORE-- acquire: 0 use: 32682 total: 32682 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683283929 0x1a374d0 --CORE-- acquire: 0 use: 10209 total: 10209 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683373937 0x1a374d0 --CORE-- acquire: 0 use: 18808 total: 18808 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683462333 0x1a374d0 --CORE-- acquire: 0 use: 22882 total: 22882 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683484804 0x1a374d0 --CORE-- acquire: 0 use: 20074 total: 20074 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683489564 0x1a374d0 --CORE-- acquire: 1753 use: 21 total: 1774 lock stack: ['qd_buffer_t']
+Long wait timestamp:294683520420 0x1a374d0 --CORE-- acquire: 0 use: 17069 total: 17069 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683584519 0x1a374d0 --CORE-- acquire: 1 use: 39195 total: 39196 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683598526 0x1a374d0 --CORE-- acquire: 1982 use: 11 total: 1993 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294683622661 0x1a374d0 --CORE-- acquire: 1 use: 14846 total: 14847 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683669618 0x1a374d0 --CORE-- acquire: 0 use: 17583 total: 17583 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683684648 0x1a374d0 --CORE-- acquire: 0 use: 12418 total: 12418 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683726951 0x1a374d0 --CORE-- acquire: 0 use: 20282 total: 20282 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683785251 0x1a374d0 --CORE-- acquire: 0 use: 38241 total: 38241 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683807421 0x1a374d0 --CORE-- acquire: 1714 use: 55 total: 1769 lock stack: ['LOG']
+Long wait timestamp:294683824961 0x1a374d0 --CORE-- acquire: 1 use: 14961 total: 14962 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683845376 0x1a374d0 --CORE-- acquire: 1360 use: 11 total: 1371 lock stack: ['LOG', 'qd_log_entry_t']
+Long wait timestamp:294683886285 0x1a374d0 --CORE-- acquire: 0 use: 22431 total: 22431 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683931084 0x1a374d0 --CORE-- acquire: 0 use: 22898 total: 22898 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683985351 0x1a374d0 --CORE-- acquire: 0 use: 23648 total: 23648 lock stack: ['CORE_ACTION']
+Long wait timestamp:294683997318 0x1a374d0 --CORE-- acquire: 1082 use: 21 total: 1103 lock stack: ['LOG']
+Long wait timestamp:294684023065 0x1a374d0 --CORE-- acquire: 0 use: 17914 total: 17914 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684085872 0x1a374d0 --CORE-- acquire: 0 use: 38757 total: 38757 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684129072 0x1a374d0 --CORE-- acquire: 0 use: 23225 total: 23225 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684185988 0x1a374d0 --CORE-- acquire: 1 use: 31679 total: 31680 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684223902 0x1a374d0 --CORE-- acquire: 0 use: 17900 total: 17900 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684286734 0x1a374d0 --CORE-- acquire: 0 use: 36919 total: 36919 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684319970 0x1a374d0 --CORE-- acquire: 0 use: 13369 total: 13369 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684375563 0x1a374d0 --CORE-- acquire: 1 use: 41575 total: 41576 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684440279 0x1a374d0 --CORE-- acquire: 0 use: 18087 total: 18087 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684488737 0x1a374d0 --CORE-- acquire: 0 use: 10498 total: 10498 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684586922 0x1a374d0 --CORE-- acquire: 0 use: 60899 total: 60899 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684674832 0x1a374d0 --CORE-- acquire: 0 use: 49932 total: 49932 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684689656 0x1a374d0 --CORE-- acquire: 0 use: 10060 total: 10060 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684698599 0x1a374d0 --CORE-- acquire: 1006 use: 244 total: 1250 lock stack: ['LOG']
+Long wait timestamp:294684887530 0x1a374d0 --CORE-- acquire: 0 use: 23890 total: 23890 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684928355 0x1a374d0 --CORE-- acquire: 0 use: 19328 total: 19328 lock stack: ['CORE_ACTION']
+Long wait timestamp:294684958858 0x1a374d0 --CORE-- acquire: 0 use: 14904 total: 14904 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685051824 0x1a374d0 --CORE-- acquire: 0 use: 13107 total: 13107 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685158634 0x1a374d0 --CORE-- acquire: 0 use: 19955 total: 19955 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685374099 0x1a374d0 --CORE-- acquire: 0 use: 11263 total: 11263 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685406297 0x1a374d0 --CORE-- acquire: 1252 use: 712 total: 1964 lock stack: ['CONN_WORK']
+Long wait timestamp:294685446940 0x1a374d0 --CORE-- acquire: 1026 use: 139 total: 1165 lock stack: ['LOG']
+Long wait timestamp:294685450188 0x1a374d0 --CORE-- acquire: 1301 use: 11 total: 1312 lock stack: ['LOG', 'qd_log_entry_t']
+Long wait timestamp:294685525888 0x1a374d0 --CORE-- acquire: 0 use: 20634 total: 20634 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685589001 0x1a374d0 --CORE-- acquire: 0 use: 35716 total: 35716 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685676856 0x1a374d0 --CORE-- acquire: 0 use: 30209 total: 30209 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685726694 0x1a374d0 --CORE-- acquire: 0 use: 16326 total: 16326 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685790510 0x1a374d0 --CORE-- acquire: 0 use: 40822 total: 40822 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685840516 0x1a374d0 --CORE-- acquire: 0 use: 22706 total: 22706 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685890277 0x1a374d0 --CORE-- acquire: 0 use: 20239 total: 20239 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685936293 0x1a374d0 --CORE-- acquire: 0 use: 15348 total: 15348 lock stack: ['CORE_ACTION']
+Long wait timestamp:294685989648 0x1a374d0 --CORE-- acquire: 0 use: 18975 total: 18975 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686026277 0x1a374d0 --CORE-- acquire: 0 use: 18153 total: 18153 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686040616 0x1a374d0 --CORE-- acquire: 0 use: 12428 total: 12428 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686090533 0x1a374d0 --CORE-- acquire: 0 use: 35585 total: 35585 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686125041 0x1a374d0 --CORE-- acquire: 0 use: 15840 total: 15840 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686190159 0x1a374d0 --CORE-- acquire: 0 use: 31875 total: 31875 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686224775 0x1a374d0 --CORE-- acquire: 0 use: 10604 total: 10604 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686240681 0x1a374d0 --CORE-- acquire: 2188 use: 105 total: 2293 lock stack: ['LOG']
+Long wait timestamp:294686291147 0x1a374d0 --CORE-- acquire: 0 use: 40716 total: 40716 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686302514 0x1a374d0 --CORE-- acquire: 1071 use: 19 total: 1090 lock stack: ['qd_message_t']
+Long wait timestamp:294686385497 0x1a374d0 --CORE-- acquire: 0 use: 47686 total: 47686 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686401072 0x1a374d0 --CORE-- acquire: 1217 use: 153 total: 1370 lock stack: ['CONN_WORK']
+Long wait timestamp:294686481597 0x1a374d0 --CORE-- acquire: 2983 use: 30 total: 3013 lock stack: ['qd_log_entry_t']
+Long wait timestamp:294686591788 0x1a374d0 --CORE-- acquire: 0 use: 48760 total: 48760 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686680432 0x1a374d0 --CORE-- acquire: 1 use: 46014 total: 46015 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686712268 0x7fcbad72fe60 acquire: 1 use: 15375 total: 15376 lock stack: ['PYTHON']
+Long wait timestamp:294686777935 0x1a374d0 --CORE-- acquire: 0 use: 34235 total: 34235 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686843994 0x1a374d0 --CORE-- acquire: 0 use: 25801 total: 25801 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686889369 0x1a374d0 --CORE-- acquire: 0 use: 11221 total: 11221 lock stack: ['CORE_ACTION']
+Long wait timestamp:294686931747 0x1a374d0 --CORE-- acquire: 1962 use: 10 total: 1972 lock stack: ['LOG', 'qd_log_entry_t']
+Long wait timestamp:294687056996 0x1a374d0 --CORE-- acquire: 0 use: 25437 total: 25437 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687125544 0x1a374d0 --CORE-- acquire: 0 use: 11059 total: 11059 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687244828 0x1a374d0 --CORE-- acquire: 0 use: 22278 total: 22278 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687286423 0x1a374d0 --CORE-- acquire: 0 use: 15553 total: 15553 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687337449 0x1a374d0 --CORE-- acquire: 1 use: 14751 total: 14752 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687376968 0x1a374d0 --CORE-- acquire: 0 use: 12148 total: 12148 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687488170 0x1a374d0 --CORE-- acquire: 0 use: 32837 total: 32837 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687528022 0x1a374d0 --CORE-- acquire: 0 use: 11937 total: 11937 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687592980 0x1a374d0 --CORE-- acquire: 0 use: 51450 total: 51450 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687690586 0x1a374d0 --CORE-- acquire: 0 use: 95474 total: 95474 lock stack: ['CORE_ACTION']
+Long wait timestamp:294687846860 0x1a374d0 --CORE-- acquire: 0 use: 147616 total: 147616 lock stack: ['CORE_ACTION']
+Long wait timestamp:294688390654 0x1a374d0 --CORE-- acquire: 0 use: 541414 total: 541414 lock stack: ['CORE_ACTION']
+Long wait timestamp:294688490015 0x1a374d0 --CORE-- acquire: 0 use: 83876 total: 83876 lock stack: ['CORE_ACTION']
+Long wait timestamp:294688687361 0x1a374d0 --CORE-- acquire: 0 use: 156335 total: 156335 lock stack: ['CORE_ACTION']
+Long wait timestamp:294688850179 0x1a374d0 --CORE-- acquire: 0 use: 160646 total: 160646 lock stack: ['CORE_ACTION']
+Long wait timestamp:294689393085 0x1a374d0 --CORE-- acquire: 0 use: 506271 total: 506271 lock stack: ['CORE_ACTION']
+Long wait timestamp:294689491208 0x1a374d0 --CORE-- acquire: 0 use: 91260 total: 91260 lock stack: ['CORE_ACTION']
+Long wait timestamp:294689690887 0x1a374d0 --CORE-- acquire: 0 use: 197439 total: 197439 lock stack: ['CORE_ACTION']
+Long wait timestamp:294689851701 0x1a374d0 --CORE-- acquire: 0 use: 157742 total: 157742 lock stack: ['CORE_ACTION']
+Long wait timestamp:294690395710 0x1a374d0 --CORE-- acquire: 0 use: 541623 total: 541623 lock stack: ['CORE_ACTION']
+Long wait timestamp:294690493499 0x1a374d0 --CORE-- acquire: 1 use: 89753 total: 89754 lock stack: ['CORE_ACTION']
+Long wait timestamp:294690684179 0x1a374d0 --CORE-- acquire: 0 use: 187541 total: 187541 lock stack: ['CORE_ACTION']
+Long wait timestamp:294691092729 0x1a374d0 --CORE-- acquire: 0 use: 375034 total: 375034 lock stack: ['CORE_ACTION']
+Long wait timestamp:294691397035 0x1a374d0 --CORE-- acquire: 0 use: 297765 total: 297765 lock stack: ['CORE_ACTION']
+Long wait timestamp:294691463297 0x1a374d0 --CORE-- acquire: 0 use: 48214 total: 48214 lock stack: ['CORE_ACTION']
+Long wait timestamp:294691860357 0x1a374d0 --CORE-- acquire: 0 use: 392001 total: 392001 lock stack: ['CORE_ACTION']
+
+Per thread lock summary
+=======================
+
+Thread 0x7fcbad72fe60 
+            , acq:       0, acq:       1, acq:     2-9, acq:   10-99, acq: 100-999, acq:  1k-10k, acq:10k-100k, acq: 100k-1m,       Total
+use: 100k-1m,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:10k-100k,            2,            3,            0,            0,            0,            0,            0,            0,            5
+use:  1k-10k,           42,           10,            0,            1,            1,            1,            0,            0,           55
+use: 100-999,          713,          156,            1,          149,          129,            8,            0,            0,         1156
+use:   10-99,        11426,         1534,          199,         1745,          208,            6,            0,            0,        15118
+use:     2-9,        20128,         1518,          281,          433,           19,            4,            0,            0,        22383
+use:       1,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:       0,            0,            0,            0,            0,            0,            0,            0,            0,            0
+       Total,        32311,         3221,          481,         2328,          357,           19,            0,            0,        38717
+
+Thread 0x1a374d0 --CORE--
+            , acq:       0, acq:       1, acq:     2-9, acq:   10-99, acq: 100-999, acq:  1k-10k, acq:10k-100k, acq: 100k-1m,       Total
+use: 100k-1m,           24,            0,            0,            0,            0,            0,            0,            0,           24
+use:10k-100k,          163,           15,            0,            0,            0,            0,            0,            0,          178
+use:  1k-10k,          456,           58,            0,            6,            4,            0,            0,            0,          524
+use: 100-999,         3347,          534,            7,          551,          342,           12,            0,            0,         4793
+use:   10-99,        35900,         3953,          797,         7037,          624,           26,            0,            0,        48337
+use:     2-9,        49160,         3956,         1615,         1600,           76,            6,            0,            0,        56413
+use:       1,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:       0,            0,            0,            0,            0,            0,            0,            0,            0,            0
+       Total,        89050,         8516,         2419,         9194,         1046,           44,            0,            0,       110269
+
+Thread 0x1a6b210 
+            , acq:       0, acq:       1, acq:     2-9, acq:   10-99, acq: 100-999, acq:  1k-10k, acq:10k-100k, acq: 100k-1m,       Total
+use: 100k-1m,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:10k-100k,            3,            6,            0,            0,            0,            0,            0,            0,            9
+use:  1k-10k,           79,           12,            0,            1,            0,            0,            0,            0,           92
+use: 100-999,          773,          188,            9,          212,          168,            6,            0,            0,         1356
+use:   10-99,        12161,         1771,          246,         2267,          274,           11,            0,            0,        16730
+use:     2-9,        19748,         1580,          407,          651,           33,            2,            0,            0,        22421
+use:       1,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:       0,            0,            0,            0,            0,            0,            0,            0,            0,            0
+       Total,        32764,         3557,          662,         3131,          475,           19,            0,            0,        40608
+
+Thread 0x1a67a90 
+            , acq:       0, acq:       1, acq:     2-9, acq:   10-99, acq: 100-999, acq:  1k-10k, acq:10k-100k, acq: 100k-1m,       Total
+use: 100k-1m,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:10k-100k,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:  1k-10k,           32,           10,            0,            1,            2,            0,            0,            0,           45
+use: 100-999,         1115,          236,            9,          247,          222,           11,            0,            0,         1840
+use:   10-99,        14775,         1915,          321,         2691,          337,           13,            0,            0,        20052
+use:     2-9,        29028,         1977,          643,          672,           34,            1,            0,            0,        32355
+use:       1,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:       0,            0,            0,            0,            0,            0,            0,            0,            0,            0
+       Total,        44950,         4138,          973,         3611,          595,           25,            0,            0,        54292
+
+Thread 0x1a13050 
+            , acq:       0, acq:       1, acq:     2-9, acq:   10-99, acq: 100-999, acq:  1k-10k, acq:10k-100k, acq: 100k-1m,       Total
+use: 100k-1m,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:10k-100k,            4,            1,            0,            0,            0,            0,            0,            0,            5
+use:  1k-10k,           36,           10,            1,            1,            1,            0,            0,            0,           49
+use: 100-999,         1095,          227,            5,          249,          202,           10,            0,            0,         1788
+use:   10-99,        16613,         1884,          390,         3337,          388,           18,            0,            0,        22630
+use:     2-9,        25072,         2043,          802,          810,           46,            5,            0,            0,        28778
+use:       1,            0,            0,            0,            0,            0,            0,            0,            0,            0
+use:       0,            0,            0,            0,            0,            0,            0,            0,            0,            0
+       Total,        42820,         4165,         1198,         4397,          637,           33,            0,            0,        53250
+
+
+Process finished with exit code 0

--- a/src/adaptors/http1/http1_adaptor.c
+++ b/src/adaptors/http1/http1_adaptor.c
@@ -642,7 +642,7 @@ static void qd_http1_adaptor_init(qdr_core_t *core, void **adaptor_context)
     ZERO(adaptor);
     adaptor->core    = core;
     adaptor->log = qd_log_source(QD_HTTP_LOG_SOURCE);
-    adaptor->lock = sys_mutex();
+    adaptor->lock = sys_mutex("HTTP1_ADAPTOR");
     DEQ_INIT(adaptor->listeners);
     DEQ_INIT(adaptor->connectors);
     DEQ_INIT(adaptor->connections);

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -2719,7 +2719,7 @@ static void qdr_http2_adaptor_init(qdr_core_t *core, void **adaptor_context)
                                             qdr_http_conn_trace);
     adaptor->log_source = qd_log_source(QD_HTTP_LOG_SOURCE);
     adaptor->protocol_log_source = qd_log_source("PROTOCOL");
-    adaptor->lock = sys_mutex();
+    adaptor->lock = sys_mutex("HTTP2_ADAPTOR");
     *adaptor_context = adaptor;
     DEQ_INIT(adaptor->listeners);
     DEQ_INIT(adaptor->connectors);

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -936,7 +936,7 @@ static qdr_tcp_connection_t *qdr_tcp_connection_ingress(qd_tcp_listener_t* liste
 {
     qdr_tcp_connection_t* tc = new_qdr_tcp_connection_t();
     ZERO(tc);
-    tc->activation_lock = sys_mutex();
+    tc->activation_lock = sys_mutex("TCP_ACTIVATION");
     tc->ingress = true;
     tc->context.context = tc;
     tc->context.handler = &handle_connection_event;
@@ -1045,7 +1045,7 @@ static qdr_tcp_connection_t *qdr_tcp_connection_egress(qd_tcp_bridge_t *config, 
 {
     qdr_tcp_connection_t* tc = new_qdr_tcp_connection_t();
     ZERO(tc);
-    tc->activation_lock = sys_mutex();
+    tc->activation_lock = sys_mutex("TCP_ACTIVATION");
     if (initial_delivery) {
         tc->egress_dispatcher = false;
         tc->initial_delivery  = initial_delivery;

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -1098,7 +1098,7 @@ static qd_tcp_bridge_t *qd_bridge_config()
     if (!bc) return 0;
     ZERO(bc);
     sys_atomic_init(&bc->ref_count, 1);
-    bc->stats_lock = sys_mutex();
+    bc->stats_lock = sys_mutex("bridge_stats_lock");
     return bc;
 }
 

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -288,7 +288,7 @@ static void qd_alloc_init(qd_alloc_type_desc_t *desc)
         desc->global_pool = NEW(qd_alloc_pool_t);
         DEQ_ITEM_INIT(desc->global_pool);
         init_stack(&desc->global_pool->free_list);
-        desc->lock = sys_mutex();
+        desc->lock = sys_mutex(desc->type_name);
         DEQ_INIT(desc->tpool_list);
 #if QD_MEMORY_STATS
         desc->stats = NEW(qd_alloc_stats_t);
@@ -528,7 +528,7 @@ uint32_t qd_alloc_sequence(void *p)
 
 void qd_alloc_initialize(void)
 {
-    init_lock = sys_mutex();
+    init_lock = sys_mutex("ALLOC_INIT");
     DEQ_INIT(type_list);
 }
 

--- a/src/connection_manager.c
+++ b/src/connection_manager.c
@@ -1079,16 +1079,19 @@ void qd_connection_manager_delete_connector(qd_dispatch_t *qd, void *impl)
         // cannot free the timer while holding ct->lock since the
         // timer callback may be running during the call to qd_timer_free
         qd_timer_t *timer = 0;
+        void *dct = qd_connection_new_qd_deferred_call_t();
         sys_mutex_lock(ct->lock);
         timer = ct->timer;
         ct->timer = 0;
         ct->state = CXTR_STATE_DELETED;
         qd_connection_t *conn = ct->qd_conn;
         if (conn && conn->pn_conn) {
-            qd_connection_invoke_deferred(conn, deferred_close, conn->pn_conn);
+            qd_connection_invoke_deferred_impl(conn, deferred_close, conn->pn_conn, dct);
+            sys_mutex_unlock(ct->lock);
+        } else {
+            sys_mutex_unlock(ct->lock);
+            qd_connection_free_qd_deferred_call_t(dct);
         }
-        sys_mutex_unlock(ct->lock);
-
         qd_timer_free(timer);
         DEQ_REMOVE(qd->connection_manager->connectors, ct);
         qd_connector_decref(ct);

--- a/src/container.c
+++ b/src/container.c
@@ -767,7 +767,7 @@ qd_container_t *qd_container(qd_dispatch_t *qd)
     container->server        = qd->server;
     container->node_type_map = qd_hash(6,  4, 1);  // 64 buckets, item batches of 4
     container->node_map      = qd_hash(10, 32, 0); // 1K buckets, item batches of 32
-    container->lock          = sys_mutex();
+    container->lock          = sys_mutex("CONTAINER");
     container->default_node  = 0;
     DEQ_INIT(container->nodes);
     DEQ_INIT(container->node_type_list);

--- a/src/entity_cache.c
+++ b/src/entity_cache.c
@@ -52,7 +52,7 @@ static sys_mutex_t *event_lock = 0;
 static entity_event_list_t  event_list;
 
 void qd_entity_cache_initialize(void) {
-    event_lock = sys_mutex();
+    event_lock = sys_mutex("ENTITY_CACHE");
     DEQ_INIT(event_list);
 }
 

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -224,7 +224,7 @@ static void work_queue_destroy(work_queue_t *wq) {
 }
 
 static void work_queue_init(work_queue_t *wq) {
-    wq->lock = sys_mutex();
+    wq->lock = sys_mutex("LWS_WORK_QUEUE");
     wq->cond = sys_cond();
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -512,7 +512,7 @@ void qd_log_initialize(void)
     for (level_index_t i = NONE + 1; i < N_LEVELS; ++i)
         aprintf(&begin, end, ", %s", levels[i].name);
 
-    log_source_lock = sys_mutex();
+    log_source_lock = sys_mutex("LOG");
 
     default_log_source = qd_log_source(SOURCE_DEFAULT);
     default_log_source->mask = levels[INFO].mask;

--- a/src/message.c
+++ b/src/message.c
@@ -1002,7 +1002,7 @@ qd_message_t *qd_message()
     }
 
     ZERO(msg->content);
-    msg->content->lock = sys_mutex();
+    msg->content->lock = sys_mutex("MSG_CONTENT");
     sys_atomic_init(&msg->content->ref_count, 1);
     sys_atomic_init(&msg->content->aborted, 0);
     msg->content->parse_depth = QD_DEPTH_NONE;

--- a/src/policy.c
+++ b/src/policy.c
@@ -119,9 +119,9 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->qd                   = qd;
     policy->log_source           = qd_log_source("POLICY");
     policy->max_connection_limit = 65535;
-    policy->tree_lock            = sys_mutex();
+    policy->tree_lock            = sys_mutex("POLICY_TREE");
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
-    stats_lock                   = sys_mutex();
+    stats_lock                   = sys_mutex("POLICY_STATS");
     policy_log_source            = policy->log_source;
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");

--- a/src/posix/threading.c
+++ b/src/posix/threading.c
@@ -17,37 +17,97 @@
  * under the License.
  */
 
-//
-// Enable debug for asserts in this module regardless of what the project-wide
-// setting is.
-//
-#undef NDEBUG
 
 #include "qpid/dispatch/threading.h"
 
 #include "qpid/dispatch/ctools.h"
 
-#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
 #include <pthread.h>
 
+/*
+ * Thread and mutex operations are critical. If any of these operations fail
+ * then the system is in an undefined state. On failure abort the system.
+ */
+#define _CHECK(B) \
+    if (!(B)) {                                                 \
+        fprintf(stderr, "%s:%s:%i: " #B " failed: %s\n",        \
+                __FILE__, __func__, __LINE__, strerror(errno)); \
+        fflush(stderr);                                         \
+        abort();                                                \
+    }
+
+
+#ifdef QD_THREAD_DEBUG
+
+// prevents multiple threads from dumping to I/O at once
+static pthread_mutex_t _debug_lock = PTHREAD_MUTEX_INITIALIZER;
+
+#define QD_THREAD_MAX_LOCKS   16  // simultaineously held locks
+static __thread const char *_held_locks[QD_THREAD_MAX_LOCKS];
+static __thread int _held_index;
+
+static void _dump_locks()
+{
+    pthread_mutex_lock(&_debug_lock);
+    for (int i = 0; i < _held_index; i++) {
+        fprintf(stderr, "%s%s", i ? " ==> " : "LOCKS: ", _held_locks[i]);
+    }
+    fprintf(stderr, "\n");
+    pthread_mutex_unlock(&_debug_lock);
+}
+
+#define TAKE_LOCK(N)                                \
+    do {                                            \
+        assert(_held_index < QD_THREAD_MAX_LOCKS);  \
+        _held_locks[_held_index++] = (N);           \
+        _dump_locks();                              \
+    } while (0)
+
+#define DROP_LOCK(N)                                    \
+    do {                                                \
+        assert(_held_index > 0);                        \
+        const char *old = _held_locks[--_held_index];   \
+        _held_locks[_held_index] = 0;                   \
+        assert(strcmp((N), old) == 0);                  \
+    } while (0);
+
+
+#else
+
+static void _dump_locks() {}
+#define TAKE_LOCK(M)
+#define DROP_LOCK(M)
+
+#endif
+
+
 struct sys_mutex_t {
+    char *name;
     pthread_mutex_t mutex;
 };
 
 
-sys_mutex_t *sys_mutex(void)
+sys_mutex_t *sys_mutex(const char *name)
 {
     sys_mutex_t *mutex = 0;
     NEW_CACHE_ALIGNED(sys_mutex_t, mutex);
-    assert(mutex != 0);
-    pthread_mutex_init(&(mutex->mutex), 0);
+    _CHECK(mutex != 0);
+    mutex->name = qd_strdup(name);
+    int result = pthread_mutex_init(&(mutex->mutex), 0);
+    _CHECK(result == 0);
     return mutex;
 }
 
 
 void sys_mutex_free(sys_mutex_t *mutex)
 {
-    pthread_mutex_destroy(&(mutex->mutex));
+    int result = pthread_mutex_destroy(&(mutex->mutex));
+    _CHECK(result == 0);
+    free(mutex->name);
     free(mutex);
 }
 
@@ -55,14 +115,17 @@ void sys_mutex_free(sys_mutex_t *mutex)
 void sys_mutex_lock(sys_mutex_t *mutex)
 {
     int result = pthread_mutex_lock(&(mutex->mutex));
-    assert(result == 0);
+    _CHECK(result == 0);
+    TAKE_LOCK(mutex->name);
+    _dump_locks();
 }
 
 
 void sys_mutex_unlock(sys_mutex_t *mutex)
 {
+    DROP_LOCK(mutex->name);
     int result = pthread_mutex_unlock(&(mutex->mutex));
-    assert(result == 0);
+    _CHECK(result == 0);
 }
 
 
@@ -75,14 +138,17 @@ sys_cond_t *sys_cond(void)
 {
     sys_cond_t *cond = 0;
     NEW_CACHE_ALIGNED(sys_cond_t, cond);
-    pthread_cond_init(&(cond->cond), 0);
+    _CHECK(cond != 0);
+    int result = pthread_cond_init(&(cond->cond), 0);
+    _CHECK(result == 0);
     return cond;
 }
 
 
 void sys_cond_free(sys_cond_t *cond)
 {
-    pthread_cond_destroy(&(cond->cond));
+    int result = pthread_cond_destroy(&(cond->cond));
+    _CHECK(result == 0);
     free(cond);
 }
 
@@ -90,40 +156,45 @@ void sys_cond_free(sys_cond_t *cond)
 void sys_cond_wait(sys_cond_t *cond, sys_mutex_t *held_mutex)
 {
     int result = pthread_cond_wait(&(cond->cond), &(held_mutex->mutex));
-    assert(result == 0);
+    _CHECK(result == 0);
 }
 
 
 void sys_cond_signal(sys_cond_t *cond)
 {
     int result = pthread_cond_signal(&(cond->cond));
-    assert(result == 0);
+    _CHECK(result == 0);
 }
 
 
 void sys_cond_signal_all(sys_cond_t *cond)
 {
     int result = pthread_cond_broadcast(&(cond->cond));
-    assert(result == 0);
+    _CHECK(result == 0);
 }
 
 
 struct sys_rwlock_t {
+    char *name;
     pthread_rwlock_t lock;
 };
 
 
-sys_rwlock_t *sys_rwlock(void)
+sys_rwlock_t *sys_rwlock(const char *name)
 {
     sys_rwlock_t *lock = NEW(sys_rwlock_t);
-    pthread_rwlock_init(&(lock->lock), 0);
+    lock->name = qd_strdup(name);
+    int result = pthread_rwlock_init(&(lock->lock), 0);
+    _CHECK(result == 0);
     return lock;
 }
 
 
 void sys_rwlock_free(sys_rwlock_t *lock)
 {
-    pthread_rwlock_destroy(&(lock->lock));
+    int result = pthread_rwlock_destroy(&(lock->lock));
+    _CHECK(result == 0);
+    free(lock->name);
     free(lock);
 }
 
@@ -132,6 +203,8 @@ void sys_rwlock_wrlock(sys_rwlock_t *lock)
 {
     int result = pthread_rwlock_wrlock(&(lock->lock));
     assert(result == 0);
+    TAKE_LOCK(lock->name);
+    _dump_locks();
 }
 
 
@@ -139,11 +212,14 @@ void sys_rwlock_rdlock(sys_rwlock_t *lock)
 {
     int result = pthread_rwlock_rdlock(&(lock->lock));
     assert(result == 0);
+    TAKE_LOCK(lock->name);
+    _dump_locks();
 }
 
 
 void sys_rwlock_unlock(sys_rwlock_t *lock)
 {
+    DROP_LOCK(lock->name);
     int result = pthread_rwlock_unlock(&(lock->lock));
     assert(result == 0);
 }

--- a/src/posix/threading.c
+++ b/src/posix/threading.c
@@ -70,8 +70,7 @@ static char *PHONY_IDLE_LOCK_NAME = "CORE_IDLE";
 
 bool _should_bt()
 {
-    // lock-stacks.py blows up when the stack traces are present
-    // so make it easy to turn them on and off.
+    // During experimentation, make it easy to turn on and off.
 #if 0
     return false;
 #else
@@ -90,6 +89,10 @@ bool _should_bt()
 
 void _dump_locks_lock()
 {
+#if 1
+    // Focus on unlock only.
+    return;
+#else
     char buffer[PBUFSIZE];
     char *bufptr = buffer;
     char *end = &buffer[PBUFSIZE];
@@ -112,6 +115,7 @@ void _dump_locks_lock()
     }
     aprintf(&bufptr, end, "]\n");
     fprintf(stderr, "%s", buffer);
+#endif
 }
 
 void _dump_locks_unlock()
@@ -150,7 +154,7 @@ char *_current_lock_name()
 }
 
 
-#define TAKE_LOCK(N, L, A_START, A_GRANTED)                      \
+#define TAKE_LOCK(N, L, A_START, A_GRANTED)                   \
     do {                                                      \
         assert(_held_index < QD_THREAD_MAX_LOCKS);            \
         sys_mutex_debug_t * mtxd = &_held_locks[_held_index]; \

--- a/src/posix/threading.c
+++ b/src/posix/threading.c
@@ -68,12 +68,12 @@ static void _dump_locks_lock()
     char buffer[PBUFSIZE];
     char *bufptr = buffer;
     char *end = &buffer[PBUFSIZE];
-    aprintf(&bufptr, end, "%"PRIu64" TID:%14p ", qd_timer_us_now(), (void*)sys_thread_self());
+    aprintf(&bufptr, end, "%"PRIu64" TID: %14p ", qd_timer_us_now(), (void*)sys_thread_self());
     for (int i = 0; i < _held_index; i++) {
-        aprintf(&bufptr, end, "%s%16s", i ? ", " : "  LOCKS: ", _held_locks[i].name);
+        aprintf(&bufptr, end, "%s%16s", i ? " " : "  LOCK ", _held_locks[i].name);
     }
     const sys_mutex_debug_t *last_locked = &_held_locks[_held_index - 1];
-    aprintf(&bufptr, end, " ==> [LOCK acquire uS: %ld]\n", last_locked->acquire_granted - last_locked->acquire_start);
+    aprintf(&bufptr, end, " ==> [ LOCK acquire_uS %ld ]\n", last_locked->acquire_granted - last_locked->acquire_start);
     fprintf(stderr, "%s", buffer);
 }
 
@@ -82,16 +82,16 @@ static void _dump_locks_unlock()
     char buffer[PBUFSIZE];
     char *bufptr = buffer;
     char *end = &buffer[PBUFSIZE];
-    aprintf(&bufptr, end, "%"PRIu64" TID:%14p ", qd_timer_us_now(), (void*)sys_thread_self());
+    aprintf(&bufptr, end, "%"PRIu64" TID: %14p ", qd_timer_us_now(), (void*)sys_thread_self());
     for (int i = 0; i < _held_index; i++) {
-        aprintf(&bufptr, end, "%s%16s", i ? ", " : "UNLOCKS: ", _held_locks[i].name);
+        aprintf(&bufptr, end, "%s%16s", i ? " " : "UNLOCK ", _held_locks[i].name);
     }
     const sys_mutex_debug_t *last_locked = &_held_locks[_held_index - 1];
     qd_timestamp_us_t acquire = last_locked->acquire_granted  - last_locked->acquire_start;
     qd_timestamp_us_t use     = last_locked->acquire_released - last_locked->acquire_granted;
     qd_timestamp_us_t total   = last_locked->acquire_released - last_locked->acquire_start;
     assert(total < 1000000000);
-    aprintf(&bufptr, end, " <== [UNLOCK acquire: %ld, use: %ld, total:  %ld]\n", acquire, use, total);
+    aprintf(&bufptr, end, " <== [ UNLOCK acquire_uS %ld use %ld total  %ld ]\n", acquire, use, total);
     fprintf(stderr, "%s", buffer);
 }
 

--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -51,7 +51,7 @@ void qd_python_initialize(qd_dispatch_t *qd, const char *python_pkgdir)
 {
     log_source = qd_log_source("PYTHON");
     dispatch = qd;
-    ilock = sys_mutex();
+    ilock = sys_mutex("PYTHON");
     if (python_pkgdir)
         dispatch_python_pkgdir = PyUnicode_FromString(python_pkgdir);
 

--- a/src/remote_sasl.c
+++ b/src/remote_sasl.c
@@ -145,7 +145,7 @@ static qdr_sasl_relay_t* new_qdr_sasl_relay_t(const char* address, const char* s
     }
     instance->proactor = proactor;
     init_permissions(&instance->permissions);
-    instance->lock = sys_mutex();
+    instance->lock = sys_mutex("SASL_RELAY");
     return instance;
 }
 

--- a/src/router_core/agent.c
+++ b/src/router_core/agent.c
@@ -131,7 +131,7 @@ qdr_agent_t *qdr_agent(qdr_core_t *core)
     ZERO(agent);
 
     DEQ_INIT(agent->outgoing_query_list);
-    agent->query_lock  = sys_mutex();
+    agent->query_lock  = sys_mutex("QUERY_LOCK");
     agent->timer = qd_timer(core->qd, qdr_agent_response_handler, core);
     agent->log_source = qd_log_source("AGENT");
     return agent;

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -108,7 +108,7 @@ qdr_connection_t *qdr_connection_opened(qdr_core_t                   *core,
     DEQ_INIT(conn->work_list);
     DEQ_INIT(conn->streaming_link_pool);
     conn->connection_info->role = conn->role;
-    conn->work_lock = sys_mutex();
+    conn->work_lock = sys_mutex("CONN_WORK");
     conn->conn_uptime = core->uptime_ticks;
 
     if (vhost) {

--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -147,7 +147,9 @@ qdr_delivery_t *qdrc_endpoint_delivery_CT(qdr_core_t *core, qdrc_endpoint_t *end
     dlv->delivery_id = next_delivery_id();
     dlv->link_id     = endpoint->link->identity;
     dlv->conn_id     = endpoint->link->conn_id;
-    dlv->dispo_lock  = sys_mutex();
+    char name[64];
+    snprintf(name, sizeof(name), "delivery-%"PRIu32, dlv->delivery_id);
+    dlv->dispo_lock  = sys_mutex(name);
     qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdrc_endpoint_delivery_CT", DLV_ARGS(dlv));
     return dlv;
 }

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -154,7 +154,9 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *in
     out_dlv->delivery_id = next_delivery_id();
     out_dlv->link_id     = out_link->identity;
     out_dlv->conn_id     = out_link->conn_id;
-    out_dlv->dispo_lock  = sys_mutex();
+    char name[64];
+    snprintf(name, sizeof(name), "delivery-%"PRIu32, out_dlv->delivery_id);
+    out_dlv->dispo_lock  = sys_mutex(name);
     qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_forward_new_delivery_CT", DLV_ARGS(out_dlv));
 
     if (in_dlv) {

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -92,12 +92,12 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
     // Set up the threading support
     //
     core->action_cond = sys_cond();
-    core->action_lock = sys_mutex();
+    core->action_lock = sys_mutex("CORE_ACTION");
     core->running     = true;
     DEQ_INIT(core->action_list);
     DEQ_INIT(core->action_list_background);
 
-    core->work_lock = sys_mutex();
+    core->work_lock = sys_mutex("CORE_WORK");
     DEQ_INIT(core->work_list);
     core->work_timer = qd_timer(core->qd, qdr_general_handler, core);
 
@@ -105,7 +105,7 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
     // Set up the unique identifier generator
     //
     core->next_identifier = 1;
-    core->id_lock = sys_mutex();
+    core->id_lock = sys_mutex("CORE_ID");
 
     //
     // Initialize the management agent

--- a/src/router_core/router_core_thread.c
+++ b/src/router_core/router_core_thread.c
@@ -207,6 +207,8 @@ void *router_core_thread(void *arg)
     qdr_action_t      *action;
 
     qd_log(core->log, QD_LOG_INFO, "Router Core thread running. %s/%s", core->router_area, core->router_id);
+    qd_log(core->log, QD_LOG_CRITICAL, "Core thread TID:%14p start. This log timestamp corresponds to lock/unlock report timestamp %"PRIu64,
+           (void*)sys_thread_self(), qd_timer_us_now());
     while (core->running) {
         //
         // Use the lock only to protect the condition variable and the action lists
@@ -256,6 +258,8 @@ void *router_core_thread(void *arg)
         }
     }
 
+    qd_log(core->log, QD_LOG_CRITICAL, "Core thread TID:%14p  exit. This log timestamp corresponds to lock/unlock report timestamp %"PRIu64,
+           (void*)sys_thread_self(), qd_timer_us_now());
     qd_log(core->log, QD_LOG_INFO, "Router Core thread exited");
     return 0;
 }

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -59,7 +59,9 @@ qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterato
     dlv->delivery_id        = next_delivery_id();
     dlv->link_id            = link->identity;
     dlv->conn_id            = link->conn_id;
-    dlv->dispo_lock         = sys_mutex();
+    char name[64];
+    snprintf(name, sizeof(name), "delivery-%"PRIu32, dlv->delivery_id);
+    dlv->dispo_lock         = sys_mutex(name);
     qd_log(link->core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_link_deliver", DLV_ARGS(dlv));
 
     qdr_delivery_incref(dlv, "qdr_link_deliver - newly created delivery, add to action list");
@@ -95,7 +97,9 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
     dlv->delivery_id        = next_delivery_id();
     dlv->link_id            = link->identity;
     dlv->conn_id            = link->conn_id;
-    dlv->dispo_lock         = sys_mutex();
+    char name[64];
+    snprintf(name, sizeof(name), "delivery-%"PRIu32, dlv->delivery_id);
+    dlv->dispo_lock         = sys_mutex(name);
     qd_log(link->core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_link_deliver_to", DLV_ARGS(dlv));
 
     qdr_delivery_incref(dlv, "qdr_link_deliver_to - newly created delivery, add to action list");
@@ -126,7 +130,9 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
     dlv->delivery_id        = next_delivery_id();
     dlv->link_id            = link->identity;
     dlv->conn_id            = link->conn_id;
-    dlv->dispo_lock         = sys_mutex();
+    char name[64];
+    snprintf(name, sizeof(name), "delivery-%"PRIu32, dlv->delivery_id);
+    dlv->dispo_lock         = sys_mutex(name);
     qd_log(link->core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_link_deliver_to_routed_link", DLV_ARGS(dlv));
 
     qdr_delivery_incref(dlv, "qdr_link_deliver_to_routed_link - newly created delivery, add to action list");

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1649,7 +1649,7 @@ qd_router_t *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *are
     router->router_id    = id;
     router->node         = qd_container_set_default_node_type(qd, &router_node, (void*) router, QD_DIST_BOTH);
 
-    router->lock  = sys_mutex();
+    router->lock  = sys_mutex("ROUTER");
     router->timer = qd_timer(qd, qd_router_timer_handler, (void*) router);
 
     sys_atomic_init(&global_delivery_id, 1);

--- a/src/server.c
+++ b/src/server.c
@@ -568,7 +568,7 @@ qd_connection_t *qd_server_connection(qd_server_t *server, qd_server_config_t *c
     if (!ctx) return NULL;
     ZERO(ctx);
     ctx->pn_conn       = pn_connection();
-    ctx->deferred_call_lock = sys_mutex();
+    ctx->deferred_call_lock = sys_mutex("CONN_DEFERRED_CALL");
     ctx->role = strdup(config->role);
     if (!ctx->pn_conn || !ctx->deferred_call_lock || !ctx->role) {
         if (ctx->pn_conn) pn_connection_free(ctx->pn_conn);
@@ -1354,8 +1354,8 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
     qd_server->proactor         = pn_proactor();
     qd_server->container        = 0;
     qd_server->start_context    = 0;
-    qd_server->lock             = sys_mutex();
-    qd_server->conn_activation_lock = sys_mutex();
+    qd_server->lock             = sys_mutex("SERVER");
+    qd_server->conn_activation_lock = sys_mutex("CONN_ACTIVATION");
     qd_server->cond             = sys_cond();
     DEQ_INIT(qd_server->conn_list);
 
@@ -1664,7 +1664,7 @@ qd_connector_t *qd_server_connector(qd_server_t *server)
     sys_atomic_init(&connector->ref_count, 1);
     DEQ_INIT(connector->conn_info_list);
 
-    connector->lock = sys_mutex();
+    connector->lock = sys_mutex("CONNECTOR");
     if (!connector->lock)
         goto error;
     connector->timer = qd_timer(server->qd, try_open_cb, connector);

--- a/src/server.c
+++ b/src/server.c
@@ -935,12 +935,12 @@ STATIC void qd_connection_free(qd_connection_t *qd_conn)
 
     sys_mutex_lock(qd_server->lock);
     DEQ_REMOVE(qd_server->conn_list, qd_conn);
+    sys_mutex_unlock(qd_server->lock);
 
     // If counted for policy enforcement, notify it has closed
     if (qd_conn->policy_counted) {
         qd_policy_socket_close(qd_server->qd->policy, qd_conn);
     }
-    sys_mutex_unlock(qd_server->lock);
 
     invoke_deferred_calls(qd_conn, true);  // Discard any pending deferred calls
     sys_mutex_free(qd_conn->deferred_call_lock);

--- a/src/server.c
+++ b/src/server.c
@@ -565,11 +565,13 @@ STATIC void connection_wake(qd_connection_t *ctx) {
     if (ctx->pn_conn) pn_connection_wake(ctx->pn_conn);
 }
 
-/* Construct a new qd_connection. Thread safe. */
-qd_connection_t *qd_server_connection(qd_server_t *server, qd_server_config_t *config)
+/* Construct a new qd_connection. Thread safe.
+ * Does not allocate any managed objects and therefore
+ * does not take ENTITY_CACHE lock.
+ */
+qd_connection_t *qd_server_connection_impl(qd_server_t *server, qd_server_config_t *config, qd_connection_t *ctx)
 {
-    qd_connection_t *ctx = new_qd_connection_t();
-    if (!ctx) return NULL;
+    assert(ctx);
     ZERO(ctx);
     ctx->pn_conn       = pn_connection();
     ctx->deferred_call_lock = sys_mutex("CONN_DEFERRED_CALL");
@@ -578,7 +580,7 @@ qd_connection_t *qd_server_connection(qd_server_t *server, qd_server_config_t *c
         if (ctx->pn_conn) pn_connection_free(ctx->pn_conn);
         if (ctx->deferred_call_lock) sys_mutex_free(ctx->deferred_call_lock);
         free(ctx->role);
-        free(ctx);
+        free_qd_connection_t(ctx);
         return NULL;
     }
     ctx->server = server;
@@ -595,6 +597,16 @@ qd_connection_t *qd_server_connection(qd_server_t *server, qd_server_config_t *c
     return ctx;
 }
 
+/* Construct a new qd_connection. Thread safe.
+ * Allocates a qd_connection_t object and therefore
+ * takes ENTITY_CACHE lock.
+ */
+qd_connection_t *qd_server_connection(qd_server_t *server, qd_server_config_t *config)
+{
+    qd_connection_t *ctx = new_qd_connection_t();
+    if (!ctx) return NULL;
+    return qd_server_connection_impl(server, config, ctx);
+}
 
 STATIC void on_accept(pn_event_t *e, qd_listener_t *listener)
 {
@@ -1160,11 +1172,10 @@ STATIC qd_failover_item_t *qd_connector_get_conn_info(qd_connector_t *ct) {
 
 
 /* Timer callback to try/retry connection open */
-STATIC void try_open_lh(qd_connector_t *connector)
+STATIC void try_open_lh(qd_connector_t *connector, qd_connection_t *connection)
 {
-    // Allocate a new connection. No other thread will touch this
     // connection until pn_proactor_connect is called below
-    qd_connection_t *qd_conn = qd_server_connection(connector->server, &connector->config);
+    qd_connection_t *qd_conn = qd_server_connection_impl(connector->server, &connector->config, connection);
     if (!qd_conn) {                 /* Try again later */
         qd_log(connector->server->log_source, QD_LOG_CRITICAL, "Allocation failure connecting to %s",
                connector->config.host_port);
@@ -1327,12 +1338,24 @@ STATIC void try_open_cb(void *context)
 {
     qd_connector_t *ct = (qd_connector_t*) context;
 
-    sys_mutex_lock(ct->lock);   /* TODO aconway 2017-05-09: this lock looks too big */
+    // Allocate connection before taking connector lock to avoid
+    // CONNECTOR - ENTITY_CACHE lock inversion deadlock window.
+    qd_connection_t *ctx = new_qd_connection_t();
+    if (!ctx) {
+        qd_log(ct->server->log_source, QD_LOG_CRITICAL, "Allocation failure connecting to %s",
+               ct->config.host_port);
+        ct->delay = 10000;
+        ct->state = CXTR_STATE_CONNECTING;
+        qd_timer_schedule(ct->timer, ct->delay);
+        return;
+    }
+
+    sys_mutex_lock(ct->lock);
 
     if (ct->state == CXTR_STATE_CONNECTING || ct->state == CXTR_STATE_INIT) {
         // else deleted or failed - on failed wait until after connection is freed
         // and state is set to CXTR_STATE_CONNECTING (timer is rescheduled then)
-        try_open_lh(ct);
+        try_open_lh(ct, ctx);
     }
 
     sys_mutex_unlock(ct->lock);
@@ -1588,7 +1611,16 @@ void qd_connection_invoke_deferred(qd_connection_t *conn, qd_deferred_t call, vo
     if (!conn)
         return;
 
-    qd_deferred_call_t *dc = new_qd_deferred_call_t();
+    qd_connection_invoke_deferred_impl(conn, call, context, new_qd_deferred_call_t());
+}
+
+
+void qd_connection_invoke_deferred_impl(qd_connection_t *conn, qd_deferred_t call, void *context, void *dct)
+{
+    if (!conn)
+        return;
+
+    qd_deferred_call_t *dc = (qd_deferred_call_t*)dct;
     DEQ_ITEM_INIT(dc);
     dc->call    = call;
     dc->context = context;
@@ -1600,6 +1632,18 @@ void qd_connection_invoke_deferred(qd_connection_t *conn, qd_deferred_t call, vo
     sys_mutex_lock(conn->server->conn_activation_lock);
     qd_server_activate(conn);
     sys_mutex_unlock(conn->server->conn_activation_lock);
+}
+
+
+void *qd_connection_new_qd_deferred_call_t()
+{
+    return new_qd_deferred_call_t();
+}
+
+
+void qd_connection_free_qd_deferred_call_t(void *dct)
+{
+    free_qd_deferred_call_t((qd_deferred_call_t *)dct);
 }
 
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -210,6 +210,15 @@ qd_timestamp_t qd_timer_now()
     return ((qd_timestamp_t)tv.tv_sec) * 1000 + tv.tv_nsec / 1000000;
 }
 
+
+qd_timestamp_us_t qd_timer_us_now()
+{
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    return ((qd_timestamp_t)tv.tv_sec) * 1000000 + tv.tv_nsec / 1000;
+}
+
+
 void qd_timer_schedule(qd_timer_t *timer, qd_duration_t duration)
 {
     sys_mutex_lock(lock);

--- a/src/trace_mask.c
+++ b/src/trace_mask.c
@@ -43,7 +43,7 @@ struct qd_tracemask_t {
 qd_tracemask_t *qd_tracemask(void)
 {
     qd_tracemask_t *tm = NEW(qd_tracemask_t);
-    tm->lock               = sys_rwlock();
+    tm->lock               = sys_rwlock("TRACE_MASK");
     tm->hash               = qd_hash(8, 1, 0);
     tm->router_by_mask_bit = NEW_PTR_ARRAY(qdtm_router_t, qd_bitmask_width());
 

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -486,8 +486,8 @@ class Qdrouterd(Process):
         if not default_log:
             self.logfile = "%s.log" % name
             config.append(
-                ('log', {'module': 'DEFAULT', 'enable': 'trace+',
-                         'includeSource': 'true', 'outputFile': self.logfile}))
+                ('log', {'module': 'DEFAULT', 'enable': 'info+',
+                         'includeSource': 'false', 'outputFile': self.logfile}))
         else:
             self.logfile = default_log[0][1].get('outputfile')
         args = ['qdrouterd', '-c', config.write(name)] + cl_args

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -486,7 +486,7 @@ class Qdrouterd(Process):
         if not default_log:
             self.logfile = "%s.log" % name
             config.append(
-                ('log', {'module': 'DEFAULT', 'enable': 'info+',
+                ('log', {'module': 'DEFAULT', 'enable': 'trace+',
                          'includeSource': 'false', 'outputFile': self.logfile}))
         else:
             self.logfile = default_log[0][1].get('outputfile')

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -63,7 +63,7 @@ void *thread_id_thread(void *arg)
 //
 static char *test_thread_id(void *context)
 {
-    mutex = sys_mutex();
+    mutex = sys_mutex("TEST_TID");
     sys_mutex_lock(mutex);
 
     // start threads and retain their addresses
@@ -132,7 +132,7 @@ void *test_condition_thread(void *arg)
 
 static char *test_condition(void *context)
 {
-    mutex = sys_mutex();
+    mutex = sys_mutex("TEST_COND");
     cond = sys_cond();
 
     sys_mutex_lock(mutex);

--- a/tests/threaded_timer_test.c
+++ b/tests/threaded_timer_test.c
@@ -75,7 +75,7 @@ static struct event_t {
 
 static void test_setup()
 {
-    event.m = sys_mutex();
+    event.m = sys_mutex("TEST_EVENT");
     event.c = sys_cond();
 }
 
@@ -447,7 +447,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    ticker_lock = sys_mutex();
+    ticker_lock = sys_mutex("TEST_TICKER");
     
     sys_thread_t *ticker = sys_thread(ticker_thread, 0);
 

--- a/tools/lock-analyzer.py
+++ b/tools/lock-analyzer.py
@@ -321,6 +321,9 @@ def main_except(argv):
     p.add_argument('--verbose',
                    action='store_true',
                    help='Show suppressed mutex data: disposition locks')
+    p.add_argument('--core-thread-only',
+                   action='store_true',
+                   help='Tables show core thread activity only')
     p.add_argument("--include-start-stop",
                    action='store_true',
                    help='Normally the mutex activity during router server startup and shutdown is excluded. This switch includes it.')
@@ -389,6 +392,9 @@ def main_except(argv):
                         # always add to kept structure
                         core_thread_core_idle.add(acquire, use)
                         do_this = args.include_core_idle
+                else:
+                    if args.core_thread_only:
+                        do_this = False
                 if do_this:
                     if tid not in thread_data:
                         thread_data[tid] = StatsStorage(common, "Thread", title, len(thread_data))
@@ -404,7 +410,7 @@ def main_except(argv):
                     common.deliveries_hidden += 1
 
                 # Collect interesting lines
-                if is_interesting(common, acquire, use, lock_name, is_core, args.include_core_idle):
+                if do_this and is_interesting(common, acquire, use, lock_name, is_core, args.include_core_idle):
                     interesting_lines.append(fields)
 
     print()
@@ -414,6 +420,7 @@ def main_except(argv):
 
     print("CLI infile  : %s" % os.path.abspath(args.infile))
     print("CLI logfile : %s" % os.path.abspath(args.logfile))
+    print("CLI selects %s" % ("CORE thread only" if args.core_thread_only else "all threads"))
     print()
 
     start_ticks = int(common.collection_times_first)

--- a/tools/lock-analyzer.py
+++ b/tools/lock-analyzer.py
@@ -29,6 +29,9 @@ import os
 import sys
 import traceback
 
+from datetime import timedelta
+from datetime import datetime
+
 """
 This program accepts a filename for a thread-debug-cr4 .out file and produces 
 a summary of the lock patterns.
@@ -45,133 +48,321 @@ Input for a thread locking and unlocking two locks:
   255398575188 TID:0x7ff9097bee60 UNLOCK              LOG     ENTITY_CACHE <== [ UNLOCK acquire_uS 0 use 6 total  6 ]
   255398575193 TID:0x7ff9097bee60 UNLOCK              LOG <== [ UNLOCK acquire_uS 1 use 49 total  50 ]
 
-The v0 goal of this program is to produce a csv text for importing into a spreadsheet and then
-to be displayed as numbers or as a graph. 
-* The rows are buckets of lock-acquire times, the columns are buckets of lock-total times, 
-  and the values are counts of mutex lock-unlock observations for the bucket.
-* Separate csv sections are produced for each thread.
+A special log line reveals the core TID and has two timestamps: the normal log timestamp
+and the monotonic uS timestamp. From the timestamps a base time is computed.
+  base_time = full_log_timestamp - monotonic_uS
+  
+Then the base time is used to convert the lock/unlock uS values into human-readable full log timestamps.
+
+# Server preface with container name
+2021-06-17 21:23:42.747976 -0400 SERVER (info) Container Name: A (/home/chug/git/qpid-dispatch/src/server.c:1373)
+
+# Router is started
+2021-06-17 21:23:42.768158 -0400 SERVER (notice) Operational, 4 Threads Running (process ID 221746) (/home
+
+# Router is stopping
+2021-06-17 21:24:00.328465 -0400 SERVER (notice) Shut Down (/home
+
 """
 
-FLD_TIMESTAMP  = 0
-FLD_TID_TXT    = 1
-FLD_TID        = 2
-FLD_L_OR_UNL   = 3
-FLD_FIRST_LOCK = 4
-FLD_LAST_LOCK  = -10
-FLD_ACQUIRE    = -6
-FLD_USE        = -4
-FLD_CLOSE      = -1
+class Common():
+    FLD_TIMESTAMP  = 0
+    FLD_TID_TXT    = 1
+    FLD_TID        = 2
+    FLD_L_OR_UNL   = 3
+    FLD_FIRST_LOCK = 4
+    FLD_LAST_LOCK  = -10
+    FLD_ACQUIRE    = -6
+    FLD_USE        = -4
+    FLD_CLOSE      = -1
 
-REASONABLE_LOCK_CUTOFF = 10000  # lock transaction totals .gt. this are unreasonable
+    INTERESTING_ACQUIRE_THRESHOLD = 10000
+    INTERESTING_USE_THRESHOLD     = 10000
+    INTERESTING_CORE_ACQUIRE      = 1000
+    INTERESTING_CORE_USE          = 5000
 
-# CSV buckets for acq: acquisition and use: usage
-BUCKET_LIMITS = [0, 1, 10, 100, 1000, 10000, 100000, 1000000]
-BUCKET_LIMITS_LEN = len(BUCKET_LIMITS)
+    # CSV buckets for acq: acquisition and use: usage
+    BUCKET_LIMITS = [0, 1, 10, 100, 1000, 10000, 100000, 1000000]
+    BUCKET_LIMITS_LEN = len(BUCKET_LIMITS)
 
-# Try to make raw csv output legible in on its own
-# A column or row title consists of "acq:" or "use:" plus the title text
-CSV_COL_WIDTH = 12
-CSV_TITLE_WIDTH = 8
-TITLE_BLANK = ' ' * CSV_COL_WIDTH
-TITLES = ["       0", "       1", "     2-9", "   10-99",
-          " 100-999", "  1k-10k", "10k-100k", " 100k-1m"]
-TITLE_TOTAL = "       Total"
+    # Try to make raw csv output legible in on its own
+    # A column or row title consists of "acq:" or "use:" plus the title text
+    CSV_COL_WIDTH = 12
+    CSV_TITLE_WIDTH = 8
+    TITLE_BLANK = ' ' * CSV_COL_WIDTH
+    TITLE_TOP_LEFT = " acquire uS:"
+    TITLES = ["       0", "       1", "     2-9", "   10-99",
+              " 100-999", "  1k-10k", "10k-100k", " 100k-1m"]
+    TITLE_TOTAL = "       Total"
 
-class PerThread(object):
+    # Lock pseudo log file header for Scraper
+    LOCK_SERVER_CONTAINER_LINE = None
+
+    # Locating server start and stop in router log file
+    SERVER_START_CONTENT = 'SERVER (notice) Operational'
+    SERVER_STOP_CONTENT  = 'SERVER (notice) Shut Down'
+
+    # Discovered server start and stop times
+    START_DATETIME = None
+    STOP_DATETIME = None
+
+    # Locating the core thread TID and timestamps in the router log file
+    CORE_THREAD_TID_CONTENT = "(critical) Core thread TID:"
+
+    # Core TID specified in command line or discovered in router log file
+    CORE_TID = None
+    # Computed from timestamps in core_thread_tid log line
+    BASE_DATETIME = None
+
+    deliveries_hidden = 0  # Show with --verbose CLI arg
+
+class StatsStorage(object):
     """
     Store per-thread array of counts
     """
-
-    def __init__(self, threadId, is_core):
-        self.tid = threadId
-        self.buckets = [[0 for i in range(BUCKET_LIMITS_LEN)] for j in range(BUCKET_LIMITS_LEN)]
-        self.is_core = is_core
+    def __init__(self, common, store_type, title, numericId):
+        self.common = common
+        self.store_type = store_type  # 'Thread' or 'Mutex'
+        self.title = title
+        self.numeric_id = numericId  # simple int
+        self.buckets = [[0 for i in range(self.common.BUCKET_LIMITS_LEN)]
+                           for j in range(self.common.BUCKET_LIMITS_LEN)]
+        self.total_acquire = 0
+        self.total_use = 0
 
     def bucket_of(self, value):
-        for i in range(BUCKET_LIMITS_LEN):
-            if value <= BUCKET_LIMITS[i]:
+        for i in range(self.common.BUCKET_LIMITS_LEN):
+            if value <= self.common.BUCKET_LIMITS[i]:
                 return i
         print("Questionable lock/hold value: %d" % value)
-        return BUCKET_LIMITS_LEN
+        return self.common.BUCKET_LIMITS_LEN
 
-    def add(self, useconds, tid, acquire, use, lock_stack=[]):
+    def add(self, acquire, use):
         col = self.bucket_of(acquire)
         row = self.bucket_of(use)
         self.buckets[col][row] += 1
-        if acquire >= REASONABLE_LOCK_CUTOFF or use >= REASONABLE_LOCK_CUTOFF or \
-                (self.is_core and acquire >= 1000):
-            core_id = " --CORE--" if self.is_core else ""
-            print("Long wait timestamp:%d %s%s acquire: %d use: %d total: %d lock stack: %s" %
-                  (useconds, tid, core_id, acquire, use, acquire + use, lock_stack))
+        self.total_acquire += acquire
+        self.total_use += use
 
-    def dump(self):
-        print("Thread %s %s" % (self.tid, "--CORE--" if self.is_core else ""))
-        print(TITLE_BLANK + ',', end='')
-        for col in range(BUCKET_LIMITS_LEN):
-            print (" acq:%s," % (TITLES[col]), end='')
-        print(TITLE_TOTAL)
+    def dump(self, title_prefix):
+        print()
+        print("%s %s - total acquire uS: %d, total use uS: %s" %
+              (title_prefix, self.title, self.total_acquire, self.total_use))
+        print()
+        print(self.common.TITLE_TOP_LEFT + ',', end='')
+        for col in range(self.common.BUCKET_LIMITS_LEN):
+            print ("     %s," % (self.common.TITLES[col]), end='')
+        print(' ' + self.common.TITLE_TOTAL)
 
-        for row in range(BUCKET_LIMITS_LEN-1, -1, -1):
-            print("use:%s, " % (TITLES[row]), end='')
+        for row in range(self.common.BUCKET_LIMITS_LEN-1, 0, -1):
+            print("use:%s, " % (self.common.TITLES[row]), end='')
             rtotal = 0
-            for col in range(BUCKET_LIMITS_LEN):
+            for col in range(self.common.BUCKET_LIMITS_LEN):
                 print("%12d, " % (self.buckets[col][row]), end='')
                 rtotal += self.buckets[col][row]
             print("%12d" % rtotal)
+            # Does 'use: 1' ever print anything? If not then suppress it
+            if row == 1:
+                assert rtotal == 0
 
         gtotal = 0
-        print(TITLE_TOTAL + ', ', end='')
-        for col in range(BUCKET_LIMITS_LEN):
+        print(self.common.TITLE_TOTAL + ', ', end='')
+        for col in range(self.common.BUCKET_LIMITS_LEN):
             ctotal = 0
-            for row in range(BUCKET_LIMITS_LEN):
+            for row in range(self.common.BUCKET_LIMITS_LEN):
                 ctotal += self.buckets[col][row]
             print("%12d, " % ctotal, end='')
             gtotal += ctotal
         print("%12d" % gtotal)
 
 
+def usec_log_timestamp(common, usecs):
+    ntime = common.BASE_DATETIME + timedelta(microseconds=usecs)
+    return ntime.strftime('%Y-%m-%d %H:%M:%S.%f')
+
+
+def process_core_line(common, line):
+    # Derive core TID and offset from a log line
+    # 2021-06-17 21:23:42.750591 -0400 ROUTER_CORE (critical) Core thread TID:     0x1a374d0 start. This log timestamp corresponds to lock/unlock report timestamp 294674283709 (/home ...
+    line_time = datetime.strptime(line[:26], '%Y-%m-%d %H:%M:%S.%f')
+    tid_pos = line.find(common.CORE_THREAD_TID_CONTENT) + len(common.CORE_THREAD_TID_CONTENT)
+    core_tid = line[tid_pos:tid_pos + 14].strip()
+    ts_pos = line.find("report timestamp ")
+    ts = line[ts_pos:].split()[2]
+    t_offset = int(ts)
+    dt_delta = timedelta(microseconds=t_offset)
+    base_time = line_time - dt_delta
+    return core_tid, base_time
+
+
+def process_logfile(common, filename, container_name):
+    '''
+    If the router log file exists: Find core thread ID and the timestamp
+    deltas between the log timestamp and the thread-debug uS timestamp.
+    Find the "router started" and "router shutting down"
+    timestamps so that local analysis may exclude insane lock hold times
+    before startup and after shutdown.
+    :param filename:
+    :return: (core-TID, timestamp_delta)
+    '''
+    # This log line defines the core TID and offsets
+    governing_log_line = None
+
+    # Derived core TID and offset
+    core_tid = None
+    base_dt = None
+
+    with open(filename) as f:
+        # Construct the header line required by scraper
+        # Grab the timestamp from the first line of the router log
+        line = f.readline()
+        common.LOCK_SERVER_CONTAINER_LINE = \
+            line[:26] + " SERVER (info) Container Name: " + container_name + " (/home)"
+
+        for line in f:
+            if common.CORE_THREAD_TID_CONTENT in line:
+                if common.CORE_TID is None:
+                    # Accept first instance
+                    (common.CORE_TID, common.BASE_DATETIME) = process_core_line(common, line)
+                else:
+                    # Remaining instances must match to prevent multiple router
+                    # runs piling differing values into the same router log file.
+                    core_tid, base_dt = process_core_line(common, line)
+                    delta = timedelta(microseconds=100) # seen two timestamps vary by < 10 uS. Apply some slop.
+                    assert base_dt < common.BASE_DATETIME + delta
+                    assert base_dt > common.BASE_DATETIME - delta
+            elif common.SERVER_START_CONTENT in line:
+                assert common.START_DATETIME is None
+                common.START_DATETIME = datetime.strptime(line[:26], '%Y-%m-%d %H:%M:%S.%f')
+            elif common.SERVER_STOP_CONTENT in line:
+                assert common.STOP_DATETIME is None
+                common.STOP_DATETIME = datetime.strptime(line[:26], '%Y-%m-%d %H:%M:%S.%f')
+
+
+def is_interesting(common, acquire, use, is_core):
+    if is_core:
+        return acquire >= common.INTERESTING_CORE_ACQUIRE or use >= common.INTERESTING_CORE_USE
+    else:
+        return acquire >= common.INTERESTING_ACQUIRE_THRESHOLD or use >= common.INTERESTING_USE_THRESHOLD
+
+
 def main_except(argv):
 
     p = argparse.ArgumentParser()
-    p.add_argument('--outfile', '-o',
-                   help='Required thread-debug .out filename')
-    p.add_argument('--core-tid',
-                   help='Optional core thread ID')
+    p.add_argument('--infile', '-i',
+                   help='Required thread-debug .out filename which is input to this progrqm')
+    p.add_argument('--logfile', '-l',
+                   help="Optional router .log filename which is input to this program")
+    p.add_argument('--verbose',
+                   action='store_true',
+                   help='Show suppressed mutex data')
     del argv[0]
     args = p.parse_args(argv)
 
-    if args.outfile is None:
-        raise Exception("User must specify --outfile filename")
+    if args.infile is None:
+        raise Exception("User must specify --infile filename")
+    if args.logfile is None:
+        raise Exception("User must specify --logfile filename")
+
+    common = Common()
+
+    basename = os.path.basename(args.infile)
+    process_logfile(common, args.logfile, os.path.splitext(basename)[0])
 
     thread_data = {}
     lock_data = {}
+    interesting_lines = []  # lines split into fields
 
-    with open(args.outfile) as f:
-        print("Exceptional observations made during processing")
-        print("===============================================")
-        print()
+    with open(args.infile) as f:
         for line in f:  # files are routinely > 1 gigabyte. heads up.
             fields = line.split(' ')
             fields = [x for x in fields if x]
-            if fields[FLD_L_OR_UNL] == "UNLOCK":
-                ts = int(fields[FLD_TIMESTAMP])  # uS from arbitrary starting point
-                tid = fields[FLD_TID]  # thread ID
+            if fields[common.FLD_L_OR_UNL] == "UNLOCK":
+                # Thread id
+                tid = fields[common.FLD_TID]  # thread ID
+                is_core = tid == common.CORE_TID
+
+                # Lock usage
+                acquire = int(fields[common.FLD_ACQUIRE])
+                use = int(fields[common.FLD_USE])
+
+                # Accumulate per thread
                 if not tid in thread_data:
-                    is_core = tid == args.core_tid
-                    thread_data[tid] = PerThread(tid, is_core)
-                assert (fields[FLD_CLOSE] == "]\n" )
-                acquire = int(fields[FLD_ACQUIRE])
-                use = int(fields[FLD_USE])
-                lock_stack = fields[FLD_FIRST_LOCK:FLD_LAST_LOCK]
-                thread_data[tid].add(ts, tid, acquire, use, lock_stack)
+                    title = "%s #%d" % (tid, len(thread_data))
+                    if is_core:
+                        title += " CORE"
+                    thread_data[tid] = StatsStorage(common, "Thread", title, len(thread_data))
+                thread_data[tid].add(acquire, use)
+
+                # Accumulate per mutex
+                lock_stack = fields[common.FLD_FIRST_LOCK:common.FLD_LAST_LOCK]
+                lock_name = lock_stack[-1]
+                if args.verbose or not lock_name.startswith("delivery-"):
+                    if not lock_name in lock_data:
+                        title = "%s #%d" % (lock_name, len(lock_data))
+                        lock_data[lock_name] = StatsStorage(common, "Mutex", title, len(lock_data))
+                    lock_data[lock_name].add(acquire, use)
+                else:
+                    common.deliveries_hidden += 1
+
+                # Collect interesting lines
+                if is_interesting(common, acquire, use, is_core):
+                    interesting_lines.append(fields)
 
     print()
     print("Per thread lock summary")
     print("=======================")
     print()
     for key, value in thread_data.items():
-        value.dump()
+        value.dump("Thread")
         print("")
+
+    print()
+    print("Per mutex lock summary")
+    print("=======================")
+    print()
+
+    for key, value in lock_data.items():
+        value.dump("Mutex")
+    if common.deliveries_hidden > 0:
+        print("\nDelivery mutex lock summaries hidden: %d. Expose with --verbose CLI arg." % common.deliveries_hidden)
+
+    print()
+    print("Interesting observations made during processing")
+    print("===============================================")
+    print()
+
+    for fields in interesting_lines:
+        ts = int(fields[common.FLD_TIMESTAMP])  # uS from arbitrary starting point like last boot
+        tid = fields[common.FLD_TID]  # thread ID
+        if tid == common.CORE_TID:
+            tid = fields[common.FLD_TID] + " CORE"
+        acquire = int(fields[common.FLD_ACQUIRE])
+        use = int(fields[common.FLD_USE])
+        lock_stack = fields[common.FLD_FIRST_LOCK:common.FLD_LAST_LOCK]
+        print("%s %d Thread %s: acquire:%6d, use:%6d, total:%6d, locks:%s" %
+              (usec_log_timestamp(common, ts), ts, tid, acquire, use, acquire+use, lock_stack))
+
+    print()
+    print("Interesting observations in logfile format")
+    print("==========================================")
+    print()
+    print("%s" % common.LOCK_SERVER_CONTAINER_LINE)  # Required for scraper
+    for fields in interesting_lines:
+        ts = int(fields[common.FLD_TIMESTAMP])  # uS from arbitrary starting point like last boot
+        tid = fields[common.FLD_TID]  # thread ID
+        if tid == common.CORE_TID:
+            tid = fields[common.FLD_TID] + " CORE"
+        acquire = int(fields[common.FLD_ACQUIRE])
+        use = int(fields[common.FLD_USE])
+        lock_stack = fields[common.FLD_FIRST_LOCK:common.FLD_LAST_LOCK]
+        start_lock = usec_log_timestamp(common, ts - acquire - use)
+        locked     = usec_log_timestamp(common, ts - use)
+        end_lock   = usec_log_timestamp(common, ts)
+        lock_time = "acquire: %d use: %d total: %d" % (acquire, use, acquire + use)
+        print("%s LOCK (notice) %d %s mutex_lock    start %s %s" % (start_lock, ts - acquire - use, tid, lock_stack, lock_time))
+        print("%s LOCK (notice) %d %s mutex_lock acquired %s %s" % (locked,     ts - use          , tid, lock_stack, lock_time))
+        print("%s LOCK (notice) %d %s mutex_lock released %s %s" % (end_lock,   ts                , tid, lock_stack, lock_time))
 
 
 def main(argv):

--- a/tools/lock-analyzer.py
+++ b/tools/lock-analyzer.py
@@ -32,7 +32,7 @@ import traceback
 from datetime import timedelta
 from datetime import datetime
 
-"""
+design_doc = '''
 This program accepts a filename for a thread-debug-cr4 .out file and produces 
 a summary of the lock patterns.
 
@@ -51,19 +51,19 @@ Input for a thread locking and unlocking two locks:
 A special log line reveals the core TID and has two timestamps: the normal log timestamp
 and the monotonic uS timestamp. From the timestamps a base time is computed.
   base_time = full_log_timestamp - monotonic_uS
-  
+
 Then the base time is used to convert the lock/unlock uS values into human-readable full log timestamps.
 
 # Server preface with container name
 2021-06-17 21:23:42.747976 -0400 SERVER (info) Container Name: A (/home/chug/git/qpid-dispatch/src/server.c:1373)
 
 # Router is started
-2021-06-17 21:23:42.768158 -0400 SERVER (notice) Operational, 4 Threads Running (process ID 221746) (/home
+2021-06-17 21:23:42.768158 -0400 SERVER (notice) Operational, 4 Threads Running (process ID 221746) (/home)
 
 # Router is stopping
-2021-06-17 21:24:00.328465 -0400 SERVER (notice) Shut Down (/home
+2021-06-17 21:24:00.328465 -0400 SERVER (notice) Shut Down (/home)
+'''
 
-"""
 
 class Common():
     FLD_TIMESTAMP  = 0
@@ -82,7 +82,7 @@ class Common():
     INTERESTING_CORE_USE          = 5000
 
     # CSV buckets for acq: acquisition and use: usage
-    BUCKET_LIMITS = [0, 1, 10, 100, 1000, 10000, 100000, 1000000]
+    BUCKET_LIMITS = [0, 1, 10, 100, 1000, 10000, 100000, 10000000]
     BUCKET_LIMITS_LEN = len(BUCKET_LIMITS)
 
     # Try to make raw csv output legible in on its own
@@ -92,7 +92,7 @@ class Common():
     TITLE_BLANK = ' ' * CSV_COL_WIDTH
     TITLE_TOP_LEFT = " acquire uS:"
     TITLES = ["       0", "       1", "     2-9", "   10-99",
-              " 100-999", "  1k-10k", "10k-100k", " 100k-1m"]
+              " 100-999", "  1k-10k", "10k-100k", "100k-10m"]
     TITLE_TOTAL = "       Total"
 
     # Lock pseudo log file header for Scraper
@@ -106,15 +106,31 @@ class Common():
     START_DATETIME = None
     STOP_DATETIME = None
 
+    # Computed server start and stop uS timestamps
+    # Required to exclude router startup and shutdown unusual mutex
+    # lock patterns.
+    START_US = None
+    STOP_US = None
+
     # Locating the core thread TID and timestamps in the router log file
     CORE_THREAD_TID_CONTENT = "(critical) Core thread TID:"
+
+    # Locating phony lock that tracks core thread idle time via cond_wait
+    CORE_THREAD_IDLE_LOCK = "CORE_IDLE"
 
     # Core TID specified in command line or discovered in router log file
     CORE_TID = None
     # Computed from timestamps in core_thread_tid log line
     BASE_DATETIME = None
 
-    deliveries_hidden = 0  # Show with --verbose CLI arg
+    deliveries_hidden = 0     # Show with CLI arg --verbose
+    start_stop_hidden = 0     # Show with CLI arg --include-start-stop
+
+    collection_times_first = 0
+    collection_times_last = 0
+
+    total_duration = 0  # uS int
+
 
 class StatsStorage(object):
     """
@@ -125,65 +141,109 @@ class StatsStorage(object):
         self.store_type = store_type  # 'Thread' or 'Mutex'
         self.title = title
         self.numeric_id = numericId  # simple int
-        self.buckets = [[0 for i in range(self.common.BUCKET_LIMITS_LEN)]
-                           for j in range(self.common.BUCKET_LIMITS_LEN)]
-        self.total_acquire = 0
-        self.total_use = 0
+        # buckets holds event counts, buckets_us holds accumulated times in microseconds
+        self.buckets = [[0 for i in range(common.BUCKET_LIMITS_LEN)] for j in range(common.BUCKET_LIMITS_LEN)]
+        self.buckets_us = [[0 for i in range(common.BUCKET_LIMITS_LEN)] for j in range(common.BUCKET_LIMITS_LEN)]
+        self.total_locks = 0
+        self.total_acquire_us = 0
+        self.total_use_us = 0
+        self.acquire_min = 1000000
+        self.acquire_max = 0
+        self.use_min = 1000000
+        self.use_max = 0
 
     def bucket_of(self, value):
         for i in range(self.common.BUCKET_LIMITS_LEN):
             if value <= self.common.BUCKET_LIMITS[i]:
                 return i
         print("Questionable lock/hold value: %d" % value)
-        return self.common.BUCKET_LIMITS_LEN
+        return self.common.BUCKET_LIMITS_LEN - 1
 
     def add(self, acquire, use):
         col = self.bucket_of(acquire)
         row = self.bucket_of(use)
         self.buckets[col][row] += 1
-        self.total_acquire += acquire
-        self.total_use += use
+        self.buckets_us[col][row] += use + acquire
+        self.total_locks += 1
+        self.total_acquire_us += acquire
+        self.total_use_us += use
+        if acquire < self.acquire_min:
+            self.acquire_min = acquire
+        if acquire > self.acquire_max:
+            self.acquire_max = acquire
+        if use < self.use_min:
+            self.use_min = use
+        if use > self.use_max:
+            self.use_max = use
 
-    def dump(self, title_prefix):
+    def summary_title(self):
+        #      123456789012345678901234567890 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 1234567890 12345678
+        print("                                             Min      Max     Mean    Total  Total %      Min      Max     Mean      Total    Total")
+        print("                         Title, N locks, Acquire, Acquire, Acquire, Acquire, Acquire,     Use,     Use,  Use uS,       Use,   Use %")
+        print("------------------------------ -------- -------- -------- -------- -------- -------- -------- -------- -------- ---------- --------")
+
+    def summary(self):
+        avg_acq = float(self.total_acquire_us) / (float(self.total_locks) if self.total_locks > 0 else 1.0)
+        acq_pct =(float(self.total_acquire_us) / float(self.common.total_duration)) * 100.0
+        avg_use = float(self.total_use_us)     / (float(self.total_locks) if self.total_locks > 0 else 1.0)
+        use_pct =(float(self.total_use_us)     / float(self.common.total_duration)) * 100.0
+        print("%-30s,%8d,%8d,%8d,%8.2f,%8d,%8.2f,%8d,%8d,%8.2f,%10d,%8.2f" %
+              (self.title, self.total_locks,
+               self.acquire_min, self.acquire_max, avg_acq, self.total_acquire_us, acq_pct,
+               self.use_min,     self.use_max,     avg_use, self.total_use_us, use_pct))
+
+    def dump(self, title_prefix, show_events):
         print()
-        print("%s %s - total acquire uS: %d, total use uS: %s" %
-              (title_prefix, self.title, self.total_acquire, self.total_use))
+        if show_events:
+            print("%s %s - Event counts (not accumulated uS). Total elapsed lock usage uS = %d" %
+                  (title_prefix, self.title, self.total_use_us))
+            buckets = self.buckets
+        else:
+            print("%s %s - Accumulated mutex usage (uS). Total locks = %d" %
+                  (title_prefix, self.title, self.total_locks))
+            buckets = self.buckets_us
         print()
         print(self.common.TITLE_TOP_LEFT + ',', end='')
         for col in range(self.common.BUCKET_LIMITS_LEN):
-            print ("     %s," % (self.common.TITLES[col]), end='')
+            print("     %s," % (self.common.TITLES[col]), end='')
         print(' ' + self.common.TITLE_TOTAL)
 
-        for row in range(self.common.BUCKET_LIMITS_LEN-1, 0, -1):
+        for row in range(self.common.BUCKET_LIMITS_LEN - 1, 0, -1):
             print("use:%s, " % (self.common.TITLES[row]), end='')
             rtotal = 0
             for col in range(self.common.BUCKET_LIMITS_LEN):
-                print("%12d, " % (self.buckets[col][row]), end='')
-                rtotal += self.buckets[col][row]
+                print("%12d, " % (buckets[col][row]), end='')
+                rtotal += buckets[col][row]
             print("%12d" % rtotal)
-            # Does 'use: 1' ever print anything? If not then suppress it
-            if row == 1:
-                assert rtotal == 0
 
         gtotal = 0
         print(self.common.TITLE_TOTAL + ', ', end='')
         for col in range(self.common.BUCKET_LIMITS_LEN):
             ctotal = 0
             for row in range(self.common.BUCKET_LIMITS_LEN):
-                ctotal += self.buckets[col][row]
+                ctotal += buckets[col][row]
             print("%12d, " % ctotal, end='')
             gtotal += ctotal
         print("%12d" % gtotal)
 
 
 def usec_log_timestamp(common, usecs):
-    ntime = common.BASE_DATETIME + timedelta(microseconds=usecs)
+    ntime = usec_to_dt(common, usecs)
     return ntime.strftime('%Y-%m-%d %H:%M:%S.%f')
+
+
+def usec_to_dt(common, usecs):
+    return common.BASE_DATETIME + timedelta(microseconds=usecs)
 
 
 def process_core_line(common, line):
     # Derive core TID and offset from a log line
     # 2021-06-17 21:23:42.750591 -0400 ROUTER_CORE (critical) Core thread TID:     0x1a374d0 start. This log timestamp corresponds to lock/unlock report timestamp 294674283709 (/home ...
+    # line_time = 2021-06-17 21:23:42.750591
+    # core_tid  = 0x1a374d0
+    # ts        = 294674283709
+    # t_offset  = int(ts)
+    # base_time = line_time - t_offset
     line_time = datetime.strptime(line[:26], '%Y-%m-%d %H:%M:%S.%f')
     tid_pos = line.find(common.CORE_THREAD_TID_CONTENT) + len(common.CORE_THREAD_TID_CONTENT)
     core_tid = line[tid_pos:tid_pos + 14].strip()
@@ -200,8 +260,8 @@ def process_logfile(common, filename, container_name):
     If the router log file exists: Find core thread ID and the timestamp
     deltas between the log timestamp and the thread-debug uS timestamp.
     Find the "router started" and "router shutting down"
-    timestamps so that local analysis may exclude insane lock hold times
-    before startup and after shutdown.
+    timestamps so that local analysis may exclude insane lock hold patterns
+    during startup and shutdown.
     :param filename:
     :return: (core-TID, timestamp_delta)
     '''
@@ -228,7 +288,7 @@ def process_logfile(common, filename, container_name):
                     # Remaining instances must match to prevent multiple router
                     # runs piling differing values into the same router log file.
                     core_tid, base_dt = process_core_line(common, line)
-                    delta = timedelta(microseconds=100) # seen two timestamps vary by < 10 uS. Apply some slop.
+                    delta = timedelta(microseconds=100)
                     assert base_dt < common.BASE_DATETIME + delta
                     assert base_dt > common.BASE_DATETIME - delta
             elif common.SERVER_START_CONTENT in line:
@@ -239,9 +299,14 @@ def process_logfile(common, filename, container_name):
                 common.STOP_DATETIME = datetime.strptime(line[:26], '%Y-%m-%d %H:%M:%S.%f')
 
 
-def is_interesting(common, acquire, use, is_core):
+def is_interesting(common, acquire, use, lock_name, is_core, verbose):
     if is_core:
-        return acquire >= common.INTERESTING_CORE_ACQUIRE or use >= common.INTERESTING_CORE_USE
+        if acquire >= common.INTERESTING_CORE_ACQUIRE or use >= common.INTERESTING_CORE_USE:
+            # could be interesting
+            if lock_name == common.CORE_THREAD_IDLE_LOCK:
+                return verbose
+            else:
+                return True
     else:
         return acquire >= common.INTERESTING_ACQUIRE_THRESHOLD or use >= common.INTERESTING_USE_THRESHOLD
 
@@ -255,7 +320,16 @@ def main_except(argv):
                    help="Optional router .log filename which is input to this program")
     p.add_argument('--verbose',
                    action='store_true',
-                   help='Show suppressed mutex data')
+                   help='Show suppressed mutex data: disposition locks')
+    p.add_argument("--include-start-stop",
+                   action='store_true',
+                   help='Normally the mutex activity during router server startup and shutdown is excluded. This switch includes it.')
+    p.add_argument('--include-core-idle',
+                   action='store_true',
+                   help='Include core thread idle time in core thread stats')
+    p.add_argument('--tables-show-event-counts',
+                   action='store_true',
+                   help='Normally CSV tables show accumulated microsecond times. This switch shows event instance counts instead.')
     del argv[0]
     args = p.parse_args(argv)
 
@@ -273,11 +347,24 @@ def main_except(argv):
     lock_data = {}
     interesting_lines = []  # lines split into fields
 
+    core_thread_core_idle = StatsStorage(common, "Mutex", "core_thread_core_idle", 0)
+
     with open(args.infile) as f:
         for line in f:  # files are routinely > 1 gigabyte. heads up.
             fields = line.split(' ')
             fields = [x for x in fields if x]
             if fields[common.FLD_L_OR_UNL] == "UNLOCK":
+                if not args.include_start_stop:
+                    line_dt = usec_to_dt(common, int(fields[common.FLD_TIMESTAMP]))
+                    if line_dt < common.START_DATETIME or line_dt > common.STOP_DATETIME:
+                        common.start_stop_hidden += 1
+                        continue
+
+                # Collection limits
+                if common.collection_times_first == 0:
+                    common.collection_times_first = fields[common.FLD_TIMESTAMP]
+                common.collection_times_last =  fields[common.FLD_TIMESTAMP]
+
                 # Thread id
                 tid = fields[common.FLD_TID]  # thread ID
                 is_core = tid == common.CORE_TID
@@ -286,46 +373,129 @@ def main_except(argv):
                 acquire = int(fields[common.FLD_ACQUIRE])
                 use = int(fields[common.FLD_USE])
 
-                # Accumulate per thread
-                if not tid in thread_data:
-                    title = "%s #%d" % (tid, len(thread_data))
-                    if is_core:
-                        title += " CORE"
-                    thread_data[tid] = StatsStorage(common, "Thread", title, len(thread_data))
-                thread_data[tid].add(acquire, use)
-
-                # Accumulate per mutex
+                # Lock name
                 lock_stack = fields[common.FLD_FIRST_LOCK:common.FLD_LAST_LOCK]
                 lock_name = lock_stack[-1]
-                if args.verbose or not lock_name.startswith("delivery-"):
-                    if not lock_name in lock_data:
-                        title = "%s #%d" % (lock_name, len(lock_data))
+
+                # Accumulate per thread
+                # 'do_this' controls adding lock data to general thread/mutex tables
+                # The special CORE_IDLE lock is locked when the core is idle, not when
+                # the core is busy using it. Including it skews the lock numbers.
+                do_this = True
+                title = "#%d %s" % (len(thread_data), tid)
+                if is_core:
+                    title += " CORE"
+                    if lock_name == common.CORE_THREAD_IDLE_LOCK:
+                        # always add to kept structure
+                        core_thread_core_idle.add(acquire, use)
+                        do_this = args.include_core_idle
+                if do_this:
+                    if tid not in thread_data:
+                        thread_data[tid] = StatsStorage(common, "Thread", title, len(thread_data))
+                    thread_data[tid].add(acquire, use)
+
+                # Accumulate per mutex
+                if do_this and (args.verbose or not lock_name.startswith("delivery-")):
+                    if lock_name not in lock_data:
+                        title = "#%d %s" % (len(lock_data), lock_name)
                         lock_data[lock_name] = StatsStorage(common, "Mutex", title, len(lock_data))
                     lock_data[lock_name].add(acquire, use)
                 else:
                     common.deliveries_hidden += 1
 
                 # Collect interesting lines
-                if is_interesting(common, acquire, use, is_core):
+                if is_interesting(common, acquire, use, lock_name, is_core, args.include_core_idle):
                     interesting_lines.append(fields)
+
+    print()
+    print("Analysis summary")
+    print("================")
+    print()
+
+    print("CLI infile  : %s" % os.path.abspath(args.infile))
+    print("CLI logfile : %s" % os.path.abspath(args.logfile))
+    print()
+
+    start_ticks = int(common.collection_times_first)
+    stop_ticks = int(common.collection_times_last)
+    common.total_duration = stop_ticks - start_ticks
+    print("Collection %s locks before server started and after server stopped." %
+          ("includes" if args.include_start_stop else "excludes"))
+    print("Collection  begin time: %s, ticks: %d" % (usec_log_timestamp(common, start_ticks), start_ticks))
+    print("Collection    end time: %s, ticks: %d" % (usec_log_timestamp(common, stop_ticks), stop_ticks))
+    print("Collection duration uS: %d" % common.total_duration)
+    print()
+    print("Threads reported: %d" % len(thread_data))
+    print("Mutexes reported: %d" % len(lock_data))
+    print()
+    print("Core thread id     : %s" % common.CORE_TID)
+    if core_thread_core_idle.total_locks > 0:
+        try:
+            core_idle = float(core_thread_core_idle.total_use_us) / float(common.total_duration)
+            print("Core thread busy %% : %6.2f" % (100.0 - float(core_idle * 100.0)))
+        except KeyError:
+            print("Core thread busy unknown.")
+    else:
+        print("Core thread busy unknown. No CORE_IDLE locks taken by core thread.")
+
+    print()
+    if common.deliveries_hidden > 0:
+        print("%d Delivery mutex lock summaries hidden. Expose with --verbose CLI arg."
+              % common.deliveries_hidden)
+    if common.start_stop_hidden > 0:
+        print("%d Mutex locks during server start and stop hidden. Expose with --include-start-stop CLI arg."
+              % common.start_stop_hidden)
 
     print()
     print("Per thread lock summary")
     print("=======================")
     print()
+
+    need_title = True
     for key, value in thread_data.items():
-        value.dump("Thread")
-        print("")
+        if need_title:
+            value.summary_title()
+            need_title = False
+        value.summary()
 
     print()
     print("Per mutex lock summary")
     print("=======================")
     print()
 
+    need_title = True
     for key, value in lock_data.items():
-        value.dump("Mutex")
-    if common.deliveries_hidden > 0:
-        print("\nDelivery mutex lock summaries hidden: %d. Expose with --verbose CLI arg." % common.deliveries_hidden)
+        if need_title:
+            value.summary_title()
+            need_title = False
+        value.summary()
+
+    print()
+    print("Per thread lock details")
+    print("=======================")
+    print()
+
+    for key, value in thread_data.items():
+        value.dump("Thread", args.tables_show_event_counts)
+        print("")
+
+    print()
+    print("Per mutex lock details")
+    print("=======================")
+    print()
+
+    print("Core thread idle mutex wait lock")
+    print("--------------------------------")
+    print()
+    core_thread_core_idle.dump("CORE IDLE", False)
+
+    print()
+    print("Other locks")
+    print("-----------")
+    print()
+
+    for key, value in lock_data.items():
+        value.dump("Mutex", args.tables_show_event_counts)
 
     print()
     print("Interesting observations made during processing")
@@ -341,7 +511,7 @@ def main_except(argv):
         use = int(fields[common.FLD_USE])
         lock_stack = fields[common.FLD_FIRST_LOCK:common.FLD_LAST_LOCK]
         print("%s %d Thread %s: acquire:%6d, use:%6d, total:%6d, locks:%s" %
-              (usec_log_timestamp(common, ts), ts, tid, acquire, use, acquire+use, lock_stack))
+              (usec_log_timestamp(common, ts), ts, tid, acquire, use, acquire + use, lock_stack))
 
     print()
     print("Interesting observations in logfile format")

--- a/tools/lock-analyzer.py
+++ b/tools/lock-analyzer.py
@@ -230,12 +230,38 @@ class StatsStorage(object):
 
 
 def usec_log_timestamp(common, usecs):
+    """
+    Return printable string representing base time + given number of usecs
+    :param common: common block
+    :param usecs: usecs from base
+    :return:
+    """
     ntime = usec_to_dt(common, usecs)
     return ntime.strftime('%Y-%m-%d %H:%M:%S.%f')
 
 
 def usec_to_dt(common, usecs):
+    """
+    Return datetime object representing base time + given number of usecs
+    :param common: common block
+    :param usecs: usecs from base
+    :return: datetime object
+    """
     return common.BASE_DATETIME + timedelta(microseconds=usecs)
+
+
+def usec_from_dt(common, dt):
+    """
+    Given a datetime timestamp return its offset from base time in usecs
+    :param common: common block
+    :param dt: timestamp
+    :return: usecs
+    """
+    delta = dt - common.BASE_DATETIME
+    usec = delta.microseconds
+    usec += delta.seconds * 1000000
+    usec += delta.days * 1000000 * 60 * 60 * 24
+    return int(usec)
 
 
 def process_core_line(common, line):
@@ -441,6 +467,15 @@ def main_except(argv):
     print("Collection    end time: %s, ticks: %d" % (usec_log_timestamp(common, stop_ticks), stop_ticks))
     print("Collection duration uS: %d" % common.total_duration)
     print()
+
+    common.START_US = usec_from_dt(common, common.START_DATETIME)
+    common.STOP_US  = usec_from_dt(common, common.STOP_DATETIME)
+    print("Server start-stop times")
+    print("Server  begin time: %s, ticks: %d" % (common.START_DATETIME, common.START_US))
+    print("Server    end time: %s, ticks: %d" % (common.STOP_DATETIME, common.STOP_US))
+    print("Server duration uS: %d" % (common.STOP_US - common.START_US))
+    print()
+
     print("Threads reported: %d" % len(thread_data))
     print("Mutexes reported: %d" % len(lock_data))
     print()

--- a/tools/lock-analyzer.py
+++ b/tools/lock-analyzer.py
@@ -288,7 +288,7 @@ def process_logfile(common, filename, container_name):
                     # Remaining instances must match to prevent multiple router
                     # runs piling differing values into the same router log file.
                     core_tid, base_dt = process_core_line(common, line)
-                    delta = timedelta(microseconds=100)
+                    delta = timedelta(microseconds=500)
                     assert base_dt < common.BASE_DATETIME + delta
                     assert base_dt > common.BASE_DATETIME - delta
             elif common.SERVER_START_CONTENT in line:

--- a/tools/lock-analyzer.py
+++ b/tools/lock-analyzer.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+import traceback
+
+"""
+This program accepts a filename for a thread-debug-cr4 .out file and produces 
+a summary of the lock patterns.
+
+Input for a thread locking and unlocking a single lock:
+
+  255398575248 TID:0x7ff9097bee60   LOCK           PYTHON ==> [ LOCK acquire_uS 0 ]
+  255398624651 TID:0x7ff9097bee60 UNLOCK           PYTHON <== [ UNLOCK acquire_uS 0 use 49402 total  49402 ]
+
+Input for a thread locking and unlocking two locks:
+
+  255398575145 TID:0x7ff9097bee60   LOCK              LOG ==> [ LOCK acquire_uS 1 ]
+  255398575182 TID:0x7ff9097bee60   LOCK              LOG     ENTITY_CACHE ==> [ LOCK acquire_uS 0 ]
+  255398575188 TID:0x7ff9097bee60 UNLOCK              LOG     ENTITY_CACHE <== [ UNLOCK acquire_uS 0 use 6 total  6 ]
+  255398575193 TID:0x7ff9097bee60 UNLOCK              LOG <== [ UNLOCK acquire_uS 1 use 49 total  50 ]
+
+The v0 goal of this program is to produce a csv text for importing into a spreadsheet and then
+to be displayed as numbers or as a graph. 
+* The rows are buckets of lock-acquire times, the columns are buckets of lock-total times, 
+  and the values are counts of mutex lock-unlock observations for the bucket.
+* Separate csv sections are produced for each thread.
+"""
+
+FLD_TIMESTAMP  = 0
+FLD_TID_TXT    = 1
+FLD_TID        = 2
+FLD_L_OR_UNL   = 3
+FLD_FIRST_LOCK = 4
+FLD_LAST_LOCK  = -10
+FLD_ACQUIRE    = -6
+FLD_USE        = -4
+FLD_CLOSE      = -1
+
+REASONABLE_LOCK_CUTOFF = 10000  # lock transaction totals .gt. this are unreasonable
+
+# CSV buckets for acq: acquisition and use: usage
+BUCKET_LIMITS = [0, 1, 10, 100, 1000, 10000, 100000, 1000000]
+BUCKET_LIMITS_LEN = len(BUCKET_LIMITS)
+
+# Try to make raw csv output legible in on its own
+# A column or row title consists of "acq:" or "use:" plus the title text
+CSV_COL_WIDTH = 12
+CSV_TITLE_WIDTH = 8
+TITLE_BLANK = ' ' * CSV_COL_WIDTH
+TITLES = ["       0", "       1", "     2-9", "   10-99",
+          " 100-999", "  1k-10k", "10k-100k", " 100k-1m"]
+TITLE_TOTAL = "       Total"
+
+class PerThread(object):
+    """
+    Store per-thread array of counts
+    """
+
+    def __init__(self, threadId, is_core):
+        self.tid = threadId
+        self.buckets = [[0 for i in range(BUCKET_LIMITS_LEN)] for j in range(BUCKET_LIMITS_LEN)]
+        self.is_core = is_core
+
+    def bucket_of(self, value):
+        for i in range(BUCKET_LIMITS_LEN):
+            if value <= BUCKET_LIMITS[i]:
+                return i
+        print("Questionable lock/hold value: %d" % value)
+        return BUCKET_LIMITS_LEN
+
+    def add(self, useconds, tid, acquire, use, lock_stack=[]):
+        col = self.bucket_of(acquire)
+        row = self.bucket_of(use)
+        self.buckets[col][row] += 1
+        if acquire >= REASONABLE_LOCK_CUTOFF or use >= REASONABLE_LOCK_CUTOFF or \
+                (self.is_core and acquire >= 1000):
+            core_id = " --CORE--" if self.is_core else ""
+            print("Long wait timestamp:%d %s%s acquire: %d use: %d total: %d lock stack: %s" %
+                  (useconds, tid, core_id, acquire, use, acquire + use, lock_stack))
+
+    def dump(self):
+        print("Thread %s %s" % (self.tid, "--CORE--" if self.is_core else ""))
+        print(TITLE_BLANK + ',', end='')
+        for col in range(BUCKET_LIMITS_LEN):
+            print (" acq:%s," % (TITLES[col]), end='')
+        print(TITLE_TOTAL)
+
+        for row in range(BUCKET_LIMITS_LEN-1, -1, -1):
+            print("use:%s, " % (TITLES[row]), end='')
+            rtotal = 0
+            for col in range(BUCKET_LIMITS_LEN):
+                print("%12d, " % (self.buckets[col][row]), end='')
+                rtotal += self.buckets[col][row]
+            print("%12d" % rtotal)
+
+        gtotal = 0
+        print(TITLE_TOTAL + ', ', end='')
+        for col in range(BUCKET_LIMITS_LEN):
+            ctotal = 0
+            for row in range(BUCKET_LIMITS_LEN):
+                ctotal += self.buckets[col][row]
+            print("%12d, " % ctotal, end='')
+            gtotal += ctotal
+        print("%12d" % gtotal)
+
+
+def main_except(argv):
+
+    p = argparse.ArgumentParser()
+    p.add_argument('--outfile', '-o',
+                   help='Required thread-debug .out filename')
+    p.add_argument('--core-tid',
+                   help='Optional core thread ID')
+    del argv[0]
+    args = p.parse_args(argv)
+
+    if args.outfile is None:
+        raise Exception("User must specify --outfile filename")
+
+    thread_data = {}
+    lock_data = {}
+
+    with open(args.outfile) as f:
+        print("Exceptional observations made during processing")
+        print("===============================================")
+        print()
+        for line in f:  # files are routinely > 1 gigabyte. heads up.
+            fields = line.split(' ')
+            fields = [x for x in fields if x]
+            if fields[FLD_L_OR_UNL] == "UNLOCK":
+                ts = int(fields[FLD_TIMESTAMP])  # uS from arbitrary starting point
+                tid = fields[FLD_TID]  # thread ID
+                if not tid in thread_data:
+                    is_core = tid == args.core_tid
+                    thread_data[tid] = PerThread(tid, is_core)
+                assert (fields[FLD_CLOSE] == "]\n" )
+                acquire = int(fields[FLD_ACQUIRE])
+                use = int(fields[FLD_USE])
+                lock_stack = fields[FLD_FIRST_LOCK:FLD_LAST_LOCK]
+                thread_data[tid].add(ts, tid, acquire, use, lock_stack)
+
+    print()
+    print("Per thread lock summary")
+    print("=======================")
+    print()
+    for key, value in thread_data.items():
+        value.dump()
+        print("")
+
+
+def main(argv):
+    try:
+        main_except(argv)
+        return 0
+    except Exception as e:
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/lock-stacks.py
+++ b/tools/lock-stacks.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
+import argparse
+import ast
+import os
+import sys
+import traceback
+
+from collections import defaultdict
+from datetime import timedelta
+from datetime import datetime
+
+class Common():
+    FLD_TIMESTAMP  = 0
+    FLD_TID_TXT    = 1
+    FLD_TID        = 2
+    FLD_L_OR_UNL   = 3
+    FLD_FIRST_LOCK = 4
+    FLD_LAST_LOCK  = -10
+    FLD_ACQUIRE    = -6
+    FLD_USE        = -4
+    FLD_CLOSE      = -1
+
+#
+# Usage:
+#  cd build
+#  make
+#  ctest
+#
+#  # To examine a single router's output
+#  lock-stacks.py < some-router.out
+#
+#  # To examine all routers' output
+#  find . -name "*.out" | xargs grep UNLOCK | lock-stacks.py
+#
+
+def main_except(argv):
+    common = Common()
+
+    # lock inversion data is a set of lists where each list is a lock stack
+    lock_stacks = set()
+
+    # first instances helps a user find in which router the lock stack happens
+    first_instances = {}
+
+    # total instances indicates how many times the lock stack was seen
+    total_instances = defaultdict(lambda:0)
+
+    n_lines = 0
+    n_lock_stacks_len_eq_1 = 0
+    n_lock_stacks_len_gt_1 = 0
+    n_unlocks_processed = 0
+    for line in sys.stdin:  # *.out UNLOCK only: 74 M lines, 15 Gb ...
+        n_lines += 1
+        if n_lines % 500000 == 0:
+            print("Processing line %10d" % n_lines)
+        fields = line.split(' ')
+        fields = [x for x in fields if x]
+        if fields[common.FLD_L_OR_UNL] == "UNLOCK":
+            n_unlocks_processed += 1
+            # last_lock constant is incorrect for lock output with stack traces
+            for last_lock in range(common.FLD_FIRST_LOCK, len(fields)):
+                if "==" in fields[last_lock]:
+                    break
+            lock_stack = fields[common.FLD_FIRST_LOCK:last_lock]
+            if len(lock_stack) > 1:
+                n_lock_stacks_len_gt_1 += 1
+                lock_stack_str = ','.join(lock_stack)
+                lock_stacks.add(lock_stack_str)
+                if lock_stack_str not in first_instances:
+                    # store only first instance not every instance
+                    first_instances[lock_stack_str] = line.rstrip()
+                total_instances[lock_stack_str] += 1
+            else:
+                n_lock_stacks_len_eq_1 += 1
+
+    print()
+    print("Lock stacks")
+    print("===========")
+    print()
+    print("Found %10d lines total" % n_lines)
+    print("Found %10d UNLOCK lines" % n_unlocks_processed)
+    print("Found %10d lock stacks len >= 2 to process" % len(lock_stacks))
+    print("Found %10d lock stacks len == 1 to ignore" % n_lock_stacks_len_eq_1)
+    print()
+    for val in sorted(lock_stacks):
+        print("%-47s : n=%10d : %s" % (val, total_instances[val], first_instances[val]))
+
+    print()
+    print("Possible deadlocks")
+    print("==================")
+    print()
+
+    # Deadlock inversion detection. Create inversion database.
+    lock_inversion_data = defaultdict(set)
+    for lock_stack_str in lock_stacks:
+        lock_stack = lock_stack_str.split(',')
+        stack_len = len(lock_stack)
+        # Add lock stack to inversion database
+        for heldi in range(stack_len-1):
+            for locksi in range(heldi + 1, stack_len):
+                held = lock_stack[heldi]
+                locks = lock_stack[locksi]
+                if held not in lock_inversion_data:
+                    lock_inversion_data[held] = set()
+                lock_inversion_data[held].add(locks)
+
+    # Deadlock inversion detection
+    for k, v in lock_inversion_data.items():
+        for locks in v:
+            if locks in lock_inversion_data:
+                if k in lock_inversion_data[locks]:
+                    print("Inversion %s and %s" % (k, locks))
+
+
+
+def main(argv):
+    try:
+        main_except(argv)
+        return 0
+    except Exception as e:
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
This commit provides a framework for analyzing mutex locking patterns. Each mutex gets a name when it is created. Then when the mutex is locked and unlocked a per-thread stack of locked mutexes is printed to stderr.

- The first commit by kgiusti provides the foundation instrumentation to show the lock nesting. 
- The second commit by chugr adds timestamps and prints lock acquisition and hold times in microseconds.

This package is pertty verbose. A full run of self tests on my laptop consumes 34Gbytes of disk storage to hold the lock log output. That of course makes useful data a little hard to find. With a little patience one can find instances of locks being held for > 1 second. (Check edge_router test, EA1.out file) Analysis tools to crunch the data are forthcoming. 

Note that the second commit also prints timestamped data to stderr out-of-order! There is a tradeoff for the ordering problem which is corrected by a simple sort vs. adding an extra mutex lock for every line printed. The commit chooses the out-of-order solution for speed and simplicity.