### PR TITLE
NO-JIRA: Use simpler CMAKE syntax

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -28,8 +28,9 @@ if(CONSOLE_INSTALL)
   if (NPM_EXECUTABLE)
     execute_process(COMMAND ${NPM_EXECUTABLE} --version
         OUTPUT_VARIABLE NPM_VERSION)
-    if(NOT (${NPM_VERSION} VERSION_LESS "3.1.10"))
-
+    if(${NPM_VERSION} VERSION_LESS "3.1.10")
+      message(STATUS "Cannot build console. npm version 3.1.10 or greater is required.")
+    else(${NPM_VERSION} VERSION_LESS "3.1.10")
           set(CONSOLE_SOURCE_DIR "${CMAKE_SOURCE_DIR}/console/react")
           set(CONSOLE_BUILD_DIR "${CMAKE_BINARY_DIR}/console")
 
@@ -94,9 +95,7 @@ if(CONSOLE_INSTALL)
             PATTERN "*.map" EXCLUDE
           )
 
-    else(NOT (${NPM_VERSION} VERSION_LESS "3.1.10"))
-      message(STATUS "Cannot build console. npm version 3.1.10 or greater is required.")
-    endif(NOT (${NPM_VERSION} VERSION_LESS "3.1.10"))
+    endif(${NPM_VERSION} VERSION_LESS "3.1.10")
   endif(NPM_EXECUTABLE)
 
 endif(CONSOLE_INSTALL)


### PR DESCRIPTION
It appears that the CMAKE version on the RHEL 9 box does not support the IF(NOT(...)) syntax.
The IF() statement now avoids the NOT(). This matches the syntax in the other CMakeFiles.txt files. 