### PR TITLE
DISPATCH-2250: add extra poll for output after event batch

### DIFF
--- a/src/container.c
+++ b/src/container.c
@@ -481,6 +481,10 @@ void qd_conn_event_batch_complete(qd_container_t *container, qd_connection_t *qd
         to_free = DEQ_HEAD(qd_conn->free_link_session_list);
 
     }
+
+    if (!conn_closed) {
+        writable_handler(container, qd_conn->pn_conn, qd_conn);
+    }
 }
 
 


### PR DESCRIPTION
This improves single-router throughput by about 8% for small message
traffic.  The extra poll picks up any output work scheduled by the
core since the last PN_CONNECTION_WAKE event.