### PR TITLE
Dispatch 2166 - Thread safety improvements for message flags accessed by multiple threads

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -927,7 +927,6 @@ static void qd_message_parse_priority(qd_message_t *in_msg)
     qd_iterator_t        *iter     = qd_message_field_iterator(in_msg, QD_FIELD_HEADER);
 
     content->priority_parsed  = true;
-    content->priority_present = false;
 
     if (!!iter) {
         qd_parsed_field_t *field = qd_parse(iter);
@@ -937,7 +936,6 @@ static void qd_message_parse_priority(qd_message_t *in_msg)
                 if (qd_parse_tag(priority_field) != QD_AMQP_NULL) {
                     uint32_t value = qd_parse_as_uint(priority_field);
                     content->priority = value > QDR_MAX_PRIORITY ? QDR_MAX_PRIORITY : (uint8_t) (value & 0x00ff);
-                    content->priority_present = true;
                 }
             }
         }
@@ -1025,6 +1023,7 @@ qd_message_t *qd_message()
     sys_atomic_init(&msg->content->ref_count, 1);
     sys_atomic_init(&msg->content->aborted, 0);
     msg->content->parse_depth = QD_DEPTH_NONE;
+    msg->content->priority    = QDR_DEFAULT_PRIORITY;
     return (qd_message_t*) msg;
 }
 
@@ -1307,7 +1306,7 @@ uint8_t qd_message_get_priority(qd_message_t *msg)
     if (!content->priority_parsed)
         qd_message_parse_priority(msg);
 
-    return content->priority_present ? content->priority : QDR_DEFAULT_PRIORITY;
+    return content->priority;
 }
 
 bool qd_message_receive_complete(qd_message_t *in_msg)

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -143,7 +143,6 @@ typedef struct {
     bool                 q2_input_holdoff;               // hold off calling pn_link_recv
     bool                 disable_q2_holdoff;             // Disable the Q2 flow control
     bool                 priority_parsed;
-    bool                 priority_present;
     bool                 oversize;                       // policy oversize handling in effect
     bool                 no_body;                        // Used for http2 messages. If no_body is true, the HTTP request had no body
     uint8_t              priority;                       // The priority of this message

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -141,7 +141,7 @@ typedef struct {
 
     bool                 ma_parsed;                      // Have parsed incoming message annotations message
     sys_atomic_t         discard;                        // Message is being discarded
-    bool                 receive_complete;               // Message has been completely received
+    sys_atomic_t         receive_complete;               // Message has been completely received
     bool                 q2_input_holdoff;               // Q2 state: hold off calling pn_link_recv
     bool                 disable_q2_holdoff;             // Disable Q2 flow control
     bool                 priority_parsed;                // Message priority has been parsed

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -144,10 +144,10 @@ typedef struct {
     sys_atomic_t         receive_complete;               // Message has been completely received
     bool                 q2_input_holdoff;               // Q2 state: hold off calling pn_link_recv
     bool                 disable_q2_holdoff;             // Disable Q2 flow control
-    bool                 priority_parsed;                // Message priority has been parsed
+    sys_atomic_t         priority_parsed;                // Message priority has been parsed
     sys_atomic_t         oversize;                       // Policy oversize-message handling in effect
-    bool                 no_body;                        // HTTP2 request has no body
-    uint8_t              priority;                       // Message AMQP priority
+    sys_atomic_t         no_body;                        // HTTP2 request has no body
+    sys_atomic_t         priority;                       // Message AMQP priority
     sys_atomic_t         aborted;                        // Message has been aborted
 } qd_message_content_t;
 

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -129,7 +129,7 @@ typedef struct {
     qd_parsed_field_t   *ma_pf_to_override;
     qd_parsed_field_t   *ma_pf_trace;
     int                  ma_int_phase;
-    bool                 ma_stream;                      // indicates whether this message is streaming
+    sys_atomic_t         ma_stream;                      // indicates whether this message is streaming
     uint64_t             max_message_size;               // configured max; 0 if no max to enforce
     uint64_t             bytes_received;                 // bytes returned by pn_link_recv() when enforcing max_message_size
     size_t               protected_buffers;              // count of permanent buffers that hold the message headers

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -145,7 +145,7 @@ typedef struct {
     bool                 q2_input_holdoff;               // Q2 state: hold off calling pn_link_recv
     bool                 disable_q2_holdoff;             // Disable Q2 flow control
     bool                 priority_parsed;                // Message priority has been parsed
-    bool                 oversize;                       // Policy oversize-message handling in effect
+    sys_atomic_t         oversize;                       // Policy oversize-message handling in effect
     bool                 no_body;                        // HTTP2 request has no body
     uint8_t              priority;                       // Message AMQP priority
     sys_atomic_t         aborted;                        // Message has been aborted

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -166,7 +166,7 @@ struct qd_message_pvt_t {
     unsigned char                 *body_cursor;     // Stream: tracks the point in the content buffer chain
     qd_buffer_t                   *body_buffer;     // Stream: to parse the next body data section, if any
     bool                           strip_annotations_in;
-    bool                           send_complete;   // Message has been been completely sent
+    sys_atomic_t                   send_complete;   // Message has been been completely sent
     bool                           tag_sent;        // Tags are sent
     bool                           is_fanout;       // Message is an outgoing fanout
 };

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -140,7 +140,7 @@ typedef struct {
     qd_message_q2_unblocker_t q2_unblocker;              // Callback and context to signal Q2 unblocked to receiver
 
     bool                 ma_parsed;                      // Have parsed incoming message annotations message
-    bool                 discard;                        // Message is being discarded
+    sys_atomic_t         discard;                        // Message is being discarded
     bool                 receive_complete;               // Message has been completely received
     bool                 q2_input_holdoff;               // Q2 state: hold off calling pn_link_recv
     bool                 disable_q2_holdoff;             // Disable Q2 flow control

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -79,9 +79,6 @@ race:qdr_delivery_mcast_outbound_disposition_CT
 # DISPATCH-2157
 race:^qd_message_send$
 
-# DISPATCH-2166
-race:qd_message_set_send_complete
-
 #
 # External libraries
 #


### PR DESCRIPTION
This PR is created with a series of commits where each commit changes one message variable. Small commits make it easier to see how each variable was handled.