### PR TITLE
Fix "${InstallPrefix}" variable in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
             ${{ matrix.os }}-${{ matrix.runtimeCheck }}-${{ env.cache-name }}
 
       - name: Create Build and Install directories
-        run: mkdir -p "${ProtonBuildDir}" "${DispatchBuildDir}" "{InstallPrefix}"
+        run: mkdir -p "${ProtonBuildDir}" "${DispatchBuildDir}" "${InstallPrefix}"
 
       - name: Setup python
         uses: actions/setup-python@v2


### PR DESCRIPTION
In CI, a variable InstallPrefix is written as `“{InstallPrefix}”` instead of `“${InstallPrefix}”`.
https://github.com/apache/qpid-dispatch/blob/main/.github/workflows/build.yaml#L96 

```run: mkdir -p "${ProtonBuildDir}" "${DispatchBuildDir}" "{InstallPrefix}"```
This line creating a directory called "{InstallPrefix}". Later, while cmake build/install, creating the correct one called “INSTALL” when using the variable properly.

Link to related PR: https://github.com/apache/qpid-proton/pull/321 