### PR TITLE
DISPATCH-1274: avoid sharing mutex between timer and server

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1385,7 +1385,7 @@ qd_server_t *qd_server(qd_dispatch_t *qd, int thread_count, const char *containe
     qd_server->cond             = sys_cond();
     DEQ_INIT(qd_server->conn_list);
 
-    qd_timer_initialize(qd_server->lock);
+    qd_timer_initialize();
 
     qd_server->pause_requests         = 0;
     qd_server->threads_paused         = 0;

--- a/src/timer.c
+++ b/src/timer.c
@@ -279,9 +279,9 @@ void qd_timer_cancel(qd_timer_t *timer)
 //=========================================================================
 
 
-void qd_timer_initialize(sys_mutex_t *server_lock)
+void qd_timer_initialize()
 {
-    lock = server_lock;
+    lock = sys_mutex();
     DEQ_INIT(scheduled_timers);
     time_base = 0;
 }
@@ -289,6 +289,7 @@ void qd_timer_initialize(sys_mutex_t *server_lock)
 
 void qd_timer_finalize(void)
 {
+    sys_mutex_free(lock);
     lock = 0;
 }
 

--- a/src/timer_private.h
+++ b/src/timer_private.h
@@ -22,7 +22,7 @@
 #include "qpid/dispatch/timer.h"
 #include "qpid/dispatch/threading.h"
 
-void qd_timer_initialize(sys_mutex_t *server_lock);
+void qd_timer_initialize(void);
 void qd_timer_finalize(void);
 void qd_timer_visit();
 


### PR DESCRIPTION
Historically the qd_server_t and the timer subsystem have shared a
single mutex. There is no technical reason for this as each use the
lock to protect entirely separate critial sections.

Recent analysis of lock usage shows that the timer subsystem makes
heavy use of the lock.  This patch introduces separate locks as to
avoid any contention between the qd_server_t and timer operations.