### PR TITLE
DISPATCH-2121 Allow the -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON build option without warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+if (POLICY CMP0069)
+    # INTERPROCEDURAL_OPTIMIZATION is enforced when enabled.
+    cmake_policy (SET CMP0069 NEW)
+endif ()
+
 # https://bugzilla.redhat.com/show_bug.cgi?id=1850174 GCC 4.8 claims to support atomics, but it's missing stdatomic.h
 include(CheckIncludeFile)
 check_include_file("stdatomic.h" HAVE_STDATOMIC_H)

--- a/README.adoc
+++ b/README.adoc
@@ -316,4 +316,8 @@ Other options include `Debug` (disables optimizations) and `Coverage`.
 
 |`-DRUNTIME_CHECK=`
 |Enables C/C++ runtime checkers.See "Run Time Validation" chapter above.
+
+|`-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`
+|With CMake 3.9+, compiles the project with LTO (Link Time Optimization) enabled.
+Older CMake will only honor this option with the Intel compiler on Linux.
 |===


### PR DESCRIPTION
```
CMake Warning (dev) at router/CMakeLists.txt:35 (add_executable):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'qdrouterd'.
```