### PR TITLE
DISPATCH-2307: prevent router failure if id is greater than 64 bytes

### DIFF
--- a/include/qpid/dispatch/iterator.h
+++ b/include/qpid/dispatch/iterator.h
@@ -140,6 +140,12 @@ typedef struct {
  */
 
 /**
+ * Clean up any internal state in the iterator library.  This must be called at
+ * shutdown after all iterators have been released.
+ */
+void qd_iterator_finalize(void);
+
+/**
  * Set the area and router names for the local router.  These are used to match
  * my-area and my-router in address fields.  These settings are global and used
  * for all iterators in the process.

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -547,12 +547,10 @@ void qd_message_set_tag_sent(qd_message_t *msg, bool tag_sent);
 /**
  * Increase the fanout of the message by 1.
  *
- * @param in_msg A pointer to the inbound message.
- * @param out_msg A pointer to the outbound message or 0 if forwarding to a
- * local subscriber.
+ * @param out_msg A pointer to the message to be sent outbound or to a local
+ * subscriber.
  */
-void qd_message_add_fanout(qd_message_t *in_msg,
-                           qd_message_t *out_msg);
+void qd_message_add_fanout(qd_message_t *out_msg);
 
 /**
  * Disable the Q2-holdoff for this message.

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -379,6 +379,7 @@ void qd_dispatch_free(qd_dispatch_t *qd)
     qd_python_finalize();
     qd_dispatch_set_router_id(qd, NULL);
     qd_dispatch_set_router_area(qd, NULL);
+    qd_iterator_finalize();
     free(qd->timestamp_format);
     free(qd->metadata);
 

--- a/src/message.c
+++ b/src/message.c
@@ -1274,12 +1274,9 @@ void qd_message_set_discard(qd_message_t *msg, bool discard)
 
 // update the buffer reference counts for a new outgoing message
 //
-void qd_message_add_fanout(qd_message_t *in_msg,
-                           qd_message_t *out_msg)
+void qd_message_add_fanout(qd_message_t *out_msg)
 {
-    if (!out_msg)
-        return;
-
+    assert(out_msg);
     qd_message_pvt_t *msg = (qd_message_pvt_t *)out_msg;
     msg->is_fanout = true;
 

--- a/src/router_core/forwarder.c
+++ b/src/router_core/forwarder.c
@@ -180,7 +180,7 @@ qdr_delivery_t *qdr_forward_new_delivery_CT(qdr_core_t *core, qdr_delivery_t *in
     //
     // Add one to the message fanout. This will later be used in the qd_message_send function that sends out messages.
     //
-    qd_message_add_fanout(msg, out_dlv->msg);
+    qd_message_add_fanout(out_dlv->msg);
 
     //
     // Create peer linkage if the outgoing delivery is unsettled. This peer linkage is necessary to deal with dispositions that show up in the future.
@@ -439,7 +439,7 @@ static inline bool qdr_forward_edge_echo_CT(qdr_delivery_t *in_dlv, qdr_link_t *
  */
 static void qdr_forward_to_subscriber_CT(qdr_core_t *core, qdr_subscription_t *sub, qdr_delivery_t *in_dlv, qd_message_t *in_msg, bool receive_complete)
 {
-    qd_message_add_fanout(in_msg, 0);
+    qd_message_add_fanout(in_msg);
 
     //
     // Only if the message has been completely received, forward it to the subscription.

--- a/tests/c_unittests/helpers.hpp
+++ b/tests/c_unittests/helpers.hpp
@@ -305,6 +305,7 @@ class QDRMinimalEnv
         qd_log_finalize();
         qd_alloc_finalize();
         qd_entity_cache_free_entries();
+        qd_iterator_finalize();
     }
 };
 

--- a/tests/message_test.c
+++ b/tests/message_test.c
@@ -1167,9 +1167,9 @@ static char *test_check_stream_data_fanout(void *context)
 
     // "fan out" the message
     out_msg1 = qd_message_copy(in_msg);
-    qd_message_add_fanout(in_msg, out_msg1);
+    qd_message_add_fanout(out_msg1);
     out_msg2 = qd_message_copy(in_msg);
-    qd_message_add_fanout(in_msg, out_msg2);
+    qd_message_add_fanout(out_msg2);
 
     // walk the data streams for both messages:
     qd_message_stream_data_t *out_sd1[sd_count] = {0};
@@ -1291,9 +1291,9 @@ static char *test_check_stream_data_footer(void *context)
 
     // "fan out" the message
     out_msg1 = qd_message_copy(in_msg);
-    qd_message_add_fanout(in_msg, out_msg1);
+    qd_message_add_fanout(out_msg1);
     out_msg2 = qd_message_copy(in_msg);
-    qd_message_add_fanout(in_msg, out_msg2);
+    qd_message_add_fanout(out_msg2);
 
     qd_message_stream_data_t *stream_data = 0;
     bool done = false;

--- a/tests/run_unit_tests_size.c
+++ b/tests/run_unit_tests_size.c
@@ -19,6 +19,7 @@
 
 #include "qpid/dispatch/alloc.h"
 #include "qpid/dispatch/buffer.h"
+#include "qpid/dispatch/iterator.h"
 
 void qd_log_initialize(void);
 void qd_log_finalize(void);
@@ -52,6 +53,7 @@ int main(int argc, char** argv)
 
     qd_log_finalize();
     qd_alloc_finalize();
+    qd_iterator_finalize();
     return result;
 }
 


### PR DESCRIPTION
fixes:
  - buffer overflow in iterator library
  - incorrect fanout value for locally destined messages