### PR TITLE
DISPATCH-2299 re-enable system_tests_http delete listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ install
 .pydevproject
 tests/system_test.dir/
 tests/policy-1/policy-*.json
-tests/system_tests_http.py
-python/qpid_dispatch_internal/management/agent.py
 *.iml
 .idea
 .metadata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,26 +128,6 @@ find_package(LibWebSockets 3.0.1)
 CMAKE_DEPENDENT_OPTION(USE_LIBWEBSOCKETS "Use libwebsockets for WebSocket support" ON
                          "LIBWEBSOCKETS_FOUND" OFF)
 
-set(SKIP_DELETE_HTTP_LISTENER "True")
-if (LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
-  # This is a fix for DISPATCH-1513. libwebsockets versions 3.2.0 introduces a new flag called LWS_SERVER_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER
-  # The new flag allows (as the flag says) HTTP over HTTPS listeners. Since this flag is not available before lws 3.2.0 we need
-  # to selectively comment out a test.
-  set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "#")
-  set(LWS_VERSION_WITH_SSL_FIX "3.2.0")
-  if ((LIBWEBSOCKETS_VERSION_STRING STREQUAL LWS_VERSION_WITH_SSL_FIX) OR (LIBWEBSOCKETS_VERSION_STRING STRGREATER  LWS_VERSION_WITH_SSL_FIX))
-    set(TEST_OPTION_ALLOW_HTTP_ON_HTTPS_LISTENER "")
-  endif()
-  # The listener delete functionality worked in all versions of LibWebSockets
-  # starting from v2.4.2 thru v3.2.3. It stopped working in v4.0.0 and beyond
-  if ( (LIBWEBSOCKETS_VERSION_STRING STREQUAL "2.4.2") OR (  (LIBWEBSOCKETS_VERSION_STRING STRGREATER_EQUAL  "3.0.0") AND (LIBWEBSOCKETS_VERSION_STRING STRLESS  "4.0.0") )  )
-    # Do not skip the tests (in system_tests_http.py) that specifically
-    # test deletion of http:yes listeners.
-    set(SKIP_DELETE_HTTP_LISTENER "False")
-  endif()
-
-endif(LIBWEBSOCKETS_FOUND AND LIBWEBSOCKETS_VERSION_STRING)
-
 if (NOT DEFINED DISPATCH_TEST_TIMEOUT)
     set(DISPATCH_TEST_TIMEOUT "600")
 endif (NOT DEFINED DISPATCH_TEST_TIMEOUT)
@@ -283,8 +263,6 @@ install(FILES
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/run.py.in ${CMAKE_CURRENT_BINARY_DIR}/run.py)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/run.py.in ${CMAKE_CURRENT_BINARY_DIR}/tests/run.py)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/system_tests_http.py.in ${CMAKE_CURRENT_SOURCE_DIR}/tests/system_tests_http.py)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/python/qpid_dispatch_internal/management/agent.py.in ${CMAKE_CURRENT_SOURCE_DIR}/python/qpid_dispatch_internal/management/agent.py)
 execute_process(COMMAND ${RUN} --sh OUTPUT_FILE config.sh)
 
 add_subdirectory(src) # Build src first so other subdirs can use qpid-dispatch library

--- a/cmake/FindLibWebSockets.cmake
+++ b/cmake/FindLibWebSockets.cmake
@@ -45,10 +45,11 @@ find_path(LIBWEBSOCKETS_INCLUDE_DIRS
   PATHS "/usr/include"
   )
 
+# strips trailing version elaboration, e.g. #define LWS_LIBRARY_VERSION "4.1.6-git..."
 if(LIBWEBSOCKETS_INCLUDE_DIRS AND EXISTS "${LIBWEBSOCKETS_INCLUDE_DIRS}/lws_config.h")
   file(STRINGS "${LIBWEBSOCKETS_INCLUDE_DIRS}/lws_config.h" lws_version_str
     REGEX "^#define[ \t]+LWS_LIBRARY_VERSION[ \t]+\"[^\"]+\"")
