### PR TITLE
DISPATCH-2275: restore testing of proton main branch in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'apache/qpid-proton'
-          ref: '0.36.0'
+          ref: 'main'
           path: 'qpid-proton'
 
       - uses: actions/checkout@v2
@@ -323,7 +323,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'apache/qpid-proton'
-          ref: '0.36.0'
+          ref: 'main'
           path: 'qpid-proton'
 
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Debug
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
   - name: "qdrouterd:Coverage"
     os: linux
@@ -115,7 +115,7 @@ jobs:
     env:
       - QPID_SYSTEM_TEST_TIMEOUT=300
       - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-      - PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+      - PROTON_VERSION=main BUILD_TYPE=RelWithDebInfo
       - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal) on arm64"
     arch: arm64
@@ -174,7 +174,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=main
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
     # exclude tests that require raw_connection functionality; not available in libuv proactor
     - DISPATCH_CTEST_EXTRA='-E system_tests_tcp_adaptor|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc|system_tests_http1_over_tcp'


### PR DESCRIPTION
Defer checkin until post 1.18.0 release.