### PR TITLE
NO-JIRA Run apt update in Actions CI, to avoid package download failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt install -y swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz
+          sudo apt update; sudo apt install -y swig libpython3-dev libsasl2-dev libjsoncpp-dev libwebsockets-dev libnghttp2-dev ccache ninja-build pixz
 
       - name: Zero ccache stats
         run: ccache -z
@@ -208,7 +208,7 @@ jobs:
       - name: Install Linux runtime/test dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt install -y libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp1 libwebsockets15 pixz bubblewrap curl
+          sudo apt update; sudo apt install -y libsasl2-2 libsasl2-modules sasl2-bin libjsoncpp1 libwebsockets15 pixz bubblewrap curl
 
       - name: Unpack archive
         run: tar -I pixz -xf archive.tar.xz
@@ -475,12 +475,12 @@ jobs:
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt install -y libqpid-proton-proactor1-dev python3-qpid-proton libpython3-dev libwebsockets-dev libnghttp2-dev ninja-build
+          sudo apt update; sudo apt install -y libqpid-proton-proactor1-dev python3-qpid-proton libpython3-dev libwebsockets-dev libnghttp2-dev ninja-build
 
       - name: Install Linux docs dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
-          sudo apt install -y asciidoc asciidoctor ruby-asciidoctor-pdf dblatex libxml2-utils
+          sudo apt update; sudo apt install -y asciidoc asciidoctor ruby-asciidoctor-pdf dblatex libxml2-utils
 
       - name: qpid-dispatch cmake configure
         working-directory: ${{env.DispatchBuildDir}}


### PR DESCRIPTION
This fixes fails such as https://github.com/apache/qpid-dispatch/pull/1290/checks?check_run_id=3029417768

```
Err:5 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libuv1-dev amd64 1.34.2-1ubuntu1.1
  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libu/libuv1/libuv1-dev_1.34.2-1ubuntu1.1_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
Fetched 1443 kB in 0s (12.8 MB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```