### PR TITLE
DISPATCH-2194: Fix CONNECTOR - ENTITY_CACHE lock inversion

### DIFF
--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -569,6 +569,35 @@ void qd_connection_invoke_deferred(qd_connection_t *conn, qd_deferred_t call, vo
 
 
 /**
+ * Schedule a call to be invoked on a thread that has ownership of this connection
+ * when it will be safe for the callback to perform operations related to this connection.
+ * A qd_deferred_call_t object has been allocated before hand to avoid taking
+ * the ENTITY_CACHE lock.
+ *
+ * @param conn Connection object
+ * @param call The function to be invoked on the connection's thread
+ * @param context The context to be passed back in the callback
+ * @param dct Pointer to preallocated qd_deferred_call_t object
+ */
+void qd_connection_invoke_deferred_impl(qd_connection_t *conn, qd_deferred_t call, void *context, void *dct);
+
+
+/**
+ * Allocate a qd_deferred_call_t object
+ */
+void *qd_connection_new_qd_deferred_call_t();
+
+
+/**
+ * Deallocate a qd_deferred_call_t object
+ *
+ * @param dct Pointer to preallocated qd_deferred_call_t object
+ */
+void qd_connection_free_qd_deferred_call_t(void *dct);
+
+
+
+/**
  * Listen for incoming connections, return true if listening succeeded.
  */
 bool qd_listener_listen(qd_listener_t *l);


### PR DESCRIPTION
The two locks are taken in both orders.

 * entity_cache first, connector second is routinely used by management
   entity updates in a pattern shared by all entities.

 * connector first, entity_cache second is used only when a connector
   creates or deletes an associated connection. The allocation and
   disposal of the connection causes an implicit entity_cache lock.

The fix is to avoid the connector - entity_cache lock order by allocating
the connection before taking the connector lock and by freeing the
connection after releasing the connector lock.

This patch also corrects an improper free call in a failure path.