-  string(REGEX REPLACE "^#define[ \t]+LWS_LIBRARY_VERSION[ \t]+\"([^\"]+)\".*" "\\1"
+  string(REGEX REPLACE "^#define[ \t]+LWS_LIBRARY_VERSION[ \t]+\"([0-9.]+).*" "\\1"
     LIBWEBSOCKETS_VERSION_STRING "${lws_version_str}")
   unset(lws_version_str)
 endif()

--- a/python/qpid_dispatch_internal/display_name/__init__.py
+++ b/python/qpid_dispatch_internal/display_name/__init__.py
@@ -16,4 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-"Qpid Dispatch internal display name service"
+
+"""Qpid Dispatch internal display name service"""

--- a/python/qpid_dispatch_internal/management/agent.py
+++ b/python/qpid_dispatch_internal/management/agent.py
@@ -33,7 +33,7 @@ EntityAdapters are created/deleted in two ways:
 - Externally by CREATE/DELETE operations (or loading config file)
 - Internally by creation or deletion of corresponding implementation object.
 
-Memory managment: The implementation is reponsible for informing the L{Agent}
+Memory management: The implementation is responsible for informing the L{Agent}
 when an implementation object is created and *before* it is deleted in the case
 of a C object.
 
@@ -75,6 +75,7 @@ from io import StringIO
 from ctypes import c_void_p, py_object, c_long
 from subprocess import Popen
 
+import qpid_dispatch_site
 from ..dispatch import IoAdapter, LogAdapter, LOG_INFO, LOG_WARNING, LOG_DEBUG, LOG_ERROR, TREATMENT_ANYCAST_CLOSEST
 from qpid_dispatch.management.error import ManagementError, OK, CREATED, NO_CONTENT, STATUS_TEXT, \
     BadRequestStatus, InternalServerErrorStatus, NotImplementedStatus, NotFoundStatus
@@ -435,7 +436,7 @@ class ListenerEntity(ConnectionBaseEntity):
         return super(ListenerEntity, self).__str__().replace("Entity(", "ListenerEntity(")
 
     def _delete(self):
-        if self.http and ${SKIP_DELETE_HTTP_LISTENER}:
+        if self.http and qpid_dispatch_site.SKIP_DELETE_HTTP_LISTENER:
             raise BadRequestStatus("HTTP listeners cannot be deleted")
         self._qd.qd_connection_manager_delete_listener(self._dispatch, self._implementations[0].key)
 

--- a/python/qpid_dispatch_site.py.in
+++ b/python/qpid_dispatch_site.py.in
@@ -20,16 +20,32 @@
 """
 INTERNAL USE ONLY - Install locations and other site information for qpid dispatch.
 """
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
+
+import sys
 
 from os.path import join
 from os import environ
-import sys
+from typing import Optional, Tuple
 
-HOME = environ.get("QPID_DISPATCH_HOME") or "${QPID_DISPATCH_HOME_INSTALLED}"
+
+def populate_pythonpath() -> None:
+    """Makes qpid_dispatch_internal available. Modifies sys.path."""
+    home = environ.get("QPID_DISPATCH_HOME") or "${QPID_DISPATCH_HOME_INSTALLED}"
+    sys.path.insert(0, join(home, 'python'))
+
+
+def parse_version(version: str) -> Optional[Tuple[int, int, int]]:
+    """Returns a 3-tuple semver version, or None (if say version is an empty string)."""
+    if not version:
+        return None
+    try:
+        major, minor, patch = (int(v) for v in version.split('.'))
+        return major, minor, patch
+    except ValueError as e:
+        raise ValueError(f"version '{version}' cannot be parsed") from e
+
+
 VERSION = "${QPID_DISPATCH_VERSION}"
 
-sys.path.insert(0, join(HOME, 'python'))
+LIBWEBSOCKETS_VERSION: Optional[Tuple[int, int, int]] = parse_version("${LIBWEBSOCKETS_VERSION_STRING}")
+SKIP_DELETE_HTTP_LISTENER = (4, 0, 0) <= LIBWEBSOCKETS_VERSION < (4, 2, 0)

--- a/tests/system_tests_http.py
+++ b/tests/system_tests_http.py
@@ -97,7 +97,8 @@ class RouterTestHttp(TestCase):
                 self.get(url, use_ca=use_ca)
             return False
         except OSError as e:
-            expected = (errno.ECONNREFUSED, errno.ECONNRESET)
+            # EADDRNOTAVAIL happens in Docker when connecting to localhost:port where nobody listens
+            expected = (errno.ECONNREFUSED, errno.ECONNRESET, errno.EADDRNOTAVAIL)
             if e.errno in expected or e.reason.errno in expected:
                 return True
             raise e

--- a/tools/qdmanage
+++ b/tools/qdmanage
@@ -24,7 +24,9 @@ import json
 import re
 from collections.abc import Mapping, Sequence
 
-import qpid_dispatch_site  # noqa: F401 # imported for side-effects (inserts to sys.path)
+import qpid_dispatch_site
+qpid_dispatch_site.populate_pythonpath()
+
 from qpid_dispatch.management.client import Node
 from qpid_dispatch_internal.tools.command import (UsageError, _qdmanage_parser, check_args,
                                                   main, opts_ssl_domain, opts_url, opts_sasl)

--- a/tools/qdstat
+++ b/tools/qdstat
@@ -23,7 +23,9 @@ import sys
 from datetime import datetime
 from time import ctime, strftime, gmtime
 
-import qpid_dispatch_site  # noqa: F401 # imported for side-effects (inserts to sys.path)
+import qpid_dispatch_site
+qpid_dispatch_site.populate_pythonpath()
+
 from qpid_dispatch.management.client import Node
 from qpid_dispatch_internal.management.qdrouter import QdSchema
 from qpid_dispatch_internal.tools import Display, Header, Sorter, TimeLong, TimeShort, BodyFormat, PlainNum


### PR DESCRIPTION
There are two stages to this. First, use CMake to generate a properties file that configures the tests, and then use the file in the tests; instead of generating the py sources directly. Next, the issue itself is addressed, which is now much easier, because there is less complicated CMake logic to deal with.