### PR TITLE
DISPATCH-2179: Set SSLDomain.VERIFY_PEER or SSLDomain.VERIFY_PEER_NAM…

### DIFF
--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -281,6 +281,10 @@ def opts_ssl_domain(opts, mode=SSLDomain.MODE_CLIENT):
     @param opts: Parsed optoins including connection_options()
     """
 
+    url = opts_url(opts)
+    if not url.scheme == "amqps":
+        return None
+
     certificate, key, trustfile, password, password_file, ssl_disable_peer_name_verify = opts.ssl_certificate,\
         opts.ssl_key,\
         opts.ssl_trustfile,\

--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -288,9 +288,6 @@ def opts_ssl_domain(opts, mode=SSLDomain.MODE_CLIENT):
         opts.ssl_password_file, \
         opts.ssl_disable_peer_name_verify
 
-    if not (certificate or trustfile):
-        return None
-
     if password_file:
         password = get_password(password_file)
 

--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -261,9 +261,8 @@ def opts_url(opts):
     url = Url(opts.bus)
 
     # If the options indicate SSL, make sure we use the amqps scheme.
-    if opts.ssl_certificate or opts.ssl_trustfile:
+    if opts.ssl_certificate or opts.ssl_trustfile or opts.bus.startswith("amqps:"):
         url.scheme = "amqps"
-
     return url
 
 
@@ -299,10 +298,11 @@ def opts_ssl_domain(opts, mode=SSLDomain.MODE_CLIENT):
 
     if trustfile:
         domain.set_trusted_ca_db(str(trustfile))
-        if ssl_disable_peer_name_verify:
-            domain.set_peer_authentication(SSLDomain.VERIFY_PEER, str(trustfile))
-        else:
-            domain.set_peer_authentication(SSLDomain.VERIFY_PEER_NAME, str(trustfile))
+
+    if ssl_disable_peer_name_verify:
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER)
+    else:
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER_NAME)
 
     if certificate:
         domain.set_credentials(str(certificate), str(key), str(password))

--- a/src/server.c
+++ b/src/server.c
@@ -711,7 +711,6 @@ static void on_connection_bound(qd_server_t *server, pn_event_t *e) {
             pn_ssl_domain_t* plugin_ssl_domain = NULL;
             if (config->sasl_plugin_config.use_ssl) {
                 plugin_ssl_domain = pn_ssl_domain(PN_SSL_MODE_CLIENT);
-                pn_ssl_domain_set_peer_authentication(plugin_ssl_domain, PN_SSL_ANONYMOUS_PEER, NULL);
                 if (config->sasl_plugin_config.ssl_certificate_file) {
                     if (pn_ssl_domain_set_credentials(plugin_ssl_domain,
                                                       config->sasl_plugin_config.ssl_certificate_file,

--- a/src/server.c
+++ b/src/server.c
@@ -711,6 +711,7 @@ static void on_connection_bound(qd_server_t *server, pn_event_t *e) {
             pn_ssl_domain_t* plugin_ssl_domain = NULL;
             if (config->sasl_plugin_config.use_ssl) {
                 plugin_ssl_domain = pn_ssl_domain(PN_SSL_MODE_CLIENT);
+
                 if (config->sasl_plugin_config.ssl_certificate_file) {
                     if (pn_ssl_domain_set_credentials(plugin_ssl_domain,
                                                       config->sasl_plugin_config.ssl_certificate_file,

--- a/src/server.c
+++ b/src/server.c
@@ -711,7 +711,7 @@ static void on_connection_bound(qd_server_t *server, pn_event_t *e) {
             pn_ssl_domain_t* plugin_ssl_domain = NULL;
             if (config->sasl_plugin_config.use_ssl) {
                 plugin_ssl_domain = pn_ssl_domain(PN_SSL_MODE_CLIENT);
-
+                pn_ssl_domain_set_peer_authentication(plugin_ssl_domain, PN_SSL_ANONYMOUS_PEER, NULL);
                 if (config->sasl_plugin_config.ssl_certificate_file) {
                     if (pn_ssl_domain_set_credentials(plugin_ssl_domain,
                                                       config->sasl_plugin_config.ssl_certificate_file,

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -98,12 +98,12 @@ class QdstatTest(system_test.TestCase):
 
     def test_connections(self):
         self.run_qdstat(['--connections'], r'host.*container.*role')
-        outs = self.run_qdstat(['--connections'], 'no-auth')
+        outs = self.run_qdstat(['--connections'], 'anonymous-user')
         outs = self.run_qdstat(['--connections'], 'QDR.A')
 
     def test_connections_csv(self):
         self.run_qdstat(['--connections', "--csv"], r'host.*container.*role')
-        outs = self.run_qdstat(['--connections'], 'no-auth')
+        outs = self.run_qdstat(['--connections'], 'anonymous-user')
         outs = self.run_qdstat(['--connections'], 'QDR.A')
 
     def test_links(self):

--- a/tests/system_tests_qdstat.py
+++ b/tests/system_tests_qdstat.py
@@ -98,12 +98,12 @@ class QdstatTest(system_test.TestCase):
 
     def test_connections(self):
         self.run_qdstat(['--connections'], r'host.*container.*role')
-        outs = self.run_qdstat(['--connections'], 'anonymous-user')
+        outs = self.run_qdstat(['--connections'], 'no-auth')
         outs = self.run_qdstat(['--connections'], 'QDR.A')
 
     def test_connections_csv(self):
         self.run_qdstat(['--connections', "--csv"], r'host.*container.*role')
-        outs = self.run_qdstat(['--connections'], 'anonymous-user')
+        outs = self.run_qdstat(['--connections'], 'no-auth')
         outs = self.run_qdstat(['--connections'], 'QDR.A')
 
     def test_links(self):

--- a/tests/system_tests_ssl.py
+++ b/tests/system_tests_ssl.py
@@ -382,6 +382,8 @@ class RouterTestSslClient(RouterTestSslBase):
         url = Url("amqps://0.0.0.0:%d/$management" % listener_port)
         # Preparing SSLDomain (client cert) and SASL authentication info
         domain = SSLDomain(SSLDomain.MODE_CLIENT)
+        domain.set_trusted_ca_db(self.ssl_file('ca-certificate.pem'))
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER)
         # Enforcing given TLS protocol
         cproton.pn_ssl_domain_set_protocols(domain._domain, tls_protocol)
 
@@ -415,6 +417,8 @@ class RouterTestSslClient(RouterTestSslBase):
         domain.set_credentials(self.ssl_file('client-certificate.pem'),
                                self.ssl_file('client-private-key.pem'),
                                'client-password')
+        domain.set_trusted_ca_db(self.ssl_file('ca-certificate.pem'))
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER)
         # Enforcing given TLS protocol
         cproton.pn_ssl_domain_set_protocols(domain._domain, tls_protocol)
 

--- a/tests/system_tests_user_id.py
+++ b/tests/system_tests_user_id.py
@@ -242,7 +242,7 @@ class QdSSLUseridTest(TestCase):
         domain = SSLDomain(mode)
         if trustfile:
             domain.set_trusted_ca_db(str(trustfile))
-        domain.set_peer_authentication(SSLDomain.VERIFY_PEER, str(trustfile))
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER, None)
         if certificate:
             domain.set_credentials(str(certificate), str(key), str(password))
 

--- a/tests/system_tests_user_id.py
+++ b/tests/system_tests_user_id.py
@@ -208,7 +208,7 @@ class QdSSLUseridTest(TestCase):
             ('listener', {'port': cls.tester.get_port(), 'sslProfile': 'server-ssl11', 'authenticatePeer': 'yes',
                           'requireSsl': 'yes', 'saslMechanisms': 'EXTERNAL'}),
 
-            # peer is not being authenticated here. the user must "anonymous" which is what pn_transport_get_user
+            # peer is not being authenticated here. the user must be "anonymous" which is what pn_transport_get_user
             # returns
             ('listener', {'port': cls.tester.get_port(), 'sslProfile': 'server-ssl12', 'authenticatePeer': 'no',
                           'requireSsl': 'yes', 'saslMechanisms': 'ANONYMOUS'}),
@@ -242,7 +242,7 @@ class QdSSLUseridTest(TestCase):
         domain = SSLDomain(mode)
         if trustfile:
             domain.set_trusted_ca_db(str(trustfile))
-            domain.set_peer_authentication(SSLDomain.VERIFY_PEER, str(trustfile))
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER, str(trustfile))
         if certificate:
             domain.set_credentials(str(certificate), str(key), str(password))
 
@@ -314,11 +314,11 @@ class QdSSLUseridTest(TestCase):
         user = node.query(type='org.apache.qpid.dispatch.connection', attribute_names=[u'user']).results[10][0]
         self.assertEqual("C=US,ST=NC,L=Raleigh,OU=Dev,O=Client,CN=127.0.0.1", str(user))
 
-        # authenticatePeer is set to 'no' in this listener, there should be no user on the connection.
+        # authenticatePeer is set to 'no' in this listener, the user should anonymous on the connection.
         addr = self.address(11).replace("amqp", "amqps")
-        node = Node.connect(addr)
+        node = Node.connect(addr, ssl_domain=domain)
         user = node.query(type='org.apache.qpid.dispatch.connection', attribute_names=[u'user']).results[11][0]
-        self.assertEqual(None, user)
+        self.assertEqual("anonymous", user)
 
         addr = self.address(12).replace("amqp", "amqps")
         node = Node.connect(addr, ssl_domain=domain)


### PR DESCRIPTION
…E based on the ssl_disable_peer_name_verify flag. Removed --ssl-disable-peer-name-verify from run_qdstat in system_tests_qdstat