### PR TITLE
DISPATCH-2368: chore(build): add missing `#include <sys/time.h>`

### DIFF
--- a/src/alloc_pool.c
+++ b/src/alloc_pool.c
@@ -37,6 +37,7 @@
 #ifdef QD_MEMORY_DEBUG
 #include "log_private.h"
 
+#include <sys/time.h>
 #include <execinfo.h>
 #endif
 

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -41,6 +41,7 @@
 #include <dlfcn.h>
 #include <inttypes.h>
 #include <stdlib.h>
+#include <sys/time.h>
 
 /**
  * Private Function Prototypes

--- a/src/log.c
+++ b/src/log.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <syslog.h>
+#include <sys/time.h>
 
 #define TEXT_MAX QD_LOG_TEXT_MAX
 #define LOG_MAX (QD_LOG_TEXT_MAX+128)


### PR DESCRIPTION
Fixes compilation failures such as this one

```
error: call to undeclared function 'gettimeofday'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```