### PR TITLE
Fix `QDROUTERD_RUNNER` CMake option parsing to be shell-like (#307)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -110,6 +110,17 @@ After running the tests, all XML reports will be found under tests/junitxmls in 
 cmake .. -DPYTHON_TEST_COMMAND='-m;pytest;-vs;--junit-xml=junitxmls/${py_test_module}.xml;--pyargs;${py_test_module}'
 ----
 
+=== Runner for `skrouterd` in tests
+
+System tests can be configured to run `skrouterd` processes with an arbitrary wrapper.
+To do this, set the `QDROUTERD_RUNNER` CMake option to a string that will be prepended before all `skrouterd` invocations during testing.
+The following example illustrates how to run the router under `gdb`, to obtain a backtrace if the router crashes.
+
+[source,shell script]
+----
+cmake .. -DQDROUTERD_RUNNER="gdb -quiet -iex 'set pagination off' -iex 'set debuginfod enabled on' -ex run -ex 'thread apply all bt' -ex 'quit $_exitcode' --batch --args"
+----
+
 === Test Suite Code Coverage (GNU tools only)
 
 Use coverage analysis to ensure that all code paths are exercised by

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -36,6 +36,7 @@ import pathlib
 import queue as Queue
 import random
 import re
+import shlex
 import shutil
 import socket
 import subprocess
@@ -451,7 +452,8 @@ class Qdrouterd(Process):
         elif env_home:
             args += ['-I', os.path.join(env_home, 'python')]
 
-        args = os.environ.get('QPID_DISPATCH_RUNNER', '').split() + args
+        # shlex.split parses -ex 'thread apply all' into two parts, not in 4 words as string split does
+        args = shlex.split(os.environ.get('QPID_DISPATCH_RUNNER', '')) + args
         super(Qdrouterd, self).__init__(args, name=name, expect=expect)
         self._management = None
         self._wait_ready = False


### PR DESCRIPTION
Previously, the option value was parsed by splitting the string at every space character, even within quoted substrings.

* https://github.com/skupperproject/skupper-router/pull/307