### PR TITLE
DISPATCH-2323 Try binding to a port before handing it out as "free"

### DIFF
--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -28,7 +28,8 @@ Features:
 - Sundry other tools.
 """
 
-from typing import Callable
+import logging
+from typing import Callable, List, Optional, Tuple
 
 import errno
 import sys
@@ -1406,19 +1407,22 @@ class Logger:
     """
     Record an event log for a self test.
     May print per-event or save events to be printed later.
+    Pytest will automatically collect the logs and will dump them for a failed test
     Optional file opened in 'append' mode to which each log line is written.
     """
 
     def __init__(self,
-                 title="Logger",
-                 print_to_console=False,
-                 save_for_dump=True,
-                 ofilename=None):
+                 title: str = "Logger",
+                 print_to_console: bool = False,
+                 save_for_dump: bool = True,
+                 python_log_level: Optional[int] = logging.DEBUG,
+                 ofilename: Optional[str] = None) -> None:
         self.title = title
         self.print_to_console = print_to_console
         self.save_for_dump = save_for_dump
-        self.logs = []
+        self.python_log_level = python_log_level
         self.ofilename = ofilename
+        self.logs: List[Tuple[Timestamp, str]] = []
 
     def log(self, msg):
         ts = Timestamp()
@@ -1427,6 +1431,8 @@ class Logger:
         if self.print_to_console:
             print("%s %s" % (ts, msg))
             sys.stdout.flush()
+        if self.python_log_level is not None:
+            logging.log(self.python_log_level, f"{ts} {self.title}: {msg}")
         if self.ofilename is not None:
             with open(self.ofilename, 'a') as f_out:
                 f_out.write("%s %s\n" % (ts, msg))

--- a/tests/system_tests_http1_over_tcp.py
+++ b/tests/system_tests_http1_over_tcp.py
@@ -70,6 +70,12 @@ class Http1OverTcpOneRouterTest(Http1OneRouterTestBase,
                                                   handler_cls=RequestHandler10)
         cls.INT_A.wait_connectors()
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.http10_server.wait()
+        cls.http11_server.wait()
+        super().tearDownClass()
+
 
 class Http1OverTcpEdge2EdgeTest(Http1Edge2EdgeTestBase, CommonHttp1Edge2EdgeTest):
     """

--- a/tests/tox.ini.in
+++ b/tests/tox.ini.in
@@ -149,6 +149,9 @@ exclude =
 # do not filter test file names
 python_files = *.py
 
+# https://docs.pytest.org/en/6.2.x/logging.html#incompatible-changes-in-pytest-3-4
+log_level = DEBUG
+
 # pylint
 [MESSAGE_CONTROL]
 disable =


### PR DESCRIPTION
This has three more-or-less independent commits. I did not understand the full problem at first, so I tried to get the ports in a better way. Which I still think is worthwhile to do, but it does not fix all the fails.

Second commit avoids the daemon threads and fudge sleeps, which only obfuscate the problems and don't really do all that much good.

Third commit adds log dump to Git Hub Actions (or whenever the tests are being run by pytest). See for example https://github.com/apache/qpid-dispatch/runs/4998230289?check_suite_focus=true#step:27:703 to see what it looks like when test fails. There are logging messages from proton and from the test itself.