### PR TITLE
NO-JIRA use pip-installed tox instead of system-wide in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/opt/local/bin:/opt/local/sbin:$PATH" PROTON_VERSION=main
+    - PATH="/opt/local/bin:/opt/local/sbin:$HOME/.local/bin:$PATH" PROTON_VERSION=main
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
     # exclude tests that require raw_connection functionality; not available in libuv proactor
     - DISPATCH_CTEST_EXTRA='-E system_tests_tcp_adaptor|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc|system_tests_http1_over_tcp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,26 +47,26 @@ jobs:
     after_script:
     - cat target/rat.txt || true
   # prepending /usr/bin to PATH to avoid mismatched python interpreters in /opt
-  # also prepending /usr/local/bin to pick up pip-installed tox instead of /usr/bin/tox
+  # also prepending $HOME/.local/bin to pick up pip-installed tox instead of /usr/bin/tox
   - name: "qdrouterd:Debug (gcc on xenial)"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
+    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
   - name: "qdrouterd:Coverage"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Coverage
+    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Coverage
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on xenial)"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
     os: linux
@@ -92,7 +92,7 @@ jobs:
     - QPID_SYSTEM_TEST_SKIP_HTTP2_LARGE_IMAGE_UPLOAD_TEST=True
     - CC=clang-13
     - CXX=clang++-13
-    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on focal)"
     arch: s390x
@@ -148,7 +148,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
   - name: "qdrouterd:TSAN"
     os: linux
     dist: focal
@@ -167,7 +167,7 @@ jobs:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
     - QPID_SYSTEM_TEST_SKIP_HTTP2_LARGE_IMAGE_UPLOAD_TEST=True
-    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=tsan'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on macOS)"
     os: osx
@@ -175,7 +175,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=main
+    - PATH="/opt/local/bin:/opt/local/sbin:$HOME/.local/bin:$PATH" PROTON_VERSION=main
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
     # exclude tests that require raw_connection functionality; not available in libuv proactor
     - DISPATCH_CTEST_EXTRA='-E system_tests_tcp_adaptor|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc|system_tests_http1_over_tcp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/opt/local/bin:/opt/local/sbin:$HOME/.local/bin:$PATH" PROTON_VERSION=main
+    - PATH="/opt/local/bin:/opt/local/sbin:/usr/local/bin:$PATH" PROTON_VERSION=main
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
     # exclude tests that require raw_connection functionality; not available in libuv proactor
     - DISPATCH_CTEST_EXTRA='-E system_tests_tcp_adaptor|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc|system_tests_http1_over_tcp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ jobs:
     # Update pip, it may prevent issues later
     - sudo apt-get install -y python3-pip
     - python3 -m pip install --user --upgrade pip
-    - python3 -m pip install --user --upgrade tox virtualenv
+    - python3 -m pip install --user tox
     # Install quart, h2 to run the http2 tests.
     - python3 -m pip install --user quart h2
     # DISPATCH-1883: Install selectors to run tcp echo server/client tools
@@ -103,7 +103,7 @@ jobs:
       - nvm install "lts/*"
       # Update pip, it may prevent issues later
       - python3 -m pip install --user --upgrade pip
-      - python3 -m pip install --user --upgrade tox virtualenv
+      - python3 -m pip install --user tox
       # Install quart to run the http2 tests.
       - python3 -m pip install --user quart
       # DISPATCH-1883: Install selectors to run tcp echo server/client tools
@@ -129,7 +129,7 @@ jobs:
       - nvm install "lts/*"
       # Update pip, it may prevent issues later
       - python3 -m pip install --user --upgrade pip
-      - python3 -m pip install --user --upgrade tox virtualenv
+      - python3 -m pip install --user tox
       # Install quart to run the http2 tests.
       - python3 -m pip install --user quart
       # DISPATCH-1883: Install selectors to run tcp echo server/client tools
@@ -156,7 +156,7 @@ jobs:
       # Update pip, it may prevent issues later
       - sudo apt-get install -y python3-pip
       - python3 -m pip install --user --upgrade pip
-      - python3 -m pip install --user --upgrade tox virtualenv
+      - python3 -m pip install --user tox
       # Install quart to run the http2 tests.
       - python3 -m pip install --user quart
       # DISPATCH-1883: Install selectors to run tcp echo server/client tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ jobs:
     # Update pip, it may prevent issues later
     - sudo apt-get install -y python3-pip
     - python3 -m pip install --user --upgrade pip
-    - python3 -m pip install --user tox
+    - python3 -m pip install --user tox virtualenv
     # Install quart, h2 to run the http2 tests.
     - python3 -m pip install --user quart h2
     # DISPATCH-1883: Install selectors to run tcp echo server/client tools
@@ -103,7 +103,7 @@ jobs:
       - nvm install "lts/*"
       # Update pip, it may prevent issues later
       - python3 -m pip install --user --upgrade pip
-      - python3 -m pip install --user tox
+      - python3 -m pip install --user tox virtualenv
       # Install quart to run the http2 tests.
       - python3 -m pip install --user quart
       # DISPATCH-1883: Install selectors to run tcp echo server/client tools
@@ -129,7 +129,7 @@ jobs:
       - nvm install "lts/*"
       # Update pip, it may prevent issues later
       - python3 -m pip install --user --upgrade pip
-      - python3 -m pip install --user tox
+      - python3 -m pip install --user tox virtualenv
       # Install quart to run the http2 tests.
       - python3 -m pip install --user quart
       # DISPATCH-1883: Install selectors to run tcp echo server/client tools
