### PR TITLE
DISPATCH-2368: chore(build): add missing `#include <unistd.h>`

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -42,6 +42,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 /**
  * Private Function Prototypes


### PR DESCRIPTION
Fixes compilation failures such as this one

```
/builddir/build/BUILD/qpid-dispatch-1.19.0/src/dispatch.c:412:26: error: implicit declaration of function ‘getpid’; did you mean ‘getpt’? [-Wimplicit-function-declaration]
  412 |     const pid_t my_pid = getpid();
      |                          ^~~~~~
      |                          getpt
```

from https://bugzilla.redhat.com/show_bug.cgi?id=2245601