### PR TITLE
DISPATCH-2363: chore(gha): add the missing `build` python module, necessary for Proton to build the Python binding

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,7 @@ jobs:
         -DCMAKE_C_COMPILER_LAUNCHER=ccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         -DBUILD_BINDINGS=python
+        -DBUILD_TOOLS=OFF
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
         -DENABLE_FUZZ_TESTING=OFF
@@ -322,6 +323,7 @@ jobs:
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         -DBUILD_BINDINGS=python
         -DPython_EXECUTABLE=/usr/bin/python3
+        -DBUILD_TOOLS=OFF
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
         -DENABLE_FUZZ_TESTING=OFF

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,7 +106,7 @@ jobs:
           architecture: x64
 
       - name: Install Python build dependencies
-        run: python -m pip install setuptools wheel tox cffi
+        run: python -m pip install build setuptools wheel tox cffi
 
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
@@ -383,7 +383,7 @@ jobs:
         run: dnf install -y python39-devel python39-pip
 
       - name: Install Python build dependencies
-        run: python3 -m pip install setuptools wheel tox cffi
+        run: python3 -m pip install build setuptools wheel tox cffi
 
       # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
       - name: Prepare ccache timestamp


### PR DESCRIPTION
https://issues.apache.org/jira/browse/DISPATCH-2363