### PR TITLE
DISPATCH-2371: chore(gha): enable IPv6 inside Docker container to run ip6 tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -311,7 +311,7 @@ jobs:
         # manipulate the host from within the job container
         - "/var/run/docker.sock:/var/run/docker.sock"
       # permit reading dmesg
-      options: --privileged --security-opt apparmor:unconfined --security-opt seccomp=unconfined
+      options: --privileged --security-opt apparmor:unconfined --security-opt seccomp=unconfined --sysctl net.ipv6.conf.all.disable_ipv6=0
 
     env:
       BuildType: ${{matrix.buildType}}


### PR DESCRIPTION
This is a port from skupper-router of
* https://github.com/skupperproject/skupper-router/pull/401