### PR TITLE
DISPATCH-2368: chore(build): fix qd_log formatting placeholder

### DIFF
--- a/src/router_core/modules/test_hooks/core_test_hooks.c
+++ b/src/router_core/modules/test_hooks/core_test_hooks.c
@@ -560,7 +560,7 @@ static void _do_send(test_client_t *tc)
         ++tc->counter;
         --tc->credit;
         qd_log(tc->module->core->log, QD_LOG_TRACE,
-               "client test message sent id=%"PRIi64" c=%d", tc->counter - 1, tc->credit);
+               "client test message sent id=%ld c=%d", tc->counter - 1, tc->credit);
     }
 }
 


### PR DESCRIPTION
It's unexpected that compilers can trace the string as it flows to printf, as there are no hints in the code, but apparently they can do this nowadays.

```
error: format specifies type 'long long' but the argument has type 'long' [-Werror,-Wformat]
```

This was fixed in skupper-router in
* https://github.com/skupperproject/skupper-router/pull/1248