### PR TITLE
DISPATCH-1783 Add TCP EchoServer and Socket C++ fixtures in unittests and benchmarks

### DIFF
--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -1990,7 +1990,6 @@ static uint64_t qdr_http_deliver(void *context, qdr_link_t *link, qdr_delivery_t
 		free_http2_stream_data(stream_data, false);
 	}
 	return disp;
-
 }
 
 

--- a/tests/c_benchmarks/CMakeLists.txt
+++ b/tests/c_benchmarks/CMakeLists.txt
@@ -25,13 +25,21 @@ find_package(benchmark REQUIRED)
 
 # need -Wno-pedantic, for two reasons:
 #  incompatibility in older libbenchmark, https://github.com/google/benchmark/issues/494#issuecomment-502444478
-#  PRIu64 macros without spaces around are invalid C++ (c.f. the C++11 value suffixes feature)
+#  PRIu64 macros without spaces around are invalid C++ (c.f. the C++11 suffixes feature)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD_FLAGS} ${SANITIZE_FLAGS} -Wno-pedantic -Wno-unused-function")
 
 add_executable(c-benchmarks
         ../c_unittests/helpers.cpp
         c_benchmarks_main.cpp
         bm_router_initialization.cpp
+        bm_parse_tree.cpp
+        bm_tcp_adapter.cpp
+        echo_server.cpp echo_server.hpp
+        socket_utils.cpp socket_utils.hpp
+        Socket.cpp Socket.hpp
+        SocketException.cpp SocketException.hpp
+        TCPSocket.cpp TCPSocket.hpp
+        TCPServerSocket.cpp TCPServerSocket.hpp
         $<TARGET_OBJECTS:qpid-dispatch>)
 target_link_libraries(c-benchmarks qpid-dispatch-libraries benchmark pthread)
 

--- a/tests/c_benchmarks/CMakeLists.txt
+++ b/tests/c_benchmarks/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(benchmark REQUIRED)
 
 # need -Wno-pedantic, for two reasons:
 #  incompatibility in older libbenchmark, https://github.com/google/benchmark/issues/494#issuecomment-502444478