@@ -156,7 +156,7 @@ jobs:
       # Update pip, it may prevent issues later
       - sudo apt-get install -y python3-pip
       - python3 -m pip install --user --upgrade pip
-      - python3 -m pip install --user tox
+      - python3 -m pip install --user tox virtualenv
       # Install quart to run the http2 tests.
       - python3 -m pip install --user quart
       # DISPATCH-1883: Install selectors to run tcp echo server/client tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,26 +47,25 @@ jobs:
     after_script:
     - cat target/rat.txt || true
   # prepending /usr/bin to PATH to avoid mismatched python interpreters in /opt
-  # also prepending $HOME/.local/bin to pick up pip-installed tox instead of /usr/bin/tox
   - name: "qdrouterd:Debug (gcc on xenial)"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
   - name: "qdrouterd:Coverage"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Coverage
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Coverage
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on xenial)"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
     os: linux
@@ -92,7 +91,7 @@ jobs:
     - QPID_SYSTEM_TEST_SKIP_HTTP2_LARGE_IMAGE_UPLOAD_TEST=True
     - CC=clang-13
     - CXX=clang++-13
-    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on focal)"
     arch: s390x
@@ -148,7 +147,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0
   - name: "qdrouterd:TSAN"
     os: linux
     dist: focal
@@ -167,7 +166,7 @@ jobs:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
     - QPID_SYSTEM_TEST_SKIP_HTTP2_LARGE_IMAGE_UPLOAD_TEST=True
-    - PATH="$HOME/.local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=tsan'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on macOS)"
     os: osx
@@ -175,7 +174,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/opt/local/bin:/opt/local/sbin:$HOME/.local/bin:$PATH" PROTON_VERSION=main
+    - PATH="/opt/local/bin:/opt/local/sbin:$PATH" PROTON_VERSION=main
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG -DQD_ENABLE_ASSERTIONS=ON -DDISPATCH_TEST_TIMEOUT=500'
     # exclude tests that require raw_connection functionality; not available in libuv proactor
     - DISPATCH_CTEST_EXTRA='-E system_tests_tcp_adaptor|system_tests_http1_adaptor|system_tests_http2|system_tests_grpc|system_tests_http1_over_tcp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,25 +47,26 @@ jobs:
     after_script:
     - cat target/rat.txt || true
   # prepending /usr/bin to PATH to avoid mismatched python interpreters in /opt
+  # also prepending /usr/local/bin to pick up pip-installed tox instead of /usr/bin/tox
   - name: "qdrouterd:Debug (gcc on xenial)"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
+    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=main BUILD_TYPE=Debug
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan'
   - name: "qdrouterd:Coverage"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Coverage
+    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=Coverage
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on xenial)"
     os: linux
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on focal)"
     os: linux
@@ -91,7 +92,7 @@ jobs:
     - QPID_SYSTEM_TEST_SKIP_HTTP2_LARGE_IMAGE_UPLOAD_TEST=True
     - CC=clang-13
     - CXX=clang++-13
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
+    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0 BUILD_TYPE=RelWithDebInfo
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=asan -DCMAKE_C_FLAGS=-DQD_MEMORY_DEBUG'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (gcc on focal)"
     arch: s390x
@@ -147,7 +148,7 @@ jobs:
     env:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
   - name: "qdrouterd:TSAN"
     os: linux
     dist: focal
@@ -166,7 +167,7 @@ jobs:
     - QPID_SYSTEM_TEST_TIMEOUT=300
     - QPID_SYSTEM_TEST_SKIP_FALLBACK_SWITCHOVER_TEST=True
     - QPID_SYSTEM_TEST_SKIP_HTTP2_LARGE_IMAGE_UPLOAD_TEST=True
-    - PATH="/usr/bin:$PATH" PROTON_VERSION=0.36.0
+    - PATH="/usr/local/bin:/usr/bin:$PATH" PROTON_VERSION=0.36.0
     - DISPATCH_CMAKE_ARGS='-DRUNTIME_CHECK=tsan'
   - name: "qdrouterd:RelWithDebInfo+MemoryDebug (clang on macOS)"
     os: osx

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,7 +194,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tox.ini.in ${CMAKE_CURRENT_BINARY_DIR
 # since that version allows us to skip the install step (we have
 # no modules thus no setup.py)
 #
-find_program(TOX_EXE "tox" PATHS ENV PATH)
+find_program(TOX_EXE "tox")
 if (TOX_EXE)
   # the "skip_install" feature showed up in version 1.9.0 tox,
   # which is used by our tox.ini script:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,7 +194,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tox.ini.in ${CMAKE_CURRENT_BINARY_DIR
 # since that version allows us to skip the install step (we have
 # no modules thus no setup.py)
 #
-find_program(TOX_EXE "tox")
+find_program(TOX_EXE "tox" PATHS ENV PATH)
 if (TOX_EXE)
   # the "skip_install" feature showed up in version 1.9.0 tox,
   # which is used by our tox.ini script:


### PR DESCRIPTION
```
75: Test command: /usr/bin/tox
[...]
75: py38 create: /home/travis/build/apache/qpid-dispatch/build/tests/.tox/py38
75: ERROR: invocation failed (exit code 1), logfile: /home/travis/build/apache/qpid-dispatch/build/tests/.tox/py38/log/py38-0.log
```