### PR TITLE
DISPATCH-2286: reset the raw conn context when handling disconnect

### DIFF
--- a/src/adaptors/http2/http2_adaptor.c
+++ b/src/adaptors/http2/http2_adaptor.c
@@ -2317,6 +2317,7 @@ static void handle_disconnected(qdr_http2_connection_t* conn)
 
     if (conn->pn_raw_conn) {
         qd_log(http2_adaptor->log_source, QD_LOG_TRACE, "[C%"PRIu64"] Setting conn->pn_raw_conn=0", conn->conn_id);
+        pn_raw_connection_set_context(conn->pn_raw_conn, 0);
         conn->pn_raw_conn = 0;
     }
 

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -833,6 +833,7 @@ static void handle_connection_event(pn_event_t *e, qd_server_t *qd_server, void 
                "[C%"PRIu64"] PN_RAW_CONNECTION_DISCONNECTED %s",
                conn->conn_id, qdr_tcp_connection_role_name(conn));
         LOCK(conn->activation_lock);
+        pn_raw_connection_set_context(conn->pn_raw_conn, 0);
         conn->pn_raw_conn = 0;
         UNLOCK(conn->activation_lock);
         handle_disconnected(conn);


### PR DESCRIPTION
There's a bug in proton raw connection events where PN_RAW_CONNECTION_WAKE events can arrive *after* the PN_RAW_CONNECTION_DISCONNECTED event.   Clearing this context value ensures these extra events are ignored.