### PR TITLE
DISPATCH-2235: Dump time delay before lock is acquired

### DIFF
--- a/include/qpid/dispatch/threading.h
+++ b/include/qpid/dispatch/threading.h
@@ -25,7 +25,7 @@
 
 typedef struct sys_mutex_t sys_mutex_t;
 
-sys_mutex_t *sys_mutex(void);
+sys_mutex_t *sys_mutex(const char *name);
 void         sys_mutex_free(sys_mutex_t *mutex);
 void         sys_mutex_lock(sys_mutex_t *mutex);
 void         sys_mutex_unlock(sys_mutex_t *mutex);
@@ -42,7 +42,7 @@ void        sys_cond_signal_all(sys_cond_t *cond);
 
 typedef struct sys_rwlock_t sys_rwlock_t;
 
-sys_rwlock_t *sys_rwlock(void);
+sys_rwlock_t *sys_rwlock(const char *name);
 void          sys_rwlock_free(sys_rwlock_t *lock);
 void          sys_rwlock_wrlock(sys_rwlock_t *lock);
 void          sys_rwlock_rdlock(sys_rwlock_t *lock);

--- a/src/adaptors/http1/http1_adaptor.c
+++ b/src/adaptors/http1/http1_adaptor.c
@@ -642,7 +642,7 @@ static void qd_http1_adaptor_init(qdr_core_t *core, void **adaptor_context)
     ZERO(adaptor);
     adaptor->core    = core;
     adaptor->log = qd_log_source(QD_HTTP_LOG_SOURCE);
-    adaptor->lock = sys_mutex();
+    adaptor->lock = sys_mutex("HTTP1_ADAPTOR");
     DEQ_INIT(adaptor->listeners);
     DEQ_INIT(adaptor->connectors);
     DEQ_INIT(adaptor->connections);

--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -2771,7 +2771,7 @@ static void qdr_http2_adaptor_init(qdr_core_t *core, void **adaptor_context)
                                             qdr_http_conn_trace);
     adaptor->log_source = qd_log_source(QD_HTTP_LOG_SOURCE);
     adaptor->protocol_log_source = qd_log_source("PROTOCOL");
