### PR TITLE
DISPATCH-2338 - dockerfiles: Introduce Debian-based slim image w/ CI tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+#
+
+Dockerfile
+dockerfiles
+
+.git
+.idea
+**/.mypy_cache
+**/.pytest_cache
+**/__pycache__
+**/*.pyc
+
+build
+cmake-build-*
+tests/system_test.dir

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -630,3 +630,15 @@ jobs:
       - name: Output
         if: ${{ ! cancelled() }}
         run: cat target/rat.txt || echo "Unable to print output"
+
+  container-images:
+    name: Container Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Debian image
+        uses: docker/build-push-action@v2
+        with:
+          file: dockerfiles/Dockerfile-debian
+          context: .

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -25,6 +25,7 @@ LABEL org.opencontainers.image.authors="dev@qpid.apache.org"
 
 # UPGRADE: proton > 0.37.0: replace `python3/dist-packages` with `python3.9/site-packages/`
 ARG proton_version=0.37.0
+# Enable web console: use 'ON' or 'OFF'
 ARG enable_console=OFF
 
 
@@ -32,7 +33,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential cmake pkg-config git ninja-build ca-certificates \
-        libssl-dev libsasl2-dev swig python3-dev libwebsockets-dev npm && \
+        libssl-dev libsasl2-dev swig python3-dev libwebsockets-dev \
+        $(if [ "${enable_console}" = "ON" ]; then echo "npm"; fi) && \
     rm -rf /var/lib/apt/lists/*
 
 # first, build Proton since there is no recent version packaged in Debian

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -17,13 +17,14 @@
 # under the License.
 #
 
+# build with specifying root of repository as build context, e.g. `buildah -f dockerfiles/Dockerfile-debian .`
+
 FROM debian:bullseye-slim AS build
 
 LABEL org.opencontainers.image.authors="dev@qpid.apache.org"
 
 # UPGRADE: proton > 0.37.0: replace `python3/dist-packages` with `python3.9/site-packages/`
 ARG proton_version=0.37.0
-ARG dispatch_version=1.19.0
 ARG enable_console=OFF
 
 
@@ -34,8 +35,8 @@ RUN apt-get update && \
         libssl-dev libsasl2-dev swig python3-dev libwebsockets-dev npm && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 -b ${dispatch_version} https://github.com/apache/qpid-dispatch.git && \
-	git clone --depth 1 -b ${proton_version} https://github.com/apache/qpid-proton.git
+# first, build Proton since there is no recent version packaged in Debian
+RUN git clone --depth 1 -b ${proton_version} https://github.com/apache/qpid-proton.git
 
 # build and install into system for laster usage by dispatch, but also install discretely so that it's easier to copy
 RUN mkdir /qpid-proton/build /qpid-proton/install-prefix && cd /qpid-proton/build && \
@@ -43,6 +44,8 @@ RUN mkdir /qpid-proton/build /qpid-proton/install-prefix && cd /qpid-proton/buil
 	cmake --build . --target install && \
 	cmake --install . --prefix /qpid-proton/install-prefix
 
+# build Dispatch Router
+ADD . /qpid-dispatch/
 RUN mkdir /qpid-dispatch/build /qpid-dispatch/install-prefix && cd /qpid-dispatch/build && \
 	cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DUSE_VALGRIND=NO -DCONSOLE_INSTALL=${enable_console} && \
 	cmake --build . && \

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -31,7 +31,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential cmake pkg-config git ninja-build ca-certificates \
-        libssl-dev libsasl2-dev libuv1-dev swig python3-dev libwebsockets-dev npm && \
+        libssl-dev libsasl2-dev swig python3-dev libwebsockets-dev npm && \
     rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth 1 -b ${dispatch_version} https://gitbox.apache.org/repos/asf/qpid-dispatch.git && \
@@ -39,7 +39,7 @@ RUN git clone --depth 1 -b ${dispatch_version} https://gitbox.apache.org/repos/a
 
 # build and install into system for laster usage by dispatch, but also install discretely so that it's easier to copy
 RUN mkdir /qpid-proton/build /qpid-proton/install-prefix && cd /qpid-proton/build && \
-	cmake .. -GNinja -DPROACTOR=libuv -DSYSINSTALL_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON && \
+	cmake .. -GNinja -DSYSINSTALL_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON && \
 	cmake --build . --target install && \
 	cmake --install . --prefix /qpid-proton/install-prefix
 
@@ -52,6 +52,11 @@ RUN mkdir /qpid-dispatch/build /qpid-dispatch/install-prefix && cd /qpid-dispatc
 #RUN cd /qpid-dispatch/build && ctest -VV
 
 FROM debian:bullseye-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libsasl2-2 libsasl2-modules libwebsockets16 \
+        python3 libpython3.9 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # proton
 COPY --from=build /qpid-proton/install-prefix /usr/
@@ -68,10 +73,6 @@ COPY --from=build /usr/share/qpid-dispatch /usr/share/qpid-dispatch
 COPY --from=build /etc/sasl2 /etc/sasl2
 COPY --from=build /usr/lib/python3.9/site-packages/qpid_dispatch /usr/lib/python3.9/site-packages/qpid_dispatch
 COPY --from=build /usr/lib/python3.9/site-packages/qpid_dispatch_site.py /usr/lib/python3.9/site-packages/
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libsasl2-2 libsasl2-modules libuv1 python3 libpython3.9 libwebsockets16 && \
-    rm -rf /var/lib/apt/lists/*
 
 # Add site-packages to the PYTHONPATH environment variable
 ENV PYTHONPATH=/usr/lib/python3.9/site-packages

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -34,8 +34,8 @@ RUN apt-get update && \
         libssl-dev libsasl2-dev swig python3-dev libwebsockets-dev npm && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 -b ${dispatch_version} https://gitbox.apache.org/repos/asf/qpid-dispatch.git && \
-	git clone --depth 1 -b ${proton_version} https://gitbox.apache.org/repos/asf/qpid-proton.git
+RUN git clone --depth 1 -b ${dispatch_version} https://github.com/apache/qpid-dispatch.git && \
+	git clone --depth 1 -b ${proton_version} https://github.com/apache/qpid-proton.git
 
 # build and install into system for laster usage by dispatch, but also install discretely so that it's easier to copy
 RUN mkdir /qpid-proton/build /qpid-proton/install-prefix && cd /qpid-proton/build && \

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -46,7 +46,8 @@ RUN mkdir /qpid-proton/build /qpid-proton/install-prefix && cd /qpid-proton/buil
 RUN mkdir /qpid-dispatch/build /qpid-dispatch/install-prefix && cd /qpid-dispatch/build && \
 	cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DUSE_VALGRIND=NO -DCONSOLE_INSTALL=${enable_console} && \
 	cmake --build . && \
-	cmake --install . --prefix /qpid-dispatch/install-prefix
+	cmake --install . --prefix /qpid-dispatch/install-prefix && \
+	mkdir -p /usr/share/qpid-dispatch  # make sure directory exists even if web console is disabled
 
 # Uncomment the following line if you would like to run all the dispatch unit tests and system tests
 #RUN cd /qpid-dispatch/build && ctest -VV

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM debian:bullseye-slim AS build
+
+LABEL org.opencontainers.image.authors="dev@qpid.apache.org"
+
+# UPGRADE: proton > 0.37.0: replace `python3/dist-packages` with `python3.9/site-packages/`
+ARG proton_version=0.37.0
+ARG dispatch_version=1.19.0
+ARG enable_console=OFF
+
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential cmake pkg-config git ninja-build ca-certificates \
+        libssl-dev libsasl2-dev libuv1-dev swig python3-dev libwebsockets-dev npm && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 -b ${dispatch_version} https://gitbox.apache.org/repos/asf/qpid-dispatch.git && \
+	git clone --depth 1 -b ${proton_version} https://gitbox.apache.org/repos/asf/qpid-proton.git
+
+# build and install into system for laster usage by dispatch, but also install discretely so that it's easier to copy
+RUN mkdir /qpid-proton/build /qpid-proton/install-prefix && cd /qpid-proton/build && \
+	cmake .. -GNinja -DPROACTOR=libuv -DSYSINSTALL_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON && \
+	cmake --build . --target install && \
+	cmake --install . --prefix /qpid-proton/install-prefix
+
+RUN mkdir /qpid-dispatch/build /qpid-dispatch/install-prefix && cd /qpid-dispatch/build && \
+	cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/usr -DUSE_VALGRIND=NO -DCONSOLE_INSTALL=${enable_console} && \
+	cmake --build . && \
+	cmake --install . --prefix /qpid-dispatch/install-prefix
+
+# Uncomment the following line if you would like to run all the dispatch unit tests and system tests
+#RUN cd /qpid-dispatch/build && ctest -VV
+
+FROM debian:bullseye-slim
+
+# proton
+COPY --from=build /qpid-proton/install-prefix /usr/
+# python packages
+COPY --from=build /usr/lib/python3/dist-packages/proton /usr/lib/python3/dist-packages/proton
+COPY --from=build /usr/lib/python3/dist-packages/cproton.py /usr/lib/python3/dist-packages/_cproton.so \
+	/usr/lib/python3/dist-packages/
+
+# qpid-dispatch
+COPY --from=build /qpid-dispatch/install-prefix /usr/
+# leftovers that are not so compliant with prefix, at least with how we manipulate it
+COPY --from=build /etc/qpid-dispatch /etc/qpid-dispatch
+COPY --from=build /usr/share/qpid-dispatch /usr/share/qpid-dispatch
+COPY --from=build /etc/sasl2 /etc/sasl2
+COPY --from=build /usr/lib/python3.9/site-packages/qpid_dispatch /usr/lib/python3.9/site-packages/qpid_dispatch
+COPY --from=build /usr/lib/python3.9/site-packages/qpid_dispatch_site.py /usr/lib/python3.9/site-packages/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libsasl2-2 libsasl2-modules libuv1 python3 libpython3.9 libwebsockets16 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add site-packages to the PYTHONPATH environment variable
+ENV PYTHONPATH=/usr/lib/python3.9/site-packages
+
+CMD ["qdrouterd"]


### PR DESCRIPTION
Use Debian stable release slim image with multistage build to
keep image size reasonable (143MB compared to 1.39GB Ubuntu based image).

Other changes compared to Ubuntu based image:
* ~~libuv is enabled~~
* a bit more careful work with dependencies
* allow building web console
* faster builds with Ninja
* build Proton from release, not master; configurable
* build Dispatch Router from checked out source
* minor changes in build process, Dockerfile syntax, etc

TODO:
- [x] build image on CI

---
It's not the prettiest in some ways.. but what can I do :)

~~I did not run any real workloads with it yet, but the router daemon starts and qdmanage can query from it.~~ tested