### PR TITLE
DISPATCH-413 Reference the AMQP Management spec in docs in a less ambiguous manner

### DIFF
--- a/docs/man/qdmanage.8.adoc
+++ b/docs/man/qdmanage.8.adoc
@@ -34,8 +34,8 @@ DESCRIPTION
 An AMQP management client for use with the Dispatch router daemon 
 ('qdrouterd'). Sends AMQP management operations requests and prints 
 the response in JSON format. This is a generic AMQP management tool 
-and can be used with any standard AMQP managed endpoint, not just 
-with 'qdrouterd'.
+and can be used with any AMQP endpoint that follows the AMQP Management
+specification, not just with 'qdrouterd'.
 
 OPTIONS
 -------


### PR DESCRIPTION
The spec in question is [AMQP Management v1.0 WD09](https://www.oasis-open.org/committees/document.php?document_id=54441&wg_abbrev=amqp). I managed to find a newer working draft WD12 of the spec, but I did not manage to download a readable copy of it. It looks like the spec never got past working drafts anyways.

CC @pwright 