### PR TITLE
DISPATCH-1689 Wait for startup log line to ensure router is fully started in tests

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1512,7 +1512,7 @@ void qd_server_run(qd_dispatch_t *qd)
     assert(qd_server->container); // Server can't run without a container
     qd_log(qd_server->log_source,
            QD_LOG_NOTICE, "Operational, %d Threads Running (process ID %ld)",
-           qd_server->thread_count, (long)getpid());
+           qd_server->thread_count, (long)getpid()); // Log message is matched in system_tests
 
     const uintmax_t ram_size = qd_platform_memory_size();
     const uint64_t  vm_size = qd_router_memory_usage();

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -443,7 +443,7 @@ class Qdrouterd(Process):
                 ('log', {'module': 'DEFAULT', 'enable': 'trace+',
                          'includeSource': 'true', 'outputFile': self.logfile}))
         else:
-            self.logfile = default_log[0][1].get('outputfile')
+            self.logfile = default_log[0][1].get('outputFile')
         args = ['qdrouterd', '-c', config.write(name)] + cl_args
         env_home = os.environ.get('QPID_DISPATCH_HOME')
         if pyinclude:


### PR DESCRIPTION
This is a backport from

* https://github.com/skupperproject/skupper-router/pull/140
* https://github.com/skupperproject/skupper-router/pull/187