### PR TITLE
DISPATCH-2310: limit router identifiers to 255 characters

### DIFF
--- a/include/qpid/dispatch/router.h
+++ b/include/qpid/dispatch/router.h
@@ -33,6 +33,8 @@
 
 #include <stdbool.h>
 
+#define QD_ROUTER_ID_MAX 127  // max length of router id in chars
+
 typedef struct qdr_core_t   qdr_core_t;
 typedef struct qd_router_t  qd_router_t;
 typedef struct qd_address_t qd_address_t;

--- a/tests/system_tests_routing_protocol.py
+++ b/tests/system_tests_routing_protocol.py
@@ -211,6 +211,8 @@ class HugeRouterIdTest(TestCase):
 
     Deploy a mesh of four routers with ids > 64 octets in length.
     """
+    MAX_ID_LEN = 127
+
     @classmethod
     def setUpClass(cls):
         super(HugeRouterIdTest, cls).setUpClass()
@@ -235,27 +237,27 @@ class HugeRouterIdTest(TestCase):
         ir_port_C = cls.tester.get_port()
         ir_port_D = cls.tester.get_port()
 
-        name_suffix = "." + "X" * 128
+        name_suffix = "X" * (cls.MAX_ID_LEN - 2)
 
-        cls.RA_name = 'A' + name_suffix
+        cls.RA_name = 'A.' + name_suffix
         cls.RA = router(cls.RA_name,
                         [('listener', {'role': 'inter-router', 'port': ir_port_A}),
                          ('connector', {'role': 'inter-router', 'port': ir_port_B}),
                          ('connector', {'role': 'inter-router', 'port': ir_port_C}),
                          ('connector', {'role': 'inter-router', 'port': ir_port_D})])
 
-        cls.RB_name = 'B' + name_suffix
+        cls.RB_name = 'B.' + name_suffix
         cls.RB = router(cls.RB_name,
                         [('listener', {'role': 'inter-router', 'port': ir_port_B}),
                          ('connector', {'role': 'inter-router', 'port': ir_port_C}),
                          ('connector', {'role': 'inter-router', 'port': ir_port_D})])
 
-        cls.RC_name = 'C' + name_suffix
+        cls.RC_name = 'C.' + name_suffix
         cls.RC = router(cls.RC_name,
                         [('listener', {'role': 'inter-router', 'port': ir_port_C}),
                          ('connector', {'role': 'inter-router', 'port': ir_port_D})])
 
-        cls.RD_name = 'D' + name_suffix
+        cls.RD_name = 'D.' + name_suffix
         cls.RD = router(cls.RD_name,
                         [('listener', {'role': 'inter-router', 'port': ir_port_D})])
 


### PR DESCRIPTION
This pulls over Ted's router name fix from skupper-router