### PR TITLE
DISPATCH-2357: fix(Dockerfile): switch to using Rocky Linux 8 as CentOS 8 is EOL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,4 +29,5 @@ dockerfiles
 
 build
 cmake-build-*
+**/node_modules
 tests/system_test.dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,18 +36,18 @@
 
 ################# Begin code #######
 
-FROM quay.io/centos/centos:stream8
+FROM docker.io/library/rockylinux:8
 
 MAINTAINER "dev@qpid.apache.org"
 
 ENV PROTON_VERSION=0.36.0
-ENV DISPATCH_VERSION=1.19.0
 ENV Python_EXECUTABLE=/usr/bin/python3
 
 # Install all the required packages. Some in this list were picked off from proton's INSTALL.md (https://github.com/apache/qpid-proton/blob/main/INSTALL.md) and the rest are from dispatch (https://github.com/apache/qpid-dispatch/blob/main/README)
 
 # Enable additional package repositories for CentOS
 #  note: PowerTools is called CodeReady Linux Builder in RHEL 8
+#    and it's become crb in CentOS Stream 9
 RUN dnf -y install epel-release
 RUN dnf -y install 'dnf-command(config-manager)'
 RUN dnf config-manager --set-enabled powertools
@@ -55,16 +55,17 @@ RUN dnf config-manager --set-enabled powertools
 # now install the rest of the packages
 RUN dnf -y install gcc gcc-c++ cmake libuuid-devel openssl-devel cyrus-sasl-devel cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-md5 swig python3-devel java-11-openjdk-devel git make doxygen valgrind emacs libuv libuv-devel libwebsockets-devel && dnf clean all -y
 
-# Create a main directory and clone the qpid-proton repo from github
-RUN mkdir /main && cd /main && git clone --single-branch --branch "${PROTON_VERSION}" https://github.com/apache/qpid-proton.git && cd /main/qpid-proton && mkdir /main/qpid-proton/build
+# Create a main directory and clone a (released!) version of qpid-proton repo from github
+RUN mkdir /main && cd /main && git clone --depth 1 --branch "${PROTON_VERSION}" https://github.com/apache/qpid-proton.git  && cd /main/qpid-proton && mkdir /main/qpid-proton/build
 
 WORKDIR /main/qpid-proton/build
 
 # make and install proton
 RUN cmake .. -DPython_EXECUTABLE="${Python_EXECUTABLE}" -DSYSINSTALL_BINDINGS=ON -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON && make install
 
-# Clone the qpid-dispatch git repo
-RUN cd /main && git clone --single-branch --branch "${DISPATCH_VERSION}" https://github.com/apache/qpid-dispatch.git && mkdir /main/qpid-dispatch/build
+# Copy in the qpid-dispatch sources
+COPY ./ /main/qpid-dispatch
+RUN mkdir /main/qpid-dispatch/build
 
 WORKDIR /main/qpid-dispatch/build
 RUN cmake .. -DPython_EXECUTABLE="${Python_EXECUTABLE}" -DCMAKE_INSTALL_PREFIX=/usr && make install


### PR DESCRIPTION
https://issues.apache.org/jira/browse/DISPATCH-2357

We need to use supported CentOS. In newer CentOS Streams, the PowerTools repo was renamed to crb (same name as in RHEL). Using Rocky Linux 8 seems most sensible, as we are not ready to upgrade all the way to CentOS 9 or 10.

The Dockerfile was initially intended as a help for development, not really a release artifact. If a development Dockerfile is needed, it can be added in the future.

Meanwhile, using development versions of software at random places, which then becomes part of our release tar.gz, creates bad impression and should be eliminated.

As a compromise, the Dockerfile can use the contents of the local directory for Dispatch sources. In a released tar.gz, that would be the released content, so we're fine there.