### PR TITLE
NO-JIRA Update GHA to Fedora 35; Add Python 3.10 tox profile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -255,7 +255,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         container: ['fedora']
-        containerTag: ['34']
+        containerTag: ['35']
         buildType: [RelWithDebInfo]
         runtimeCheck: [asan, tsan]
         shard: [ 1, 2 ]

--- a/tests/tox.ini.in
+++ b/tests/tox.ini.in
@@ -18,7 +18,7 @@
 #
 
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,py310
 skipsdist = True
 minversion = ${TOX_VERSION}
 skip_missing_interpreters = True
@@ -46,6 +46,9 @@ basepython = python3.8
 
 [testenv:py39]
 basepython = python3.9
+
+[testenv:py310]
+basepython = python3.10
 
 [flake8]
 # TODO(DISPATCH-1974) decrease the limit


### PR DESCRIPTION
WIP: TSAN seems to crash here without any messages

```
4: Test command: /usr/bin/python3 "/__w/qpid-dispatch/qpid-dispatch/qpid-dispatch/build/tests/run.py" "unit_tests_size" "7"
4: Test timeout computed to be: 1200
 1/37 Test  #4: unit_tests_size_7 .................................***Exception: SegFault  0.21 sec
```