-#  PRIu64 macros without spaces around are invalid C++ (c.f. the C++11 suffixes feature)
+#  PRIu64 macros without spaces around are invalid C++ (c.f. the C++11 value suffixes feature)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD_FLAGS} ${SANITIZE_FLAGS} -Wno-pedantic -Wno-unused-function")
 
 add_executable(c-benchmarks

--- a/tests/c_benchmarks/Socket.cpp
+++ b/tests/c_benchmarks/Socket.cpp
@@ -1,0 +1,158 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "Socket.hpp"
+
+#include "SocketException.hpp"
+#include "socket_utils.hpp"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+Socket::Socket(int type, int protocol) noexcept(false)
+{
+    mFileDescriptor = socket(PF_INET, type, protocol);
+    if (mFileDescriptor < 0) {
+        throw SocketException("Socket creation failed (socket())", true);
+    }
+}
+
+Socket::Socket(int fd)
+{
+    this->mFileDescriptor = fd;
+}
+
+Socket::~Socket()
+{
+    if (mFileDescriptor < 0) {
+        return;  // socket was moved out before
+    }
+
+    ::close(mFileDescriptor);
+    mFileDescriptor = -1;
+}
+
+std::string Socket::getLocalAddress() const
+{
+    sockaddr_in addr;
+    unsigned int addr_len = sizeof(addr);
+
+    if (getsockname(mFileDescriptor, reinterpret_cast<sockaddr *>(&addr), &addr_len) < 0) {
+        throw SocketException("Fetch of local address failed (getsockname())", true);
+    }
+    return inet_ntoa(addr.sin_addr);
+}
+
+unsigned short Socket::getLocalPort()
+{
+    sockaddr_in addr;
+    unsigned int addr_len = sizeof(addr);
+
+    if (getsockname(mFileDescriptor, reinterpret_cast<sockaddr *>(&addr), &addr_len) < 0) {
+        throw SocketException("Fetch of local port failed (getsockname())", true);
+    }
+    return ntohs(addr.sin_port);
+}
+
+void Socket::setLocalPort(unsigned short localPort)
+{
+    // Bind the socket to its port
+    sockaddr_in localAddr = {};
+    localAddr.sin_family      = AF_INET;
+    localAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    localAddr.sin_port        = htons(localPort);
+
+    if (bind(mFileDescriptor, reinterpret_cast<const sockaddr *>(&localAddr), sizeof(sockaddr_in)) < 0) {
+        throw SocketException("Set of local port failed (bind())", true);
+    }
+}
+
+void Socket::setLocalAddressAndPort(const std::string &localAddress, unsigned short localPort)
+{
+    // Get the address of the requested host
+    sockaddr_in localAddr;
+    fillSockAddr(localAddress, localPort, localAddr);
+
+    if (bind(mFileDescriptor, reinterpret_cast<const sockaddr *>(&localAddr), sizeof(sockaddr_in)) < 0) {
+        throw SocketException("Set of local address and port failed (bind())", true);
+    }
+}
+
+unsigned short Socket::resolveService(const std::string &service, const std::string &protocol)
+{
+    struct servent *serv = getservbyname(service.c_str(), protocol.c_str());
+    if (serv == nullptr) {
+        return atoi(service.c_str());
+    } else {
+        return ntohs(serv->s_port);
+    }
+}
+
+void Socket::connect(const std::string &remoteAddress, unsigned short remotePort) noexcept(false)
+{
+    sockaddr_in destAddr;
+    fillSockAddr(remoteAddress, remotePort, destAddr);
+
+    if (::connect(mFileDescriptor, reinterpret_cast<const sockaddr *>(&destAddr), sizeof(destAddr)) < 0) {
+        throw SocketException("Connect failed (connect())", true);
+    }
+}
+
+void Socket::send(const void *buffer, int bufferLen) noexcept(false)
+{
+    if (::send(mFileDescriptor, buffer, bufferLen, 0) < 0) {
+        throw SocketException("Send failed (send())", true);
+    }
+}
+
+int Socket::recv(void *buffer, int bufferLen) noexcept(false)
+{
+    int rtn = ::recv(mFileDescriptor, buffer, bufferLen, 0);
+    if (rtn < 0) {
+        throw SocketException("Received failed (recv())", true);
+    }
+
+    return rtn;
+}
+
+std::string Socket::getForeignAddress() noexcept(false)
+{
+    sockaddr_in addr;
+    unsigned int addr_len = sizeof(addr);
+
+    if (getpeername(mFileDescriptor, reinterpret_cast<sockaddr *>(&addr), &addr_len) < 0) {
+        throw SocketException("Fetch of remote address failed (getpeername())", true);
+    }
+    return inet_ntoa(addr.sin_addr);
+}
+
+unsigned short Socket::getForeignPort() noexcept(false)
+{
+    sockaddr_in addr;
+    unsigned int addr_len = sizeof(addr);
+
+    if (getpeername(mFileDescriptor, reinterpret_cast<sockaddr *>(&addr), &addr_len) < 0) {
+        throw SocketException("Fetch of remote port failed (getpeername())", true);
+    }
+    return ntohs(addr.sin_port);
+}

--- a/tests/c_benchmarks/Socket.cpp
+++ b/tests/c_benchmarks/Socket.cpp
@@ -135,7 +135,7 @@ int Socket::recv(void *buffer, int bufferLen) noexcept(false)
     return rtn;
 }
 
-std::string Socket::getForeignAddress() noexcept(false)
+std::string Socket::getRemoteAddress() noexcept(false)
 {
     sockaddr_in addr;
     unsigned int addr_len = sizeof(addr);
@@ -146,7 +146,7 @@ std::string Socket::getForeignAddress() noexcept(false)
     return inet_ntoa(addr.sin_addr);
 }
 