-    adaptor->lock = sys_mutex();
+    adaptor->lock = sys_mutex("HTTP2_ADAPTOR");
     *adaptor_context = adaptor;
     DEQ_INIT(adaptor->listeners);
     DEQ_INIT(adaptor->connectors);

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -937,7 +937,7 @@ static qdr_tcp_connection_t *qdr_tcp_connection_ingress(qd_tcp_listener_t* liste
 {
     qdr_tcp_connection_t* tc = new_qdr_tcp_connection_t();
     ZERO(tc);
-    tc->activation_lock = sys_mutex();
+    tc->activation_lock = sys_mutex("TCP_ACTIVATION");
     tc->ingress = true;
     tc->context.context = tc;
     tc->context.handler = &handle_connection_event;
@@ -1046,7 +1046,7 @@ static qdr_tcp_connection_t *qdr_tcp_connection_egress(qd_tcp_bridge_t *config, 
 {
     qdr_tcp_connection_t* tc = new_qdr_tcp_connection_t();
     ZERO(tc);
-    tc->activation_lock = sys_mutex();
+    tc->activation_lock = sys_mutex("TCP_ACTIVATION");
     if (initial_delivery) {
         tc->egress_dispatcher = false;
         tc->initial_delivery  = initial_delivery;
@@ -1099,7 +1099,7 @@ static qd_tcp_bridge_t *qd_bridge_config()
     if (!bc) return 0;
     ZERO(bc);
     sys_atomic_init(&bc->ref_count, 1);
-    bc->stats_lock = sys_mutex();
+    bc->stats_lock = sys_mutex("TCP_BRIDGE_STATS");
     return bc;
 }
 

--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -286,7 +286,13 @@ static void qd_alloc_init(qd_alloc_type_desc_t *desc)
         desc->global_pool = NEW(qd_alloc_pool_t);
         DEQ_ITEM_INIT(desc->global_pool);
         init_stack(&desc->global_pool->free_list);
-        desc->lock = sys_mutex();
+        {
+            size_t len = strlen(desc->type_name) + 6;
+            char *buf = qd_malloc(len);
+            snprintf(buf, len, "%s_pool", desc->type_name);
+            desc->lock = sys_mutex(buf);
+            free(buf);
+        }
         DEQ_INIT(desc->tpool_list);
         desc->stats = NEW(qd_alloc_stats_t);
         ZERO(desc->stats);
@@ -517,7 +523,7 @@ uint32_t qd_alloc_sequence(void *p)
 
 void qd_alloc_initialize(void)
 {
-    init_lock = sys_mutex();
+    init_lock = sys_mutex("ALLOC_INIT");
     DEQ_INIT(type_list);
 }
 

--- a/src/container.c
+++ b/src/container.c
@@ -764,7 +764,7 @@ qd_container_t *qd_container(qd_dispatch_t *qd)
     container->server        = qd->server;
     container->node_type_map = qd_hash(6,  4, 1);  // 64 buckets, item batches of 4
     container->node_map      = qd_hash(10, 32, 0); // 1K buckets, item batches of 32
-    container->lock          = sys_mutex();
+    container->lock          = sys_mutex("CONTAINER");
     container->default_node  = 0;
     DEQ_INIT(container->nodes);
     DEQ_INIT(container->node_type_list);

--- a/src/entity_cache.c
+++ b/src/entity_cache.c
@@ -52,7 +52,7 @@ static sys_mutex_t *event_lock = 0;
 static entity_event_list_t  event_list;
 
 void qd_entity_cache_initialize() {
-    event_lock = sys_mutex();
+    event_lock = sys_mutex("ENTITY_CACHE");
     DEQ_INIT(event_list);
 }
 

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -230,7 +230,7 @@ static void work_queue_destroy(work_queue_t *wq) {
 }
 
 static void work_queue_init(work_queue_t *wq) {
-    wq->lock = sys_mutex();
+    wq->lock = sys_mutex("LWS_WORK_QUEUE");
     wq->cond = sys_cond();
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -512,7 +512,7 @@ void qd_log_initialize(void)
     for (level_index_t i = NONE + 1; i < N_LEVELS; ++i)
         aprintf(&begin, end, ", %s", levels[i].name);
 
-    log_source_lock = sys_mutex();
+    log_source_lock = sys_mutex("LOG_SOURCE");
 
     default_log_source = qd_log_source(SOURCE_DEFAULT);
     default_log_source->mask = levels[INFO].mask;

--- a/src/message.c
+++ b/src/message.c
@@ -1022,7 +1022,7 @@ qd_message_t *qd_message()
     }
 
     ZERO(msg->content);
-    msg->content->lock = sys_mutex();
+    msg->content->lock = sys_mutex("PER_MSG_CONTENT");
     sys_atomic_init(&msg->content->aborted, 0);
     sys_atomic_init(&msg->content->discard, 0);
     sys_atomic_init(&msg->content->ma_stream, 0);

--- a/src/policy.c
+++ b/src/policy.c
@@ -119,9 +119,9 @@ qd_policy_t *qd_policy(qd_dispatch_t *qd)
     policy->qd                   = qd;
     policy->log_source           = qd_log_source("POLICY");
     policy->max_connection_limit = 65535;
-    policy->tree_lock            = sys_mutex();
+    policy->tree_lock            = sys_mutex("POLICY_TREE");
     policy->hostname_tree        = qd_parse_tree_new(QD_PARSE_TREE_ADDRESS);
-    stats_lock                   = sys_mutex();
+    stats_lock                   = sys_mutex("POLICY_STATS");
     policy_log_source            = policy->log_source;
 
     qd_log(policy->log_source, QD_LOG_TRACE, "Policy Initialized");

--- a/src/python_embedded.c
+++ b/src/python_embedded.c
@@ -53,7 +53,11 @@ void qd_python_initialize(qd_dispatch_t *qd, const char *python_pkgdir)
 {
     log_source = qd_log_source("PYTHON");
     dispatch = qd;
-    ilock = sys_mutex();
+    // the python lock must be held for the entire time the thread is running
+    // the python interpreter. Since the python interpreter can call back into
+    // C code that takes other locks, no other locks can be held when taking
+    // the python lock.
+    ilock = sys_mutex("PYTHON");
     if (python_pkgdir)
         dispatch_python_pkgdir = PyUnicode_FromString(python_pkgdir);
 

--- a/src/remote_sasl.c
+++ b/src/remote_sasl.c
@@ -138,7 +138,7 @@ static qdr_sasl_relay_t* new_qdr_sasl_relay_t(const char* address, const char* h
     }
     instance->proactor = proactor;
     init_permissions(&instance->permissions);
-    instance->lock = sys_mutex();
+    instance->lock = sys_mutex("SASL_RELAY");
     return instance;
 }
 

--- a/src/router_core/agent.c
+++ b/src/router_core/agent.c
@@ -131,7 +131,7 @@ qdr_agent_t *qdr_agent(qdr_core_t *core)
     ZERO(agent);
 
     DEQ_INIT(agent->outgoing_query_list);
-    agent->query_lock  = sys_mutex();
+    agent->query_lock  = sys_mutex("QUERY_LOCK");
     agent->timer = qd_timer(core->qd, qdr_agent_response_handler, core);
     agent->log_source = qd_log_source("AGENT");
     return agent;

--- a/src/router_core/connections.c
+++ b/src/router_core/connections.c
@@ -108,7 +108,11 @@ qdr_connection_t *qdr_connection_opened(qdr_core_t                   *core,
     DEQ_INIT(conn->work_list);
     DEQ_INIT(conn->streaming_link_pool);
     conn->connection_info->role = conn->role;
-    conn->work_lock = sys_mutex();
+    {
+        char mname[64];
+        snprintf(mname, sizeof(mname), "CONN_WORK-%"PRIu64, conn->identity);
+        conn->work_lock = sys_mutex(mname);
+    }
     conn->conn_uptime = core->uptime_ticks;
 
     if (vhost) {

--- a/src/router_core/core_link_endpoint.c
+++ b/src/router_core/core_link_endpoint.c
@@ -146,7 +146,7 @@ qdr_delivery_t *qdrc_endpoint_delivery_CT(qdr_core_t *core, qdrc_endpoint_t *end
     dlv->delivery_id = next_delivery_id();
     dlv->link_id     = endpoint->link->identity;
     dlv->conn_id     = endpoint->link->conn_id;
-    dlv->dispo_lock  = sys_mutex();
+    dlv->dispo_lock  = sys_mutex("dlv-dispo");
     qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdrc_endpoint_delivery_CT", DLV_ARGS(dlv));
     return dlv;
 }

--- a/src/router_core/delivery.c
+++ b/src/router_core/delivery.c
@@ -1261,15 +1261,13 @@ bool qdr_delivery_move_delivery_state_CT(qdr_delivery_t *dlv, qdr_delivery_t *pe
         sys_mutex_lock(peer->dispo_lock);
 
         peer->disposition = dispo;
-        qd_delivery_state_t *old = peer->local_state;
+        if (peer->local_state) {
+            // old state not consumed by I/O thread?
+            qd_delivery_state_free(peer->local_state);
+        }
         peer->local_state = dstate;
 
         sys_mutex_unlock(peer->dispo_lock);
-
-        if (old) {
-            // old state not consumed by I/O thread?
-            qd_delivery_state_free(old);
-        }
     }
 
     return !!dispo;

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -154,7 +154,7 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *in
     out_dlv->delivery_id = next_delivery_id();
     out_dlv->link_id     = out_link->identity;
     out_dlv->conn_id     = out_link->conn_id;
-    out_dlv->dispo_lock  = sys_mutex();
+    out_dlv->dispo_lock  = sys_mutex("dlv-dispo");
     qd_log(core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_forward_new_delivery_CT", DLV_ARGS(out_dlv));
 
     if (in_dlv) {

--- a/src/router_core/router_core.c
+++ b/src/router_core/router_core.c
@@ -92,12 +92,12 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
     // Set up the threading support
     //
     core->action_cond = sys_cond();
-    core->action_lock = sys_mutex();
+    core->action_lock = sys_mutex("CORE_ACTION");
     core->running     = true;
     DEQ_INIT(core->action_list);
     DEQ_INIT(core->action_list_background);
 
-    core->work_lock = sys_mutex();
+    core->work_lock = sys_mutex("CORE_WORK");
     DEQ_INIT(core->work_list);
     core->work_timer = qd_timer(core->qd, qdr_general_handler, core);
 
@@ -105,7 +105,7 @@ qdr_core_t *qdr_core(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area,
     // Set up the unique identifier generator
     //
     core->next_identifier = 1;
-    core->id_lock = sys_mutex();
+    core->id_lock = sys_mutex("CORE_ID");
 
     //
     // Initialize the management agent

--- a/src/router_core/transfer.c
+++ b/src/router_core/transfer.c
@@ -76,7 +76,7 @@ qdr_delivery_t *qdr_link_deliver(qdr_link_t *link, qd_message_t *msg, qd_iterato
     dlv->delivery_id        = next_delivery_id();
     dlv->link_id            = link->identity;
     dlv->conn_id            = link->conn_id;
-    dlv->dispo_lock         = sys_mutex();
+    dlv->dispo_lock         = sys_mutex("dlv-dispo");
     qd_log(link->core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_link_deliver", DLV_ARGS(dlv));
 
     qdr_delivery_incref(dlv, "qdr_link_deliver - newly created delivery, add to action list");
@@ -112,7 +112,7 @@ qdr_delivery_t *qdr_link_deliver_to(qdr_link_t *link, qd_message_t *msg,
     dlv->delivery_id        = next_delivery_id();
     dlv->link_id            = link->identity;
     dlv->conn_id            = link->conn_id;
-    dlv->dispo_lock         = sys_mutex();
+    dlv->dispo_lock         = sys_mutex("dlv-dispo");
     qd_log(link->core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_link_deliver_to", DLV_ARGS(dlv));
 
     qdr_delivery_incref(dlv, "qdr_link_deliver_to - newly created delivery, add to action list");
@@ -143,7 +143,7 @@ qdr_delivery_t *qdr_link_deliver_to_routed_link(qdr_link_t *link, qd_message_t *
     dlv->delivery_id        = next_delivery_id();
     dlv->link_id            = link->identity;
     dlv->conn_id            = link->conn_id;
-    dlv->dispo_lock         = sys_mutex();
+    dlv->dispo_lock         = sys_mutex("dlv-dispo");
     qd_log(link->core->log, QD_LOG_DEBUG, DLV_FMT" Delivery created qdr_link_deliver_to_routed_link", DLV_ARGS(dlv));
 
     qdr_delivery_incref(dlv, "qdr_link_deliver_to_routed_link - newly created delivery, add to action list");

--- a/src/router_node.c
+++ b/src/router_node.c
@@ -1652,7 +1652,7 @@ qd_router_t *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *are
     router->router_id    = id;
     router->node         = qd_container_set_default_node_type(qd, &router_node, (void*) router, QD_DIST_BOTH);
 
-    router->lock  = sys_mutex();
+    router->lock  = sys_mutex("ROUTER");
     router->timer = qd_timer(qd, qd_router_timer_handler, (void*) router);
 
     sys_atomic_init(&global_delivery_id, 1);

--- a/src/server.c
+++ b/src/server.c
@@ -570,7 +570,7 @@ qd_connection_t *qd_server_connection_impl(qd_server_t *server, qd_server_config
     assert(ctx);
     ZERO(ctx);
     ctx->pn_conn       = pn_connection();
-    ctx->deferred_call_lock = sys_mutex();
+    ctx->deferred_call_lock = sys_mutex("CONN_DEFERRED_CALL");
     ctx->role = strdup(config->role);
     if (!ctx->pn_conn || !ctx->deferred_call_lock || !ctx->role) {
         if (ctx->pn_conn) pn_connection_free(ctx->pn_conn);
@@ -1380,8 +1380,8 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
     qd_server->proactor         = pn_proactor();
     qd_server->container        = 0;
     qd_server->start_context    = 0;
-    qd_server->lock             = sys_mutex();
-    qd_server->conn_activation_lock = sys_mutex();
+    qd_server->lock             = sys_mutex("SERVER");
+    qd_server->conn_activation_lock = sys_mutex("CONN_ACTIVATION");
     qd_server->cond             = sys_cond();
     DEQ_INIT(qd_server->conn_list);
 
@@ -1711,7 +1711,7 @@ qd_connector_t *qd_server_connector(qd_server_t *server)
     sys_atomic_init(&connector->ref_count, 1);
     DEQ_INIT(connector->conn_info_list);
 
-    connector->lock = sys_mutex();
+    connector->lock = sys_mutex("CONNECTOR");
     if (!connector->lock)
         goto error;
     connector->timer = qd_timer(server->qd, try_open_cb, connector);

--- a/src/timer.c
+++ b/src/timer.c
@@ -285,7 +285,7 @@ void qd_timer_cancel(qd_timer_t *timer)
 
 void qd_timer_initialize()
 {
-    lock = sys_mutex();
+    lock = sys_mutex("QD_TIMER");
     DEQ_INIT(scheduled_timers);
     time_base = 0;
 }

--- a/src/trace_mask.c
+++ b/src/trace_mask.c
@@ -43,7 +43,7 @@ struct qd_tracemask_t {
 qd_tracemask_t *qd_tracemask(void)
 {
     qd_tracemask_t *tm = NEW(qd_tracemask_t);
-    tm->lock               = sys_rwlock();
+    tm->lock               = sys_rwlock("TRACE_MASK");
     tm->hash               = qd_hash(8, 1, 0);
     tm->router_by_mask_bit = NEW_PTR_ARRAY(qdtm_router_t, qd_bitmask_width());
 

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -63,7 +63,7 @@ void *thread_id_thread(void *arg)
 //
 static char *test_thread_id(void *context)
 {
-    mutex = sys_mutex();
+    mutex = sys_mutex("TEST_TID");
     sys_mutex_lock(mutex);
 
     // start threads and retain their addresses
@@ -132,7 +132,7 @@ void *test_condition_thread(void *arg)
 
 static char *test_condition(void *context)
 {
-    mutex = sys_mutex();
+    mutex = sys_mutex("TEST_COND");
     cond = sys_cond();
 
     sys_mutex_lock(mutex);

--- a/tests/threaded_timer_test.c
+++ b/tests/threaded_timer_test.c
@@ -75,7 +75,7 @@ static struct event_t {
 
 static void test_setup()
 {
-    event.m = sys_mutex();
+    event.m = sys_mutex("TEST_EVENT");
     event.c = sys_cond();
 }
 
@@ -447,8 +447,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    ticker_lock = sys_mutex();
-
+    ticker_lock = sys_mutex("TEST_TICKER");
     sys_thread_t *ticker = sys_thread(ticker_thread, 0);
 
     result = test_simple(argv[0]);


### PR DESCRIPTION
- top five total waits:
  $ sort --reverse --numeric --key 3 <output-file> | head -5
- top five with waits > 1000 nsc:
  $ sort --reverse --numeric --key 7 <output-file> | head -5
- top five maximum single-call wait times:
  sort --reverse --numeric --key 9 <output-file> | head -5