### PR TITLE
DISPATCH-2195: Fix SERVER-PYTHON lock inversion

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -289,6 +289,7 @@ void qd_policy_socket_close(qd_policy_t *policy, const qd_connection_t *conn)
 {
     sys_mutex_lock(stats_lock);
     n_connections--;
+    uint64_t nc = n_connections;
     assert (n_connections >= 0);
     sys_mutex_unlock(stats_lock);
     if (policy->enableVhostPolicy) {
@@ -319,7 +320,7 @@ void qd_policy_socket_close(qd_policy_t *policy, const qd_connection_t *conn)
            "[C%"PRIu64"] Connection '%s' closed with resources n_sessions=%d, n_senders=%d, n_receivers=%d, "
            "sessions_denied=%"PRIu64", senders_denied=%"PRIu64", receivers_denied=%"PRIu64", max_message_size_denied:%"PRIu64", nConnections= %"PRIu64".",
             conn->connection_id, hostname, conn->n_sessions, conn->n_senders, conn->n_receivers,
-            qpdc->sessionDenied, qpdc->senderDenied, qpdc->receiverDenied, qpdc->maxSizeMessagesDenied, n_connections);
+            qpdc->sessionDenied, qpdc->senderDenied, qpdc->receiverDenied, qpdc->maxSizeMessagesDenied, nc);
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -919,12 +919,12 @@ static void qd_connection_free(qd_connection_t *qd_conn)
 
     sys_mutex_lock(qd_server->lock);
     DEQ_REMOVE(qd_server->conn_list, qd_conn);
+    sys_mutex_unlock(qd_server->lock);
 
     // If counted for policy enforcement, notify it has closed
     if (qd_conn->policy_counted) {
         qd_policy_socket_close(qd_server->qd->policy, qd_conn);
     }
-    sys_mutex_unlock(qd_server->lock);
 
     invoke_deferred_calls(qd_conn, true);  // Discard any pending deferred calls
     sys_mutex_free(qd_conn->deferred_call_lock);


### PR DESCRIPTION
Release server lock before calling qd_policy_socket_close instead
of after.

As a general rule the PYTHON lock must not be taken while holding
any other lock.