### PR TITLE
DISPATCH-2357: don't clone git tips in Dockerfile, use released tags instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,34 +36,38 @@
 
 ################# Begin code #######
 
-# Get the latest Centos version from dockerhub
 FROM quay.io/centos/centos:stream8
 
 MAINTAINER "dev@qpid.apache.org"
+
+ENV PROTON_VERSION=0.36.0
+ENV DISPATCH_VERSION=1.19.0
+ENV Python_EXECUTABLE=/usr/bin/python3
 
 # Install all the required packages. Some in this list were picked off from proton's INSTALL.md (https://github.com/apache/qpid-proton/blob/main/INSTALL.md) and the rest are from dispatch (https://github.com/apache/qpid-dispatch/blob/main/README)
 
 # Enable additional package repositories for CentOS
 #  note: PowerTools is called CodeReady Linux Builder in RHEL 8
 RUN dnf -y install epel-release
+RUN dnf -y install 'dnf-command(config-manager)'
 RUN dnf config-manager --set-enabled powertools
 
 # now install the rest of the packages
 RUN dnf -y install gcc gcc-c++ cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 swig python3-devel java-11-openjdk-devel git make doxygen valgrind emacs libuv libuv-devel libwebsockets-devel && dnf clean all -y
 
 # Create a main directory and clone the qpid-proton repo from github
-RUN mkdir /main && cd /main && git clone https://github.com/apache/qpid-proton.git  && cd /main/qpid-proton && mkdir /main/qpid-proton/build
+RUN mkdir /main && cd /main && git clone --single-branch --branch "${PROTON_VERSION}" https://github.com/apache/qpid-proton.git && cd /main/qpid-proton && mkdir /main/qpid-proton/build
 
 WORKDIR /main/qpid-proton/build
 
 # make and install proton
-RUN cmake .. -DSYSINSTALL_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON && make install
+RUN cmake .. -DPython_EXECUTABLE="${Python_EXECUTABLE}" -DSYSINSTALL_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON && make install
 
 # Clone the qpid-dispatch git repo
-RUN cd /main && git clone https://github.com/apache/qpid-dispatch.git && mkdir /main/qpid-dispatch/build
+RUN cd /main && git clone --single-branch --branch "${DISPATCH_VERSION}" https://github.com/apache/qpid-dispatch.git && mkdir /main/qpid-dispatch/build
 
 WORKDIR /main/qpid-dispatch/build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make install
+RUN cmake .. -DPython_EXECUTABLE="${Python_EXECUTABLE}" -DCMAKE_INSTALL_PREFIX=/usr && make install
 
 # Uncomment the following line if you would like to run all the dispatch unit tests and system tests. 
 # RUN ctest -VV


### PR DESCRIPTION
Built with

```
podman build .
```

Checked that qdrouterd starts up and that qdstat and qdmanage --help works.