### PR TITLE
DISPATCH-2368: chore(build): add a missing `(void)` into C function declarations

### DIFF
--- a/include/qpid/dispatch/bitmask.h
+++ b/include/qpid/dispatch/bitmask.h
@@ -33,7 +33,7 @@
 typedef struct qd_bitmask_t qd_bitmask_t;
 
 /** Number of bits in a bitmask. */
-int qd_bitmask_width();
+int qd_bitmask_width(void);
 
 /** Create a bitmask.
  *@param initial if non-zero set all bits, else clear all bits.

--- a/include/qpid/dispatch/delivery_state.h
+++ b/include/qpid/dispatch/delivery_state.h
@@ -54,7 +54,7 @@ typedef struct {
 } qd_delivery_state_t;
 
 // allocate
-qd_delivery_state_t *qd_delivery_state();
+qd_delivery_state_t *qd_delivery_state(void);
 
 // this constructor takes ownership of err. err will be freed by
 // qd_delivery_state_free()

--- a/include/qpid/dispatch/error.h
+++ b/include/qpid/dispatch/error.h
@@ -76,17 +76,17 @@ qd_error_t qd_error_vimpl(qd_error_t code, const char *file, int line, const cha
  * Clear thread-local error code and message.
  *@return QD_ERROR_NONE
  */
-qd_error_t qd_error_clear();
+qd_error_t qd_error_clear(void);
 
 /**
  * @return Thread local error message. Includes text for error code.
  */
-QD_EXPORT const char* qd_error_message();
+QD_EXPORT const char* qd_error_message(void);
 
 /**
  *@return Thread local error code
  */
-QD_EXPORT qd_error_t qd_error_code();
+QD_EXPORT qd_error_t qd_error_code(void);
 
 /** Maximum length of a qd_error_message, useful for temporary buffers. */
 extern const int QD_ERROR_MAX;

--- a/include/qpid/dispatch/log.h
+++ b/include/qpid/dispatch/log.h
@@ -80,7 +80,7 @@ void qd_vlog_impl(qd_log_source_t *source, qd_log_level_t level, bool check_leve
     } while(0)
 
 /** Maximum length for a log message */
