### PR TITLE
DISPATCH-2277 Aligned memory allocation and freeing

### DIFF
--- a/include/qpid/dispatch/ctools.h
+++ b/include/qpid/dispatch/ctools.h
@@ -41,7 +41,7 @@
 //
 
 #ifdef __sun
-#define NEW_CACHE_ALIGNED(t,p)                  \
+#define NEW_CACHE_ALIGNED(t,p) \
 do { \
     p = memalign(64, sizeof(t) + (sizeof(t) % 64 ? 64 - (sizeof(t) % 64) : 0)); \
 } while (0)
@@ -51,8 +51,37 @@ do { \
     p = memalign(64, s + (s % 64 ? 64 - (s % 64) : 0)); \
 } while (0)
 
+#define FREE_CACHE_ALIGNED(p) \
+do { \
+    free(p); \
+} while (0)
 
 #else
+
+// https://stackoverflow.com/questions/33696092/whats-the-correct-replacement-for-posix-memalign-in-windows
+
+// There is a subtle difference. The POSIX function requires that the alignment is both a multiple of sizeof(void *) and a power of two. The Windows CRT function relaxes that requirement to only a power of two (i.e. not a multiple of the pointer size). This is only relevant when porting from Windows to POSIX since the requirement is always satisfied in the opposite case.
+
+#if defined(_WIN32)
+// Be careful that memory obtained from _aligned_malloc() must be freed with _aligned_free(), while posix_memalign() just uses regular free(). So you'd want to add something like:
+inline static int posix_memalign(void **ptr, const size_t alignment, const size_t size) {
+    *ptr = _aligned_malloc(size, alignment);
+    if (!*ptr) {
+        return -1;
+    }
+    return 0;
+}
+#define FREE_CACHE_ALIGNED(p) \
+do { \
+    _aligned_free(p); \
+} while (0)
+#else
+#define FREE_CACHE_ALIGNED(p) \
+do { \
+    free(p); \
+} while (0)
+#endif
+
 #define NEW_CACHE_ALIGNED(t,p) \
 do { \
     if (posix_memalign((void*) &(p), 64, (sizeof(t) + (sizeof(t) % 64 ? 64 - (sizeof(t) % 64) : 0))) != 0) (p) = 0; \

--- a/include/qpid/dispatch/ctools.h
+++ b/include/qpid/dispatch/ctools.h
@@ -51,37 +51,8 @@ do { \
     p = memalign(64, s + (s % 64 ? 64 - (s % 64) : 0)); \
 } while (0)
 
-#define FREE_CACHE_ALIGNED(p) \
-do { \
-    free(p); \
-} while (0)
 
 #else
-
-// https://stackoverflow.com/questions/33696092/whats-the-correct-replacement-for-posix-memalign-in-windows
-
-// There is a subtle difference. The POSIX function requires that the alignment is both a multiple of sizeof(void *) and a power of two. The Windows CRT function relaxes that requirement to only a power of two (i.e. not a multiple of the pointer size). This is only relevant when porting from Windows to POSIX since the requirement is always satisfied in the opposite case.
-
-#if defined(_WIN32)
-// Be careful that memory obtained from _aligned_malloc() must be freed with _aligned_free(), while posix_memalign() just uses regular free(). So you'd want to add something like:
-inline static int posix_memalign(void **ptr, const size_t alignment, const size_t size) {
-    *ptr = _aligned_malloc(size, alignment);
-    if (!*ptr) {
-        return -1;
-    }
-    return 0;
-}
-#define FREE_CACHE_ALIGNED(p) \
-do { \
-    _aligned_free(p); \
-} while (0)
-#else
-#define FREE_CACHE_ALIGNED(p) \
-do { \
-    free(p); \
-} while (0)
-#endif
-
 #define NEW_CACHE_ALIGNED(t,p) \
 do { \
     if (posix_memalign((void*) &(p), 64, (sizeof(t) + (sizeof(t) % 64 ? 64 - (sizeof(t) % 64) : 0))) != 0) (p) = 0; \
@@ -92,6 +63,11 @@ do { \
     if (posix_memalign((void*) &(p), 64, (s + (s % 64 ? 64 - (s % 64) : 0))) != 0) (p) = 0; \
 } while (0)
 #endif
+
+#define FREE_CACHE_ALIGNED(p) \
+do { \
+    free(p); \
+} while (0)
 
 #define ZERO(p) memset(p, 0, sizeof(*p))
 

--- a/src/posix/threading.c
+++ b/src/posix/threading.c
@@ -48,7 +48,7 @@ sys_mutex_t *sys_mutex(void)
 void sys_mutex_free(sys_mutex_t *mutex)
 {
     pthread_mutex_destroy(&(mutex->mutex));
-    free(mutex);
+    FREE_CACHE_ALIGNED(mutex);
 }
 
 


### PR DESCRIPTION
This is still messy, but it seems to work well on Windows. The main change is that ALIGNED allocations now require ALIGNED free. This is only checked on Windows, on other platforms it does not matter.

There used to be an inconsitency of allocating `tpool` both aligned and unaligned. I am changing this to be aligned always. This could possibly be fixed as its own separate bug...