### PR TITLE
NO-JIRA: deps(gha): update packaged github actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,7 +201,7 @@ jobs:
         run: env -0 | sort -z | tr '\0' '\n'
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: qpid_dispatch_wrk_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Display ccache stats
         run: ccache -s
 
-      # github actions/upload-artifact@v3 does not preserve executable permission on binaries
+      # github actions/upload-artifact@v4 does not preserve executable permission on binaries
       - name: Compress build
         working-directory: ${{github.workspace}}
         run: >
@@ -164,7 +164,7 @@ jobs:
             qpid-proton/build/python
 
       - name: Upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qpid_dispatch_wrk_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{ matrix.protonGitRef }}
           path: /tmp/archive.tar.xz
@@ -232,14 +232,14 @@ jobs:
           ctest --timeout 1200 -C ${BuildType} -V -T Test --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.DispatchCTestExtraArgs}}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ ! cancelled() }}
         with:
           name: Test_Results_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}_${{matrix.shard}}
           path: ${{env.DispatchBuildDir}}/Testing/**/*.xml
 
       - name: Upload log files (if any tests failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: testLogs_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}_${{matrix.shard}}
@@ -247,7 +247,7 @@ jobs:
             qpid-dispatch/build/tests
 
       - name: Upload core files (if any)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cores_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}_${{matrix.shard}}
@@ -559,14 +559,14 @@ jobs:
           ctest --timeout 1200 -C ${BuildType} -V -T Test --output-on-failure --no-compress-output -I ${{matrix.shard}},,${{matrix.shards}} -j2 ${{env.DispatchCTestExtraArgs}}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ ! cancelled() }}
         with:
           name: Test_Results_${{matrix.container}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}_${{matrix.shard}}
           path: ${{env.DispatchBuildDir}}/Testing/**/*.xml
 
       - name: Upload log files (if any tests failed)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: testLogs_${{matrix.container}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}_${{matrix.shard}}
@@ -574,7 +574,7 @@ jobs:
             qpid-dispatch/build/tests
 
       - name: Upload core files (if any)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cores_${{matrix.container}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}_${{matrix.shard}}
@@ -678,13 +678,13 @@ jobs:
         run: cmake --build "${DispatchBuildDir}" -t docs
 
       - name: Store the rendered user-guide
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: UserGuide
           path: ${{env.DispatchBuildDir}}/docs/books/user-guide
 
       - name: Store the rendered html man pages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Manpages
           path: ${{env.DispatchBuildDir}}/docs/man/*.html
@@ -693,7 +693,7 @@ jobs:
         run: asciidoctor-pdf --failure-level INFO ${{github.workspace}}/docs/books/user-guide/book.adoc
 
       - name: Store the rendered Dispatch book PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: book.pdf
           path: ${{github.workspace}}/docs/books/user-guide/book.pdf

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,7 @@ jobs:
         run: mkdir -p "${ProtonBuildDir}" "${DispatchBuildDir}" "${InstallPrefix}"
 
       - name: Setup python ${{ env.PythonVersion }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PythonVersion }}
           architecture: x64
@@ -206,7 +206,7 @@ jobs:
           name: qpid_dispatch_wrk_${{matrix.os}}_${{matrix.buildType}}_${{matrix.runtimeCheck}}_${{matrix.protonGitRef}}
 
       - name: Setup python ${{ env.PythonVersion }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PythonVersion }}
           architecture: x64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,13 +70,13 @@ jobs:
         if: ${{ always() && runner.os == 'Linux' }}
         run: env -0 | sort -z | tr '\0' '\n'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'apache/qpid-proton'
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: 'qpid-dispatch'
 
@@ -427,13 +427,13 @@ jobs:
       - name: Check that Node20 works inside in-docker steps
         run: /__e/node20/bin/node -e 'console.log("Hello World")'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'apache/qpid-proton'
           ref: ${{ matrix.protonGitRef }}
           path: 'qpid-proton'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: 'qpid-dispatch'
 
@@ -614,7 +614,7 @@ jobs:
       - name: Install python-checker test dependencies
         run: python3 -m pip install tox
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create Build and Install directories
         run: mkdir -p "${DispatchBuildDir}" "{InstallPrefix}"
@@ -646,7 +646,7 @@ jobs:
         -DCONSOLE_INSTALL=OFF
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create Build and Install directories
         run: mkdir -p "${DispatchBuildDir}" "{InstallPrefix}"
@@ -702,7 +702,7 @@ jobs:
     name: Console Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: cd console/react && npm ci
@@ -714,7 +714,7 @@ jobs:
     name: Console ESLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: cd console/react && npm ci
@@ -726,7 +726,7 @@ jobs:
     name: RAT Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -752,7 +752,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build Debian image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           message("::set-output name=timestamp::${current_date}")
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         env:
           cache-name: cache-ccache
         with:
@@ -480,7 +480,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           message("::set-output name=timestamp::${current_date}")
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         env:
           cache-name: cache-ccache
         with:
@@ -727,7 +727,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
This is a cumulative update from individual dependabot PRs.

1. less noise in git history this way
2. the upload-artifact and download-artifact actions need to be updated at the same time
3. easier to carefully review CI results for just one PR