-int qd_log_max_len();
+int qd_log_max_len(void);
 
 void qd_format_string(char *buf, int buf_size, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -433,9 +433,9 @@ int qd_message_stream_data_append(qd_message_t *msg, qd_buffer_list_t *data, boo
  */
 char* qd_message_repr(qd_message_t *msg, char* buffer, size_t len, qd_log_bits log_message);
 /** Recommended buffer length for qd_message_repr */
-int qd_message_repr_len();
+int qd_message_repr_len(void);
 
-qd_log_source_t* qd_message_log_source();
+qd_log_source_t* qd_message_log_source(void);
 
 /**
  * Accessor for incoming messages ingress router annotation

--- a/include/qpid/dispatch/server.h
+++ b/include/qpid/dispatch/server.h
@@ -589,7 +589,7 @@ void qd_connection_invoke_deferred_impl(qd_connection_t *conn, qd_deferred_t cal
 /**
  * Allocate a qd_deferred_call_t object
  */
-void *qd_connection_new_qd_deferred_call_t();
+void *qd_connection_new_qd_deferred_call_t(void);
 
 
 /**

--- a/include/qpid/dispatch/timer.h
+++ b/include/qpid/dispatch/timer.h
@@ -115,7 +115,7 @@ void qd_timer_cancel(qd_timer_t *timer);
 /**
  * The current time.
  */
-qd_timestamp_t qd_timer_now() ;
+qd_timestamp_t qd_timer_now(void) ;
 
 /**
  * @}

--- a/src/bitmask.c
+++ b/src/bitmask.c
@@ -42,7 +42,7 @@ ALLOC_DEFINE(qd_bitmask_t);
 #define FIRST_UNKNOWN -2
 
 
-int qd_bitmask_width()
+int qd_bitmask_width(void)
 {
     return QD_BITMASK_BITS;
 }

--- a/src/delivery_state.c
+++ b/src/delivery_state.c
@@ -24,7 +24,7 @@
 ALLOC_DECLARE(qd_delivery_state_t);
 ALLOC_DEFINE(qd_delivery_state_t);
 
-qd_delivery_state_t *qd_delivery_state()
+qd_delivery_state_t *qd_delivery_state(void)
 {
     qd_delivery_state_t *dstate = new_qd_delivery_state_t();
     ZERO(dstate);

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -55,7 +55,7 @@ void            qd_policy_free(qd_policy_t *policy);
 qd_router_t    *qd_router(qd_dispatch_t *qd, qd_router_mode_t mode, const char *area, const char *id);
 void            qd_router_setup_late(qd_dispatch_t *qd);
 void            qd_router_free(qd_router_t *router);
-void            qd_error_initialize();
+void            qd_error_initialize(void);
 static void qd_dispatch_set_router_id(qd_dispatch_t *qd, char *_id);
 static void qd_dispatch_set_router_area(qd_dispatch_t *qd, char *_area);
 
@@ -68,7 +68,7 @@ sys_atomic_t global_delivery_id;
 
 qd_dispatch_t *qd = 0;
 
-qd_dispatch_t *qd_dispatch_get_dispatch()
+qd_dispatch_t *qd_dispatch_get_dispatch(void)
 {
     return qd;
 }
@@ -287,7 +287,7 @@ qd_error_t qd_dispatch_register_display_name_service(qd_dispatch_t *qd, void *ob
 }
 
 
-QD_EXPORT long qd_dispatch_policy_c_counts_alloc()
+QD_EXPORT long qd_dispatch_policy_c_counts_alloc(void)
 {
     return qd_policy_c_counts_alloc();
 }
@@ -404,7 +404,7 @@ qdr_core_t* qd_dispatch_router_core(qd_dispatch_t *qd) {
  *
  * Return 0 if the memory usage cannot be determined.
  */
-uint64_t qd_router_memory_usage()
+uint64_t qd_router_memory_usage(void)
 {
     // @TODO(kgiusti): only works for linux (what? doesn't everyone run linux?)
 

--- a/src/dispatch_private.h
+++ b/src/dispatch_private.h
@@ -64,7 +64,7 @@ struct qd_dispatch_t {
     char  *metadata;
 };
 
-qd_dispatch_t *qd_dispatch_get_dispatch();
+qd_dispatch_t *qd_dispatch_get_dispatch(void);
 
 
 

--- a/src/entity_cache.c
+++ b/src/entity_cache.c
@@ -51,12 +51,12 @@ static entity_event_t *entity_event(action_t action, const char *type, void *obj
 static sys_mutex_t *event_lock = 0;
 static entity_event_list_t  event_list;
 
-void qd_entity_cache_initialize() {
+void qd_entity_cache_initialize(void) {
     event_lock = sys_mutex();
     DEQ_INIT(event_list);
 }
 
-void qd_entity_cache_free_entries() {
+void qd_entity_cache_free_entries(void) {
     sys_mutex_lock(event_lock);
     entity_event_t *event = DEQ_HEAD(event_list);
     while (event) {
@@ -101,6 +101,6 @@ QD_EXPORT qd_error_t qd_entity_refresh_begin(PyObject *list) {
     return qd_error_code();
 }
 
-QD_EXPORT void qd_entity_refresh_end() {
+QD_EXPORT void qd_entity_refresh_end(void) {
     sys_mutex_unlock(event_lock);
 }

--- a/src/entity_cache.h
+++ b/src/entity_cache.h
@@ -32,10 +32,10 @@
  */
 
 /** Initialize the module. */
-void qd_entity_cache_initialize();
+void qd_entity_cache_initialize(void);
 
 /** Free all entries in the cache. Avoids leaks in c_unittests. */
-void qd_entity_cache_free_entries();
+void qd_entity_cache_free_entries(void);
 
 /** Add an entity to the agent cache. */
 void qd_entity_cache_add(const char *type, void *object);

--- a/src/error.c
+++ b/src/error.c
@@ -66,7 +66,7 @@ static __thread struct {
 
 static qd_log_source_t* log_source = 0;
 
-void qd_error_initialize() {
+void qd_error_initialize(void) {
     log_source = qd_log_source("ERROR");
 }
 
@@ -99,17 +99,17 @@ qd_error_t qd_error_impl(qd_error_t code, const char *file, int line, const char
     return err;
 }
 
-qd_error_t qd_error_clear() {
+qd_error_t qd_error_clear(void) {
     ts.error_code = 0;
     snprintf(ts.error_message, ERROR_MAX, "No Error");
     return QD_ERROR_NONE;
 }
 
-const char* qd_error_message() {
+const char* qd_error_message(void) {
     return ts.error_message;
 }
 
-qd_error_t qd_error_code() {
+qd_error_t qd_error_code(void) {
     return ts.error_code;
 }
 

--- a/src/http-libwebsockets.c
+++ b/src/http-libwebsockets.c
@@ -63,7 +63,7 @@ static void logger(int lll, const char *line)  {
     qd_log(http_log, qd_level(lll), "%.*s", (int)len, line);
 }
 
-static void log_init() {
+static void log_init(void) {
     http_log = qd_log_source("HTTP");
     int levels = 0;
     for (int i = 0; i < LLL_COUNT; ++i) {

--- a/src/log.c
+++ b/src/log.c
@@ -46,7 +46,7 @@ const char *QD_LOG_STATS_TYPE = "logStats";
 
 static qd_log_source_t      *default_log_source=0;
 
-int qd_log_max_len() { return TEXT_MAX; }
+int qd_log_max_len(void) { return TEXT_MAX; }
 
 typedef struct qd_log_entry_t qd_log_entry_t;
 
@@ -464,7 +464,7 @@ void qd_log_impl(qd_log_source_t *source, qd_log_level_t level, const char *file
   va_end(ap);
 }
 
-static PyObject *inc_none() { Py_INCREF(Py_None); return Py_None; }
+static PyObject *inc_none(void) { Py_INCREF(Py_None); return Py_None; }
 
 /// Return the log buffer up to limit as a python list. Called by management agent.
 QD_EXPORT PyObject *qd_log_recent_py(long limit) {

--- a/src/message.c
+++ b/src/message.c
@@ -97,7 +97,7 @@ typedef void (*buffer_process_t) (void *context, const unsigned char *base, int 
 
 qd_log_source_t* log_source = 0;
 
-qd_log_source_t* qd_message_log_source()
+qd_log_source_t* qd_message_log_source(void)
 {
     if(log_source)
         return log_source;
@@ -107,11 +107,11 @@ qd_log_source_t* qd_message_log_source()
     }
 }
 
-void qd_message_initialize() {
+void qd_message_initialize(void) {
     log_source = qd_log_source("MESSAGE");
 }
 
-int qd_message_repr_len() { return qd_log_max_len(); }
+int qd_message_repr_len(void) { return qd_log_max_len(); }
 
 /**
  * Quote non-printable characters suitable for log messages. Output in buffer.
@@ -1008,7 +1008,7 @@ static qd_field_location_t *qd_message_field_location(qd_message_t *msg, qd_mess
 }
 
 
-qd_message_t *qd_message()
+qd_message_t *qd_message(void)
 {
     qd_message_pvt_t *msg = (qd_message_pvt_t*) new_qd_message_t();
     if (!msg)

--- a/src/message_private.h
+++ b/src/message_private.h
@@ -186,7 +186,7 @@ ALLOC_DECLARE(qd_message_content_t);
 #define MSG_CONTENT(m) (((qd_message_pvt_t*) m)->content)
 
 /** Initialize logging */
-void qd_message_initialize();
+void qd_message_initialize(void);
 
 // These expect content->lock to be locked.
 bool _Q2_holdoff_should_block_LH(const qd_message_content_t *content);

--- a/src/parse_tree.c
+++ b/src/parse_tree.c
@@ -99,7 +99,7 @@ static void token_iterator_next(token_iterator_t *t)
 
 
 const char address_token_sep[] = "./";
-const char *qd_parse_address_token_sep()
+const char *qd_parse_address_token_sep(void)
 {
     return address_token_sep;
 }

--- a/src/parse_tree.h
+++ b/src/parse_tree.h
@@ -50,7 +50,7 @@ typedef enum {
 qd_parse_tree_t *qd_parse_tree_new(qd_parse_tree_type_t type);
 void qd_parse_tree_free(qd_parse_tree_t *tree);
 qd_parse_tree_type_t qd_parse_tree_type(const qd_parse_tree_t *tree);
-const char *qd_parse_address_token_sep();
+const char *qd_parse_address_token_sep(void);
 
 // verify the pattern is in a legal format for the given tree's match algorithm
 bool qd_parse_tree_validate_pattern(const qd_parse_tree_t *tree,

--- a/src/policy.c
+++ b/src/policy.c
@@ -191,7 +191,7 @@ qd_error_t qd_register_policy_manager(qd_policy_t *policy, void *policy_manager)
 }
 
 
-long qd_policy_c_counts_alloc()
+long qd_policy_c_counts_alloc(void)
 {
     qd_policy_denial_counts_t * dc = NEW(qd_policy_denial_counts_t);
     assert(dc);
@@ -1561,6 +1561,6 @@ char * qd_policy_compile_allowed_csv(char * csv)
 }
 
 
-qd_log_source_t* qd_policy_log_source() {
+qd_log_source_t* qd_policy_log_source(void) {
     return policy_log_source;
 }

--- a/src/policy.h
+++ b/src/policy.h
@@ -85,7 +85,7 @@ qd_error_t qd_register_policy_manager(qd_policy_t *policy, void *policy_manager)
 /** Allocate counts statistics block.
  * Called from Python
  */
-long qd_policy_c_counts_alloc();
+long qd_policy_c_counts_alloc(void);
 
 /** Free counts statistics block.
  * Called from Python
@@ -261,5 +261,5 @@ void qd_policy_count_max_size_event(pn_link_t *link, qd_connection_t *qd_conn);
 /**
  * Return POLICY log_source to log policy 
  */
-qd_log_source_t* qd_policy_log_source();
+qd_log_source_t* qd_policy_log_source(void);
 #endif

--- a/src/posix/threading.c
+++ b/src/posix/threading.c
@@ -183,7 +183,7 @@ sys_thread_t *sys_thread(void *(*run_function) (void *), void *arg)
 }
 
 
-sys_thread_t *sys_thread_self()
+sys_thread_t *sys_thread_self(void)
 {
     return _self;
 }

--- a/src/router_core/delivery.h
+++ b/src/router_core/delivery.h
@@ -74,7 +74,7 @@ ALLOC_DECLARE(qdr_delivery_t);
 /** Delivery Id for logging - thread safe
  */
 extern sys_atomic_t global_delivery_id;
-static inline uint32_t next_delivery_id() { return sys_atomic_inc(&global_delivery_id); }
+static inline uint32_t next_delivery_id(void) { return sys_atomic_inc(&global_delivery_id); }
 
 // Common log line prefix
 #define DLV_FMT       "[C%"PRIu64"][L%"PRIu64"][D%"PRIu32"]"

--- a/src/router_core/module.h
+++ b/src/router_core/module.h
@@ -61,8 +61,8 @@ typedef void (*qdrc_module_final_t) (void *module_context);
  * @param on_final Pointer to a function for module finalization, called at core thread shutdown
  */
 #define QDR_CORE_MODULE_DECLARE(name,enable,on_init,on_final)   \
-    static void modstart() __attribute__((constructor)); \
-    void modstart() { qdr_register_core_module(name, enable, on_init, on_final); }
+    static void modstart(void) __attribute__((constructor)); \
+    void modstart(void) { qdr_register_core_module(name, enable, on_init, on_final); }
 void qdr_register_core_module(const char *name,
                               qdrc_module_enable_t enable,
                               qdrc_module_init_t on_init,

--- a/src/server.c
+++ b/src/server.c
@@ -1462,7 +1462,7 @@ void qd_server_set_container(qd_dispatch_t *qd, qd_container_t *container)
     qd->server->container = container;
 }
 
-void qd_server_trace_all_connections()
+void qd_server_trace_all_connections(void)
 {
     qd_dispatch_t *qd = qd_dispatch_get_dispatch();
     if (qd->server) {
@@ -1645,7 +1645,7 @@ void qd_connection_invoke_deferred_impl(qd_connection_t *conn, qd_deferred_t cal
 }
 
 
-void *qd_connection_new_qd_deferred_call_t()
+void *qd_connection_new_qd_deferred_call_t(void)
 {
     return new_qd_deferred_call_t();
 }

--- a/src/server_private.h
+++ b/src/server_private.h
@@ -202,7 +202,7 @@ ALLOC_DECLARE(qd_pn_free_link_session_t);
 /**
  * For every connection on the server's connection list, call pn_transport_set_tracer and enable trace logging
  */
-void qd_server_trace_all_connections();
+void qd_server_trace_all_connections(void);
 
 /**
  * This function is set as the pn_transport->tracer and is invoked when proton tries to write the log message to pn_transport->tracer

--- a/src/timer.c
+++ b/src/timer.c
@@ -88,7 +88,7 @@ ALLOC_DECLARE(qd_timer_t);
 ALLOC_DEFINE(qd_timer_t);
 
 /// For tests only
-sys_mutex_t* qd_timer_lock() { return lock; }
+sys_mutex_t* qd_timer_lock(void) { return lock; }
 
 //=========================================================================
 // Private static functions
@@ -109,7 +109,7 @@ static bool timer_cancel_LH(qd_timer_t *timer)
 
 
 /* Adjust timer's time_base and delays for the current time. */
-static void timer_adjust_now_LH()
+static void timer_adjust_now_LH(void)
 {
     qd_timestamp_t now = qd_timer_now();
     if (time_base != 0 && now > time_base) {
@@ -204,7 +204,7 @@ void qd_timer_free(qd_timer_t *timer)
 
 
 __attribute__((weak)) // permit replacement by dummy implementation in unit_tests
-qd_timestamp_t qd_timer_now()
+qd_timestamp_t qd_timer_now(void)
 {
     return pn_proactor_now_64();
 }
@@ -283,7 +283,7 @@ void qd_timer_cancel(qd_timer_t *timer)
 //=========================================================================
 
 
-void qd_timer_initialize()
+void qd_timer_initialize(void)
 {
     lock = sys_mutex();
     DEQ_INIT(scheduled_timers);
@@ -299,7 +299,7 @@ void qd_timer_finalize(void)
 
 
 /* Execute all timers that are ready and set up next timeout. */
-void qd_timer_visit()
+void qd_timer_visit(void)
 {
     sys_mutex_lock(lock);
     callback_thread = sys_thread_self();

--- a/src/timer_private.h
+++ b/src/timer_private.h
@@ -24,9 +24,9 @@
 
 void qd_timer_initialize(void);
 void qd_timer_finalize(void);
-void qd_timer_visit();
+void qd_timer_visit(void);
 
 /// For tests only
-sys_mutex_t* qd_timer_lock();
+sys_mutex_t* qd_timer_lock(void);
 
 #endif

--- a/tests/buffer_test.c
+++ b/tests/buffer_test.c
@@ -368,7 +368,7 @@ exit:
 }
 
 
-int buffer_tests()
+int buffer_tests(void)
 {
     int result = 0;
     char *test_group = "buffer_tests";

--- a/tests/clogger.c
+++ b/tests/clogger.c
@@ -125,7 +125,7 @@ static void signal_handler(int signum)
 }
 
 
-void start_message()
+void start_message(void)
 {
     static long tag = 0;  // a simple tag generator
 
@@ -160,7 +160,7 @@ void start_message()
 
 
 /* return true when message transmit is complete */
-bool send_message_data()
+bool send_message_data(void)
 {
     static const char zero_block[DEFAULT_MAX_FRAME] = {0};
 

--- a/tests/compose_test.c
+++ b/tests/compose_test.c
@@ -397,7 +397,7 @@ static char *test_compose_subfields(void *context)
 }
 
 
-int compose_tests()
+int compose_tests(void)
 {
     int result = 0;
     char *test_group = "compose_tests";

--- a/tests/failoverlist_test.c
+++ b/tests/failoverlist_test.c
@@ -152,7 +152,7 @@ static char *test_failover_list_multiple(void *unused)
 }
 
 
-int failoverlist_tests()
+int failoverlist_tests(void)
 {
     int result = 0;
     char *test_group = "failover_tests";

--- a/tests/parse_test.c
+++ b/tests/parse_test.c
@@ -623,7 +623,7 @@ cleanup:
 }
 
 
-int parse_tests()
+int parse_tests(void)
 {
     int result = 0;
     char *test_group = "parse_tests";

--- a/tests/run_unit_tests_size.c
+++ b/tests/run_unit_tests_size.c
@@ -24,15 +24,15 @@
 
 void qd_log_initialize(void);
 void qd_log_finalize(void);
-void qd_error_initialize();
+void qd_error_initialize(void);
 void qd_router_id_initialize(const char *, const char *);
 void qd_router_id_finalize(void);
 
 
-int message_tests();
-int field_tests();
-int parse_tests();
-int buffer_tests();
+int message_tests(void);
+int field_tests(void);
+int parse_tests(void);
+int buffer_tests(void);
 
 // validate router id constructor/encoder
 //

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -171,7 +171,7 @@ static char *test_condition(void *context)
 }
 
 
-int thread_tests()
+int thread_tests(void)
 {
     int result = 0;
     char *test_group = "thread_tests";

--- a/tests/threaded_timer_test.c
+++ b/tests/threaded_timer_test.c
@@ -73,13 +73,13 @@ static struct event_t {
     sys_cond_t  *c;
 } event;
 
-static void test_setup()
+static void test_setup(void)
 {
     event.m = sys_mutex();
     event.c = sys_cond();
 }
 
-static void test_cleanup()
+static void test_cleanup(void)
 {
     sys_mutex_free(event.m);
     event.m = 0;

--- a/tests/timer_test.c
+++ b/tests/timer_test.c
@@ -33,7 +33,7 @@ static qd_timer_t      *timers[16];
 
 
 /* Dummy out the now and timeout functions */
-qd_timestamp_t qd_timer_now() {
+qd_timestamp_t qd_timer_now(void) {
     return time_value;
 }
 
@@ -283,7 +283,7 @@ static char* test_big(void *context)
 }
 
 
-int timer_tests()
+int timer_tests(void)
 {
     char *test_group = "timer_tests";
     int result = 0;


### PR DESCRIPTION
This is an intermediate step (in C23 this can be handled differently), but for now it's the most reasonable fix.

Previously already fixed in skupper-router
* https://github.com/skupperproject/skupper-router/pull/803

Fixes compilation failures such as this one

```
error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
```