### PR TITLE
DISPATCH-2369: chore(build): set a PEP-440 compliant version to avoid a fail when building Python package

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,1 +1,1 @@
-1.20.0-SNAPSHOT
+1.20.0+snapshot


### PR DESCRIPTION
```
  File "/usr/lib/python3.12/site-packages/setuptools/_vendor/packaging/version.py", line 198, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
setuptools.extern.packaging.version.InvalidVersion: Invalid version: '1.20.0-SNAPSHOT
```

This is also a known problem from skupper-router, but there it was solved by a -DVERSION build argument, without using the VERSION.txt file any more.

* https://github.com/skupperproject/skupper-router/issues/973
* https://github.com/skupperproject/skupper-router/issues/1251