-unsigned short Socket::getForeignPort() noexcept(false)
+unsigned short Socket::getRemotePort() noexcept(false)
 {
     sockaddr_in addr;
     unsigned int addr_len = sizeof(addr);

--- a/tests/c_benchmarks/Socket.cpp
+++ b/tests/c_benchmarks/Socket.cpp
@@ -77,7 +77,7 @@ unsigned short Socket::getLocalPort()
 void Socket::setLocalPort(unsigned short localPort)
 {
     // Bind the socket to its port
-    sockaddr_in localAddr = {};
+    sockaddr_in localAddr     = {};
     localAddr.sin_family      = AF_INET;
     localAddr.sin_addr.s_addr = htonl(INADDR_ANY);
     localAddr.sin_port        = htons(localPort);

--- a/tests/c_benchmarks/Socket.hpp
+++ b/tests/c_benchmarks/Socket.hpp
@@ -1,0 +1,56 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#ifndef QPID_DISPATCH_SOCKET_HPP
+#define QPID_DISPATCH_SOCKET_HPP
+
+#include <string>
+class Socket
+{
+   public:
+    ~Socket();
+    std::string getLocalAddress() const;
+    unsigned short getLocalPort();
+    void setLocalPort(unsigned short localPort);
+    void setLocalAddressAndPort(const std::string &localAddress, unsigned short localPort = 0);
+    static unsigned short resolveService(const std::string &service, const std::string &protocol = "tcp");
+    Socket(const Socket &&sock) noexcept : mFileDescriptor(sock.mFileDescriptor)
+    {
+    }
+
+   private:
+    Socket(const Socket &sock);
+    void operator=(const Socket &sock);
+
+   protected:
+    int mFileDescriptor;
+    Socket(int type, int protocol) noexcept(false);
+    explicit Socket(int fd);
+
+   public:
+    void connect(const std::string &remoteAddress, unsigned short remotePort) noexcept(false);
+    void send(const void *buffer, int bufferLen) noexcept(false);
+    int recv(void *buffer, int bufferLen) noexcept(false);
+    std::string getForeignAddress() noexcept(false);
+    unsigned short getForeignPort() noexcept(false);
+};
+
+#endif  // QPID_DISPATCH_SOCKET_HPP

--- a/tests/c_benchmarks/Socket.hpp
+++ b/tests/c_benchmarks/Socket.hpp
@@ -49,8 +49,8 @@ class Socket
     void connect(const std::string &remoteAddress, unsigned short remotePort) noexcept(false);
     void send(const void *buffer, int bufferLen) noexcept(false);
     int recv(void *buffer, int bufferLen) noexcept(false);
-    std::string getForeignAddress() noexcept(false);
-    unsigned short getForeignPort() noexcept(false);
+    std::string getRemoteAddress() noexcept(false);
+    unsigned short getRemotePort() noexcept(false);
 };
 
 #endif  // QPID_DISPATCH_SOCKET_HPP

--- a/tests/c_benchmarks/SocketException.cpp
+++ b/tests/c_benchmarks/SocketException.cpp
@@ -1,0 +1,45 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+#include "SocketException.hpp"
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+
+SocketException::SocketException(std::string message, bool captureErrno) noexcept : mMessage(std::move(message))
+{
+    if (captureErrno) {
+        message.append(": ");
+        message.append(strerror(errno));
+    }
+}
+
+SocketException::SocketException(const SocketException &e) noexcept : mMessage(e.mMessage)
+{
+}
+
+SocketException::~SocketException() noexcept = default;
+
+const char *SocketException::what() const noexcept
+{
+    return mMessage.c_str();
+}

--- a/tests/c_benchmarks/SocketException.cpp
+++ b/tests/c_benchmarks/SocketException.cpp
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
 #include "SocketException.hpp"
 

--- a/tests/c_benchmarks/SocketException.hpp
+++ b/tests/c_benchmarks/SocketException.hpp
@@ -27,6 +27,7 @@ class SocketException : public std::exception
 {
    private:
     std::string mMessage;
+
    public:
     explicit SocketException(std::string message, bool captureErrno = false) noexcept;
 

--- a/tests/c_benchmarks/SocketException.hpp
+++ b/tests/c_benchmarks/SocketException.hpp
@@ -1,0 +1,39 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#ifndef QPID_DISPATCH_SOCKETEXCEPTION_HPP
+#define QPID_DISPATCH_SOCKETEXCEPTION_HPP
+
+#include <string>
+class SocketException : public std::exception
+{
+   private:
+    std::string mMessage;
+   public:
+    explicit SocketException(std::string message, bool captureErrno = false) noexcept;
+
+    SocketException(const SocketException &e) noexcept;
+
+    ~SocketException() noexcept override;
+    const char *what() const noexcept override;
+};
+
+#endif  // QPID_DISPATCH_SOCKETEXCEPTION_HPP

--- a/tests/c_benchmarks/TCPServerSocket.cpp
+++ b/tests/c_benchmarks/TCPServerSocket.cpp
@@ -1,0 +1,64 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "TCPServerSocket.hpp"
+
+#include "SocketException.hpp"
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <string>
+
+TCPServerSocket::TCPServerSocket(unsigned short localPort, int queueLen) : Socket(SOCK_STREAM, IPPROTO_TCP)
+{
+    setLocalPort(localPort);
+    setListen(queueLen);
+}
+
+TCPServerSocket::TCPServerSocket(const std::string &localAddress, unsigned short localPort, int queueLen)
+    : Socket(SOCK_STREAM, IPPROTO_TCP)
+{
+    setLocalAddressAndPort(localAddress, localPort);
+    setListen(queueLen);
+}
+
+TCPSocket *TCPServerSocket::accept()
+{
+    int newConnSD = ::accept(mFileDescriptor, nullptr, nullptr);
+    if (newConnSD < 0) {
+        throw SocketException("Accept failed (accept())", true);
+    }
+
+    return new TCPSocket(newConnSD);
+}
+
+void TCPServerSocket::shutdown()
+{
+    ::shutdown(this->mFileDescriptor, ::SHUT_RD);
+}
+
+void TCPServerSocket::setListen(int queueLen)
+{
+    if (listen(mFileDescriptor, queueLen) < 0) {
+        throw SocketException("Set listening socket failed (listen())", true);
+    }
+}

--- a/tests/c_benchmarks/TCPServerSocket.hpp
+++ b/tests/c_benchmarks/TCPServerSocket.hpp
@@ -1,0 +1,40 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#ifndef QPID_DISPATCH_TCPSERVERSOCKET_HPP
+#define QPID_DISPATCH_TCPSERVERSOCKET_HPP
+
+#include "Socket.hpp"
+#include "TCPSocket.hpp"
+
+class TCPServerSocket : public Socket
+{
+   private:
+    void setListen(int queueLen);
+
+   public:
+    TCPServerSocket(unsigned short localPort, int queueLen = 10);
+    TCPServerSocket(const std::string &localAddress, unsigned short localPort, int queueLen = 10);
+    TCPSocket *accept();
+    void shutdown();
+};
+
+#endif  // QPID_DISPATCH_TCPSERVERSOCKET_HPP

--- a/tests/c_benchmarks/TCPSocket.cpp
+++ b/tests/c_benchmarks/TCPSocket.cpp
@@ -1,0 +1,38 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "TCPSocket.hpp"
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+TCPSocket::TCPSocket() : Socket(SOCK_STREAM, IPPROTO_TCP)
+{
+}
+
+TCPSocket::TCPSocket(const std::string &remoteAddress, unsigned short remotePort) : Socket(SOCK_STREAM, IPPROTO_TCP)
+{
+    connect(remoteAddress, remotePort);
+}
+
+TCPSocket::TCPSocket(int newConnSD) : Socket(newConnSD)
+{
+}

--- a/tests/c_benchmarks/TCPSocket.hpp
+++ b/tests/c_benchmarks/TCPSocket.hpp
@@ -1,0 +1,41 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#ifndef QPID_DISPATCH_TCPSOCKET_HPP
+#define QPID_DISPATCH_TCPSOCKET_HPP
+
+#include "Socket.hpp"
+class TCPSocket : public Socket
+{
+   private:
+    friend class TCPServerSocket;
+    explicit TCPSocket(int newConnSD);
+
+   public:
+    TCPSocket();
+    TCPSocket(const std::string& remoteAddress, unsigned short remotePort);
+    TCPSocket(TCPSocket&& socket) noexcept : TCPSocket(socket.mFileDescriptor)
+    {
+        socket.mFileDescriptor = -1;
+    };
+};
+
+#endif  // QPID_DISPATCH_TCPSOCKET_HPP

--- a/tests/c_benchmarks/bm_parse_tree.cpp
+++ b/tests/c_benchmarks/bm_parse_tree.cpp
@@ -1,0 +1,95 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "../c_unittests/helpers.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <thread>
+
+extern "C" {
+#include "parse_tree.h"
+}  // extern "C"
+
+static void BM_AddRemoveSinglePattern(benchmark::State &state)
+{
+    std::thread([&state] {
+        QDRMinimalEnv env{};
+
+        qd_iterator_t *piter  = qd_iterator_string("I.am.Sam", ITER_VIEW_ALL);
+        qd_parse_tree_t *node = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
+        void *payload;
+
+        for (auto _ : state) {
+            qd_parse_tree_add_pattern(node, piter, &payload);
+            qd_parse_tree_remove_pattern(node, piter);
+        }
+
+        qd_parse_tree_free(node);
+        qd_iterator_free(piter);
+    }).join();
+}
+
+BENCHMARK(BM_AddRemoveSinglePattern)->Unit(benchmark::kMicrosecond);
+
+static void BM_AddRemoveMultiplePatterns(benchmark::State &state)
+{
+    std::thread([&state] {
+        QDRMinimalEnv env{};
+
+        int batchSize = state.range(0);
+        std::vector<std::string> data(batchSize);
+        std::vector<qd_iterator_t *> piter(batchSize);
+        for (int i = 0; i < batchSize; ++i) {
+            data[i]  = "I.am.Sam_" + std::to_string(i);
+            piter[i] = qd_iterator_string(data[i].c_str(), ITER_VIEW_ALL);
+        }
+        qd_parse_tree_t *node = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
+        const void *payload;
+
+        for (auto _ : state) {
+            for (int i = 0; i < batchSize; ++i) {
+                qd_parse_tree_add_pattern(node, piter[i], &payload);
+            }
+            for (int i = 0; i < batchSize; ++i) {
+                qd_parse_tree_remove_pattern(node, piter[i]);
+            }
+        }
+
+        qd_parse_tree_free(node);
+        for (int i = 0; i < batchSize; ++i) {
+            qd_iterator_free(piter[i]);
+        }
+
+        state.SetComplexityN(batchSize);
+    }).join();
+}
+
+BENCHMARK(BM_AddRemoveMultiplePatterns)
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(1)
+    ->Arg(3)
+    ->Arg(10)
+    ->Arg(30)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(100000)
+    ->Complexity();

--- a/tests/c_benchmarks/bm_tcp_adapter.cpp
+++ b/tests/c_benchmarks/bm_tcp_adapter.cpp
@@ -55,7 +55,7 @@ static TCPSocket try_to_connect(const std::string &servAddress, int echoServPort
 class LatencyMeasure
 {
     static const int RCVBUFSIZE = 32;
-    char echoBuffer[RCVBUFSIZE + 1];  // '\n'
+    char echoBuffer[RCVBUFSIZE + 1];  // '\0'
 
     std::string servAddress = "127.0.0.1";
     std::string echoString  = "echoString";

--- a/tests/c_benchmarks/bm_tcp_adapter.cpp
+++ b/tests/c_benchmarks/bm_tcp_adapter.cpp
@@ -1,0 +1,105 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "../c_unittests/helpers.hpp"
+#include "SocketException.hpp"
+#include "TCPSocket.hpp"
+#include "echo_server.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <iostream>
+
+extern "C" {
+#include "entity_cache.h"
+#include "log_private.h"
+#include "parse_tree.h"
+
+#include "qpid/dispatch.h"
+
+// declarations that don't have .h file
+void qd_error_initialize();
+}  // extern "C"
+
+static TCPSocket try_to_connect(const std::string &servAddress, int echoServPort)
+{
+    auto then = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - then < std::chrono::seconds(3)) {
+        try {
+            TCPSocket sock(servAddress, echoServPort);
+            return sock;
+        } catch (SocketException &e) {
+        }
+    }
+    throw std::runtime_error("Failed to connect in time");
+}
+
+class LatencyMeasure
+{
+    static const int RCVBUFSIZE = 32;
+    char echoBuffer[RCVBUFSIZE + 1];  // '\n'
+
+    std::string servAddress = "127.0.0.1";
+    std::string echoString  = "echoString";
+    int echoStringLen       = echoString.length();
+
+   public:
+    inline void latencyMeasureLoop(benchmark::State &state, unsigned short echoServerPort)
+    {
+        {
+            TCPSocket sock = try_to_connect(servAddress, echoServerPort);
+            latencyMeasureSendReceive(state, sock);  // run once outside benchmark to clean the pipes first
+
+            for (auto _ : state) {
+                latencyMeasureSendReceive(state, sock);
+            }
+        }
+    }
+
+    inline void latencyMeasureSendReceive(benchmark::State &state, TCPSocket &sock)
+    {
+        sock.send(echoString.c_str(), echoStringLen);
+
+        int totalBytesReceived = 0;
+        while (totalBytesReceived < echoStringLen) {
+            int bytesReceived = sock.recv(echoBuffer, RCVBUFSIZE);
+            if (bytesReceived <= 0) {
+                state.SkipWithError("unable to read from socket");
+            }
+            totalBytesReceived += bytesReceived;
+            echoBuffer[bytesReceived] = '\0';
+        }
+    }
+};
+
+/// Measures latency between a TCP send and a receive.
+/// There is only one request in flight at all times, so this is the
+///  lowest conceivable latency at the most ideal condition
+/// In addition, all sends are of the same (tiny) size
+static void BM_TCPEchoServerLatencyWithoutQDR(benchmark::State &state)
+{
+    EchoServerThread est;
+
+    LatencyMeasure lm;
+    lm.latencyMeasureLoop(state, est.port());
+}
+
+BENCHMARK(BM_TCPEchoServerLatencyWithoutQDR)->Unit(benchmark::kMillisecond);

--- a/tests/c_benchmarks/echo_server.cpp
+++ b/tests/c_benchmarks/echo_server.cpp
@@ -1,0 +1,22 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#include "echo_server.hpp"

--- a/tests/c_benchmarks/echo_server.hpp
+++ b/tests/c_benchmarks/echo_server.hpp
@@ -1,0 +1,117 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#ifndef QPID_DISPATCH_ECHO_SERVER_HPP
+#define QPID_DISPATCH_ECHO_SERVER_HPP
+
+#include "../c_unittests/helpers.hpp"
+#include "SocketException.hpp"
+#include "TCPServerSocket.hpp"
+
+#include <iostream>
+#include <thread>
+int run_echo_server();
+
+void stop_echo_server();
+
+const unsigned int recv_buffer_size = 32;
+
+class EchoServer
+{
+    unsigned short mPort;
+    TCPServerSocket servSock;
+
+   public:
+    // if mPort is 0, random free port will be allocated and assigned
+    EchoServer(unsigned short port = 0) : mPort(port), servSock(mPort)
+    {
+        if (mPort == 0) {
+            mPort = servSock.getLocalPort();
+        }
+    }
+
+    // will handle one TCP client and then it will return
+    void run()
+    {
+        try {
+            HandleTCPClient(servSock.accept());
+        } catch (SocketException &e) {
+            std::cerr << e.what() << std::endl;
+        }
+    }
+
+    void stop()
+    {
+        servSock.shutdown();
+    }
+
+    unsigned short port()
+    {
+        return mPort;
+    }
+
+   private:
+    void HandleTCPClient(TCPSocket *sock)
+    {
+        char echoBuffer[recv_buffer_size];
+        int recvMsgSize;
+        while ((recvMsgSize = sock->recv(echoBuffer, recv_buffer_size)) > 0) {
+            sock->send(echoBuffer, recvMsgSize);
+        }
+        delete sock;
+    }
+};
+
+class EchoServerThread
+{
+    Latch portLatch;
+    Latch echoServerLatch;
+    unsigned short echoServerPort;
+    std::thread u;
+
+   public:
+    EchoServerThread()
+    {
+        u = std::thread([this]() {
+            EchoServer es(0);
+            echoServerPort = es.port();
+            portLatch.notify();
+            es.run();
+            echoServerLatch.wait();
+            es.stop();
+        });
+
+        portLatch.wait();
+    }
+
+    ~EchoServerThread()
+    {
+        echoServerLatch.notify();
+        u.join();
+    }
+
+    unsigned short port()
+    {
+        return echoServerPort;
+    }
+};
+
+#endif  // QPID_DISPATCH_ECHO_SERVER_HPP

--- a/tests/c_benchmarks/socket_utils.cpp
+++ b/tests/c_benchmarks/socket_utils.cpp
@@ -1,0 +1,49 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+#include "socket_utils.hpp"
+
+#include "SocketException.hpp"
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+void fillSockAddr(const std::string &address, unsigned short port, sockaddr_in &addr)
+{
+    zero(addr);
+
+    hostent *host = gethostbyname(address.c_str());
+    if (host == nullptr) {
+        throw SocketException("Failed to resolve name (gethostbyname())");
+    }
+
+    addr.sin_port        = htons(port);
+    addr.sin_family      = host->h_addrtype;
+    if (host->h_addrtype == AF_INET) {
+        auto sin_addr = reinterpret_cast<struct in_addr *>(host->h_addr_list[0]);
+        addr.sin_addr.s_addr = sin_addr->s_addr;
+    } else if (host->h_addrtype == AF_INET6) {
+        // auto sin_addr = reinterpret_cast<struct in6_addr *>(host->h_addr_list[0]);
+    } else {
+        throw SocketException("Name was not resolved to IPv4 (gethostbyname())");
+    }
+}

--- a/tests/c_benchmarks/socket_utils.cpp
+++ b/tests/c_benchmarks/socket_utils.cpp
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
 #include "socket_utils.hpp"
 
@@ -38,10 +38,10 @@ void fillSockAddr(const std::string &address, unsigned short port, sockaddr_in &
         throw SocketException("Failed to resolve name (gethostbyname())");
     }
 
-    addr.sin_port        = htons(port);
-    addr.sin_family      = host->h_addrtype;
+    addr.sin_port   = htons(port);
+    addr.sin_family = host->h_addrtype;
     if (host->h_addrtype == AF_INET) {
-        auto sin_addr = reinterpret_cast<struct in_addr *>(host->h_addr_list[0]);
+        auto sin_addr        = reinterpret_cast<struct in_addr *>(host->h_addr_list[0]);
         addr.sin_addr.s_addr = sin_addr->s_addr;
     } else if (host->h_addrtype == AF_INET6) {
         throw std::invalid_argument("IPv6 addresses are not yet supported by the test");

--- a/tests/c_benchmarks/socket_utils.cpp
+++ b/tests/c_benchmarks/socket_utils.cpp
@@ -27,6 +27,8 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+#include <stdexcept>
+
 void fillSockAddr(const std::string &address, unsigned short port, sockaddr_in &addr)
 {
     zero(addr);
@@ -42,6 +44,7 @@ void fillSockAddr(const std::string &address, unsigned short port, sockaddr_in &
         auto sin_addr = reinterpret_cast<struct in_addr *>(host->h_addr_list[0]);
         addr.sin_addr.s_addr = sin_addr->s_addr;
     } else if (host->h_addrtype == AF_INET6) {
+        throw std::invalid_argument("IPv6 addresses are not yet supported by the test");
         // auto sin_addr = reinterpret_cast<struct in6_addr *>(host->h_addr_list[0]);
     } else {
         throw SocketException("Name was not resolved to IPv4 (gethostbyname())");

--- a/tests/c_benchmarks/socket_utils.hpp
+++ b/tests/c_benchmarks/socket_utils.hpp
@@ -1,0 +1,40 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+#ifndef QPID_DISPATCH_SOCKET_UTILS_HPP
+#define QPID_DISPATCH_SOCKET_UTILS_HPP
+
+#include <netinet/in.h>
+
+#include <cstring>
+#include <string>
+
+// Saw warning to not use `= {}` to initialize socket structs; it supposedly does not work right
+//  due to casting and c-style polymorphism there. It's working just fine for me, though.
+template <class T>
+inline void zero(T &value)
+{
+    memset(&value, 0, sizeof(value));
+}
+
+void fillSockAddr(const std::string &address, unsigned short port, sockaddr_in &addr);
+
+#endif  // QPID_DISPATCH_SOCKET_UTILS_HPP

--- a/tests/c_benchmarks/socket_utils.hpp
+++ b/tests/c_benchmarks/socket_utils.hpp
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 
 #ifndef QPID_DISPATCH_SOCKET_UTILS_HPP
 #define QPID_DISPATCH_SOCKET_UTILS_HPP


### PR DESCRIPTION
```
76: ------------------------------------------------------------------------------
76: Benchmark                                    Time             CPU   Iterations
76: ------------------------------------------------------------------------------
76: BM_RouterInitializeMinimalConfig           219 ms        0.214 ms            1
76: BM_AddRemoveSinglePattern                 57.0 us         57.0 us           19
76: BM_AddRemoveMultiplePatterns/1            38.9 us         38.9 us           28
76: BM_AddRemoveMultiplePatterns/3            70.8 us         70.8 us           19
76: BM_AddRemoveMultiplePatterns/10            184 us          184 us            6
76: BM_AddRemoveMultiplePatterns/30            499 us          499 us            3
76: BM_AddRemoveMultiplePatterns/100          1704 us         1703 us            1
76: BM_AddRemoveMultiplePatterns/1000        25246 us        16791 us            1
76: BM_AddRemoveMultiplePatterns/100000    3246570 us      2267338 us            1
76: BM_AddRemoveMultiplePatterns_BigO      1954.65 NlgN    1365.08 NlgN 
76: BM_AddRemoveMultiplePatterns_RMS             0 %             0 %    
76: BM_TCPEchoServerLatencyWithoutQDR        0.026 ms        0.018 ms          100
76: -----------------------------------------------------
```

Note the big O complexity estimation feature above ;P

I have some TCP tests that involve the router, but for that I need a mechanism to configure randomly assigned port in the router. That seems better to add in separate PR, since this one is already 1k lines.